### PR TITLE
feat(ansible): reboot node after kernel upgrade via apt dist-upgrade

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -14,6 +14,7 @@ common_packages:
   - htop
   - unzip
   - jq
+  - update-notifier-common
 
 # UFW rules — K3s required ports + SSH
 k3s_firewall_rules:

--- a/k3s/bootstrap/ansible/roles/common/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/common/tasks/main.yml
@@ -22,11 +22,26 @@
     update_cache: true
     upgrade: dist
     cache_valid_time: 3600
+  register: apt_upgrade_result
+
+- name: Check if reboot is required after package upgrade
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: reboot_required_file
+
+- name: Reboot node if kernel was upgraded
+  ansible.builtin.reboot:
+    msg: "Rebooting to activate newly installed kernel"
+    reboot_timeout: 300
+    pre_reboot_delay: 5
+    post_reboot_delay: 30
+  when: reboot_required_file.stat.exists
 
 - name: Install common packages
   ansible.builtin.apt:
     name: "{{ common_packages }}"
     state: present
+
 - name: Configure passwordless sudo for k3s user
   ansible.builtin.copy:
     dest: /etc/sudoers.d/k3s-nopasswd


### PR DESCRIPTION
## Summary

After `apt dist-upgrade` upgrades the kernel, the playbook previously continued running under the old kernel with no indication a reboot was needed. This adds automatic reboot handling.

## Changes

- **`common_packages`**: adds `update-notifier-common` so kernel postinst scripts reliably write `/var/run/reboot-required`
- **`roles/common/tasks/main.yml`**:
  - Registers `apt_upgrade_result` on the apt upgrade task
  - Checks for `/var/run/reboot-required` via `stat`
  - Reboots via `ansible.builtin.reboot` if the file exists (`reboot_timeout: 300`, `pre_reboot_delay: 5`, `post_reboot_delay: 30`)
  - Reboot is idempotent — skips cleanly if no reboot is required

## Behavior

- **Kernel upgraded**: playbook reboots the node, waits for it to come back, then continues with remaining tasks (package install, UFW, etc.)
- **No kernel change**: stat returns `exists: false`, reboot task skips, playbook continues as normal
- **Subsequent runs**: `/var/run/reboot-required` won't exist, reboot always skips (idempotent)