### PR TITLE
feat(k3s): implement k3s-server role with single-node-first docs and security hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-04-28  
+**Generated:** 2026-05-02  
 **Branch:** master  
 
 ## OVERVIEW
-Homelab infrastructure managing 9 Docker services on a Synology NAS (macvlan networking), with documented-but-unimplemented plans to migrate to a 3-node K3s cluster. Docker stack is operational; K3s/Flux/CDK8s architecture exists only in `k3s/` docs.
+Homelab infrastructure managing 9 Docker services on a Synology NAS (macvlan networking), with a single-node K3s cluster bootstrap (Ansible) and documented plans to migrate to HA. Docker stack is operational; K3s server role is implemented; Flux CD and CDK8s remain future work.
 
 ## STRUCTURE
 ```
@@ -18,7 +18,7 @@ homelab/
 ├── watchtower/         # Auto-update containers, daily 2am schedule
 ├── sense-exporter/     # Sense home energy monitor Prometheus exporter
 ├── netgear-cm1000-exporter/  # Netgear CM1000 cable modem exporter
-├── k3s/                # Ansible bootstrap initialized; K3s/Flux stubs only
+├── k3s/                # Ansible K3s server bootstrap (single-node); Flux/HA planned
 ├── scripts/            # network-setup.sh: creates macvlan Docker network
 ├── CLAUDE.md           # AI agent instructions
 └── README.md
@@ -33,7 +33,7 @@ homelab/
 | SNMP exporter config | `prometheus/snmp_exporter/snmp.yml` | Auto-generated; job commented out in compose |
 | Grafana datasource | `grafana/datasources/prometheus_ds.yml` | Points to `http://prometheus:9090` |
 | Network initialization | `scripts/network-setup.sh` | Run before starting any services |
-| K3s cluster plans | `k3s/k3s.md`, `k3s/BOOTSTRAP.md` | Plans only — nothing is deployed |
+| K3s cluster bootstrap | `k3s/bootstrap/ansible/` | Single-node K3s server role implemented; Flux/HA planned |
 
 ## NETWORKING
 Two external Docker networks (must exist before services start):
@@ -59,7 +59,7 @@ Two external Docker networks (must exist before services start):
 - **Do not** use standard `docker-compose.yml` naming — breaks the `<service>-compose.yml` convention.
 - **Do not** hardcode secrets in compose files — use `${VAR}` referencing `.env`.
 - **Do not** use host networking or named volumes — bind mounts to `/volume1/` only.
-- **Do not** assume K3s cluster exists — `k3s/bootstrap/ansible/` provisions OS; K3s is not yet installed.
+- **Do not** assume K3s cluster exists on target hosts — Ansible provisions and installs K3s, but verify nodes are reachable first.
 - **snmp.yml is auto-generated** — do not hand-edit it (`WARNING: This file was auto-generated`).
 - **Typo in watchtower**: `WATHCTOWER_REVIVE_STOPPED` (misspelled) — do not "fix" it, it may break things.
 
@@ -85,7 +85,7 @@ docker-compose -f prometheus-compose.yml up -d
 ```
 
 ## NOTES
-- **K3s partially initialized**: `k3s/bootstrap/ansible/` has Ansible for OS provisioning; `provision-nodes.yml` is runnable. `bootstrap-k3s.yml` and `bootstrap-flux.yml` are stubs — K3s server role, Flux configs, and CDK8s TypeScript are not yet created.
+- **K3s bootstrap implemented**: `k3s/bootstrap/ansible/` has runnable `provision-nodes.yml` and `bootstrap-k3s.yml` (single-node K3s server role). `bootstrap-flux.yml` remains a stub. See `k3s/AGENTS.md` for current status.
 - **Prowlarr healthcheck is commented out** — its health endpoint wasn't stable.
 - **SNMP scrape is commented out** in `prometheus-compose.yml` — the config exists but the job is disabled.
 - **Nginx proxy config** (`prometheus/syno-prom-proxy.conf`) is co-located with Prometheus, not in a separate nginx service.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Homelab Infrastructure
 
-This repository manages both Docker-based services and a K3s Kubernetes cluster for my homelab environment. The infrastructure includes monitoring, media automation, networking services, and is transitioning to a GitOps-managed Kubernetes setup.
+This repository manages Docker-based services on a Synology NAS and a single-node K3s cluster on a testbed machine. The infrastructure includes monitoring, media automation, networking services, and documented plans for migrating to a multi-node K3s cluster with GitOps.
 
 ## Architecture Overview
 
 ### Current Setup
 - **Docker Services**: Legacy services running on Docker with macvlan networking
-- **K3s Cluster**: 3-node HA Kubernetes cluster with Longhorn storage and Flux CD GitOps
+- **K3s Cluster**: Single-node testbed (192.168.1.128) with SQLite datastore; HA cluster planned — see `k3s/BOOTSTRAP.md` Part 2
 - **Monitoring**: Comprehensive observability with Prometheus, Grafana, and custom exporters
 - **Network**: 192.168.1.0/24 physical network with bridge networking for containers
 
@@ -31,14 +31,19 @@ homelab/
 
 ## K3s Kubernetes Cluster
 
-### Quick Overview
-- **Nodes**: 3x Dell Optiplex (192.168.1.40-42)
-- **Storage**: Longhorn distributed storage with 3-way replication
-- **GitOps**: Flux CD v2 with CDK8s TypeScript manifests  
-- **Monitoring**: Prometheus + Grafana + Loki stack
-- **Networking**: Nginx Ingress with Let's Encrypt certificates
+### Current State
+- **Node**: Single testbed machine at 192.168.1.128
+- **Datastore**: SQLite (default for single node)
+- **GitOps**: Not yet implemented (Flux CD stub exists)
+- **Storage**: Local-path provisioner (Longhorn planned)
+- **Networking**: Flannel VXLAN CNI
+- **Ingress**: Traefik (default K3s ingress; Nginx planned)
 
-See [k3s.md](k3s.md) for comprehensive documentation on cluster architecture, deployment, and operations.
+### Planned (see `k3s/BOOTSTRAP.md` Part 2 and `k3s/k3s.md`)
+- 3-node HA with embedded etcd
+- Longhorn distributed storage
+- Flux CD v2 GitOps
+- Nginx Ingress + cert-manager
 
 ## Docker Services
 
@@ -102,20 +107,19 @@ docker-compose -f <service>-compose.yml up -d
 ```
 
 ### K3s Cluster
-Bootstrap the entire cluster:
+Bootstrap the single-node cluster:
 ```bash
 cd k3s/bootstrap/ansible/
-ansible-playbook -i inventory/hosts site.yml
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
 ```
 
 ## Migration to K3s
 
-The repository supports gradual migration from Docker to Kubernetes with:
-- Data migration tooling
-- Service-by-service transition capability
-- Rollback procedures
-- Comprehensive testing workflows
+The repository documents a future migration from Docker to Kubernetes with:
+- Single-node to HA cluster upgrade path (see `k3s/BOOTSTRAP.md` Part 2)
+- Data migration tooling (planned)
+- Service-by-service transition capability (planned)
 
-See [k3s.md](k3s.md) for detailed migration procedures and GitOps workflows.  
+See [`k3s/k3s.md`](k3s/k3s.md) for the full target architecture and [`k3s/BOOTSTRAP.md`](k3s/BOOTSTRAP.md) for current deployment status.
 
 

--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -1,7 +1,7 @@
 # K3S DIRECTORY
 
 ## OVERVIEW
-**Partially implemented.** Ansible directory is initialized for OS provisioning. K3s install, Flux CD, and CDK8s remain unimplemented.
+**Single-node K3s bootstrap is implemented.** Ansible provisions OS nodes and installs K3s server role. Flux CD and CDK8s remain unimplemented — see Part 2 of `BOOTSTRAP.md` for the HA upgrade path.
 
 ## WHAT EXISTS
 ```
@@ -14,18 +14,21 @@ k3s/
     ├── inventory/group_vars/all.yml  # Common vars: packages, UFW rules, kernel modules
     ├── playbooks/
     │   ├── provision-nodes.yml  # OS hardening + K3s prereqs (runnable now)
-    │   ├── bootstrap-k3s.yml    # K3s install stub (not yet runnable)
+    │   ├── bootstrap-k3s.yml    # K3s server install (runnable; uses k3s-server role)
     │   ├── bootstrap-flux.yml   # Flux CD stub (not yet runnable)
     │   └── site.yml             # Full entrypoint (runs all phases)
-    └── roles/
+    ├── roles/
         ├── common/              # apt upgrade, packages, timezone, UFW, passwordless sudo; asserts vars non-empty
-        └── k3s-prereqs/         # swap disable, kernel modules, sysctl
+        ├── k3s-prereqs/         # swap disable, kernel modules, sysctl
+        └── k3s-server/          # K3s server install, config, kubeconfig fetch, token persistence
 ```
+
+> Last verified: 2026-05-02
 
 ## PLANNED ARCHITECTURE (not yet created)
 | Component | Planned Location | Status |
 |-----------|-----------------|--------|
-| Ansible playbooks | `k3s/bootstrap/ansible/` | ✅ Initialized (provision-nodes only) |
+| Ansible playbooks | `k3s/bootstrap/ansible/` | ✅ Initialized (provision-nodes, bootstrap-k3s runnable) |
 | Flux CD configs | `k3s/clusters/`, `k3s/infrastructure/` | ❌ Not created |
 | CDK8s TypeScript | `applications/cdk8s/src/` | ❌ Not created |
 | Generated manifests | `applications/cdk8s/manifests/` | ❌ Not created |
@@ -42,6 +45,7 @@ k3s/
 ## ANTI-PATTERNS
 - **Do not create files here expecting them to be deployed** — the K3s cluster may not exist yet.
 - **Do not treat `k3s.md` as current state** — it describes the target, not reality.
+- **Do not describe planned components as implemented** — Flux, Longhorn, CDK8s, and HA are future state only.
 - **Do not run `ansible-playbook` commands from `BOOTSTRAP.md`** without verifying nodes are provisioned.
 
 ## NOTES
@@ -49,6 +53,7 @@ k3s/
 - `k3s.md` contains CDK8s TypeScript construct API and Flux kustomization patterns.
 - Current Docker services on Synology NAS are the live production environment — K3s migration is future work.
 - **Testbed node** (i7-4770k) at 192.168.1.128 is the first node to provision. Re-IP to 192.168.1.4x before joining the cluster.
-- `provision-nodes.yml` is the only runnable playbook today — runs `common` + `k3s-prereqs` roles.
-- `bootstrap-k3s.yml` and `bootstrap-flux.yml` are stubs; K3s server role (`roles/k3s-server/`) does not yet exist.
+- `provision-nodes.yml` is runnable — runs `common` + `k3s-prereqs` roles.
+- `bootstrap-k3s.yml` is runnable — runs `k3s-server` role to install and configure a single K3s server node.
+- `bootstrap-flux.yml` is a stub — Flux CD bootstrap is not yet implemented.
 - `group_vars/` lives at `inventory/group_vars/all.yml` (not at the ansible root) — required for `ansible-playbook` variable loading to work correctly.

--- a/k3s/BOOTSTRAP.md
+++ b/k3s/BOOTSTRAP.md
@@ -1,819 +1,319 @@
-# K3s Cluster Bootstrap Guide
+# K3s Bootstrap Guide
 
-This guide covers bootstrapping a fresh K3s cluster from clean Ubuntu Server installations with minimal manual intervention. This guide is designed for Kubernetes beginners and provides detailed explanations of each step.
+This guide covers bootstrapping a single-node K3s cluster using Ansible, then optionally scaling to a multi-node HA setup.
 
-## What is K3s?
+> **Current state**: Single-node K3s server on the testbed (`192.168.1.128`) with SQLite datastore. HA cluster, Longhorn, and Flux CD are future work — see [Part 2](#part-2-scaling-to-ha-future-state) for the upgrade path.
 
-K3s is a lightweight Kubernetes distribution designed for production workloads in resource-constrained environments. It packages all Kubernetes components into a single binary and removes many optional features to reduce memory and storage footprint.
+---
 
-**Key K3s Features:**
-- Single binary installation (~100MB)
-- Built-in container runtime (containerd)
-- Embedded etcd for HA clusters
-- Automatic TLS certificate management
-- Built-in local storage provider
-- Simplified networking with Flannel CNI
+## Part 1: Single-Node K3s Bootstrap
 
-## Prerequisites
+### Overview
 
-### Hardware Requirements
-- **3 Ubuntu Server nodes** with static IP addresses (192.168.1.40-42)
-  - Minimum 2GB RAM per node (4GB recommended)
-  - Minimum 20GB disk space per node
-  - 1 CPU core per node (2+ recommended)
-- **Testbed node** at 192.168.1.128 — single-node environment for testing changes before applying to the cluster
+The Ansible playbooks automate the entire K3s server installation:
 
-### Software Requirements
-- **Fresh Ubuntu Server installations** (latest version, fully updated)
-- **k3s user account** with same password on all nodes
-- **Direct terminal access** to each node (monitor/keyboard or IPMI/iLO)
+1. **`provision-nodes.yml`** — OS hardening, packages, UFW firewall, kernel modules, sysctl
+2. **`bootstrap-k3s.yml`** — K3s server install, configuration, kubeconfig fetch, token persistence
 
-### Control Machine Setup
-Your control machine (where you run commands) needs:
+Run them in order on a single testbed node. The result is a working single-node K3s cluster using SQLite (the default and recommended datastore for single-node deployments).
+
+### Prerequisites
+
+#### Hardware
+
+- **One Ubuntu Server node** with a static IP address (default: `192.168.1.128`)
+  - Minimum 2 GB RAM (4 GB recommended)
+  - Minimum 20 GB disk
+  - 1 CPU core (2+ recommended)
+
+#### Software
+
+- **Fresh Ubuntu Server** installation, fully updated
+- **`k3s` user account** with passwordless sudo (created by Ansible)
+- **Direct console/SSH access** to the node for initial setup
+
+#### Control Machine
+
+Your workstation (where you run Ansible) needs:
 
 ```bash
-# Install Ansible (Ubuntu/Debian)
-sudo apt update
-sudo apt install -y ansible sshpass
+# Install Ansible and required collections
+pip install ansible
+ansible-galaxy collection install -r k3s/bootstrap/ansible/requirements.yml
 
-# Install kubectl for cluster management
+# Install kubectl
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-# Install Flux CLI for GitOps
-curl -s https://fluxcd.io/install.sh | sudo bash
-
-# Verify installations
+# Verify
 ansible --version
 kubectl version --client
-flux version --client
 ```
 
-## Phase 1: Manual Node Preparation
+### Step 1: Configure the Testbed Node
 
-These steps must be performed manually on each node via direct terminal access.
-
-### Step 1: Enable SSH Service
-
-**Why SSH?** SSH (Secure Shell) allows secure remote access to your nodes. Ansible uses SSH to automate tasks across multiple machines.
-
-Perform these steps **on each node** (192.168.1.40, 192.168.1.41, 192.168.1.42):
+Before Ansible can reach the node, set up SSH access manually on the testbed:
 
 ```bash
-# Update package list and install SSH server
-sudo apt update
-sudo apt install -y openssh-server
+# On the testbed node (192.168.1.128):
+sudo apt update && sudo apt install -y openssh-server
+sudo systemctl enable --now ssh
 
-# Enable SSH to start automatically on boot
-sudo systemctl enable ssh
+# Create the k3s user with passwordless sudo
+sudo useradd -m -s /bin/bash k3s
+echo "k3s:changeme" | sudo chpasswd  # Change this immediately
+sudo bash -c 'echo "k3s ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/k3s'
 
-# Start SSH service immediately
-sudo systemctl start ssh
-
-# Verify SSH is running (should show "active (running)")
-sudo systemctl status ssh
+# Copy your SSH public key
+mkdir -p ~k3s/.ssh && chmod 700 ~k3s/.ssh
+# From your control machine:
+ssh-copy-id k3s@192.168.1.128
 ```
 
-**Expected Output:**
+> **Note:** The `common` Ansible role also configures passwordless sudo for the `k3s` user. If you prefer to let Ansible handle this entirely, you only need initial SSH access to run `provision-nodes.yml`.
+
+### Step 2: Verify Inventory
+
+The inventory at `k3s/bootstrap/ansible/inventory/hosts.yml` defines the testbed node:
+
+```yaml
+all:
+  children:
+    k3s_servers:
+      hosts:
+        testbed:
+          ansible_host: 192.168.1.128
 ```
-● ssh.service - OpenBSD Secure Shell server
-   Loaded: loaded (/lib/systemd/system/ssh.service; enabled; vendor preset: enabled)
-   Active: active (running) since [timestamp]
-   Process: [PID] ExecStartPre=/usr/sbin/sshd -t (code=exited, status=0/SUCCESS)
-   Main PID: [PID] (sshd)
-```
+
+Verify connectivity:
 
 ```bash
-# Configure firewall to allow SSH (if UFW is enabled)
-sudo ufw status
-# If firewall is active, allow SSH:
-sudo ufw allow ssh
-
-# Optional: Check which port SSH is running on (default: 22)
-sudo ss -tlnp | grep :22
+cd k3s/bootstrap/ansible
+ansible all -i inventory/hosts.yml -m ping
 ```
 
-### Step 2: Configure SSH for k3s User
+### Step 3: Review Group Variables
 
-**Why these permissions?** SSH requires strict file permissions for security. The `.ssh` directory must be readable only by the owner (700), and `authorized_keys` must not be writable by others (600).
+Key settings in `inventory/group_vars/all.yml`:
 
-Perform these steps **on each node**:
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `k3s_version` | `v1.35.4+k3s1` | K3s release to install |
+| `timezone` | `America/New_York` | Node timezone |
+| `k3s_firewall_rules` | SSH, API, kubelet, Flannel | UFW ports to open |
+| `k3s_kernel_modules` | `br_netfilter`, `overlay` | Required kernel modules |
+| `k3s_sysctl_params` | bridge-nf, ip-forward, swappiness | Required sysctl settings |
+
+Role-specific defaults are in `roles/k3s-server/defaults/main.yml` — override them in `group_vars/all.yml` or via `-e` flags.
+
+### Step 4: Install Required Ansible Collections
 
 ```bash
-# Switch to the k3s user account
-su - k3s
-# You'll be prompted for the k3s user password
-
-# Verify you're now the k3s user
-whoami
-# Should output: k3s
-
-# Create SSH directory with proper permissions
-mkdir -p ~/.ssh
-chmod 700 ~/.ssh
-
-# Create authorized_keys file (will store public keys later)
-touch ~/.ssh/authorized_keys
-chmod 600 ~/.ssh/authorized_keys
-
-# Verify permissions are correct
-ls -la ~/.ssh/
+cd k3s/bootstrap/ansible
+ansible-galaxy collection install -r requirements.yml
 ```
 
-**Expected Output:**
-```
-drwx------ 2 k3s k3s 4096 [date] .
-drwxr-xr-x 3 k3s k3s 4096 [date] ..
--rw------- 1 k3s k3s    0 [date] authorized_keys
-```
+### Step 5: Run Provision Nodes Playbook
+
+This hardens the OS, installs packages, configures UFW, and sets up kernel parameters:
 
 ```bash
-# Exit back to the original user
-exit
+cd k3s/bootstrap/ansible
+ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml
 ```
 
-### Step 3: Test SSH Connectivity
-
-**Important:** This step verifies that SSH is working before we set up key-based authentication.
-
-From your **control machine**, test SSH access to each node:
+If the playbook reboots the node (due to kernel updates), wait for SSH to come back and re-run:
 
 ```bash
-# Test SSH connection to master node
-ssh k3s@192.168.1.40
-# Enter the k3s user password when prompted
-# You should see the Ubuntu welcome message and shell prompt
-# Type 'exit' to disconnect
-
-# Test SSH connection to worker node 1
-ssh k3s@192.168.1.41
-# Enter password, verify connection, then exit
-
-# Test SSH connection to worker node 2
-ssh k3s@192.168.1.42
-# Enter password, verify connection, then exit
+# Wait for the node to come back up
+ssh k3s@192.168.1.128 "uptime"
+# Re-run if the playbook was interrupted by a reboot
+ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml
 ```
 
-**Troubleshooting SSH Issues:**
-- **Connection refused:** Check if SSH service is running: `sudo systemctl status ssh`
-- **Permission denied:** Verify k3s user password is correct
-- **Network unreachable:** Verify IP addresses and network connectivity: `ping 192.168.1.40`
-- **Firewall blocking:** Check UFW status: `sudo ufw status`
+### Step 6: Bootstrap K3s Server
 
-## Phase 2: SSH Key Setup and Distribution
-
-### Step 4: Generate SSH Key Pair
-
-**Why SSH Keys?** SSH keys provide secure, password-less authentication. The private key stays on your control machine, while public keys are distributed to the nodes.
-
-On your **control machine**:
+This installs K3s, writes the config, fetches the kubeconfig, and persists the join token:
 
 ```bash
-# Generate ED25519 SSH key pair (more secure than RSA)
-ssh-keygen -t ed25519 -f ~/.ssh/k3s_cluster -N ""
+cd k3s/bootstrap/ansible
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
 ```
 
-**Command Explanation:**
-- `-t ed25519`: Use ED25519 algorithm (modern, secure)
-- `-f ~/.ssh/k3s_cluster`: Save key as 'k3s_cluster' in SSH directory
-- `-N ""`: No passphrase (empty string)
+#### What this playbook does
 
-**Expected Output:**
-```
-Generating public/private ed25519 key pair.
-Your identification has been saved in /home/[user]/.ssh/k3s_cluster
-Your public key has been saved in /home/[user]/.ssh/k3s_cluster.pub
-The key fingerprint is:
-SHA256:[fingerprint] [user]@[hostname]
-```
+1. Validates that `k3s_version` is defined
+2. Creates `/etc/rancher/k3s/` and writes `config.yaml` with:
+   - `write-kubeconfig-mode: "0600"` — root-only kubeconfig on the node
+   - `secrets-encryption: true` — encrypts Kubernetes Secrets at rest
+   - `flannel-backend: vxlan` — default CNI backend
+3. Downloads and installs the K3s binary (`INSTALL_K3S_SKIP_START=true`)
+4. Enables and starts the `k3s` systemd service
+5. Waits for the API server (port 6443) and node Ready state
+6. Reads the node token from `/var/lib/rancher/k3s/server/node-token`
+7. Persists the token locally at `~/.kube/k3s-testbed-token` (mode `0600`)
+8. Fetches `/etc/rancher/k3s/k3s.yaml` to `~/.kube/k3s-testbed.yaml`
+9. Secures the local kubeconfig (mode `0600`)
+10. Replaces `127.0.0.1` with the node's actual IP in the kubeconfig
+
+> **Important:** `secrets-encryption: true` is a one-way door. Enable it before deploying any workloads. If you toggle it after workloads exist, existing Secrets will not be re-encrypted until you manually rotate the encryption key.
+
+### Step 7: Verify the Cluster
 
 ```bash
-# Start SSH agent to manage keys
-eval "$(ssh-agent -s)"
-# Should output: Agent pid [number]
+# Use the fetched kubeconfig
+export KUBECONFIG=~/.kube/k3s-testbed.yaml
 
-# Add private key to SSH agent
-ssh-add ~/.ssh/k3s_cluster
-# Should output: Identity added: ~/.ssh/k3s_cluster
+# Check node status
+kubectl get nodes
+# Expected: one node in Ready state
 
-# Verify key was added
-ssh-add -l
-# Should show your key fingerprint
-```
-
-### Step 5: Distribute SSH Keys
-
-**What happens here?** The `ssh-copy-id` command copies your public key to each node's `~/.ssh/authorized_keys` file, enabling password-less SSH access.
-
-From your **control machine**:
-
-```bash
-# Copy public key to master node
-ssh-copy-id -i ~/.ssh/k3s_cluster.pub k3s@192.168.1.40
-# Enter k3s password when prompted
-```
-
-**Expected Output:**
-```
-/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/home/[user]/.ssh/k3s_cluster.pub"
-/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
-/usr/bin/ssh-copy-id: INFO: 1 key(s) remain to be installed -- if you are prompted now, it is to install the new key(s)
-k3s@192.168.1.40's password:
-
-Number of key(s) added: 1
-
-Now try logging into the machine, with:   "ssh 'k3s@192.168.1.40'"
-and check to make sure that only the key(s) you wanted were added.
-```
-
-```bash
-# Copy public key to worker node 1
-ssh-copy-id -i ~/.ssh/k3s_cluster.pub k3s@192.168.1.41
-# Enter k3s password when prompted
-
-# Copy public key to worker node 2
-ssh-copy-id -i ~/.ssh/k3s_cluster.pub k3s@192.168.1.42
-# Enter k3s password when prompted
-
-# Copy public key to testbed node
-ssh-copy-id -i ~/.ssh/k3s_cluster.pub k3s@192.168.1.128
-# Enter k3s password when prompted
-
-# Test password-less SSH access
-ssh -i ~/.ssh/k3s_cluster k3s@192.168.1.40 'hostname'
-# Should output the hostname without prompting for password
-ssh -i ~/.ssh/k3s_cluster k3s@192.168.1.41 'hostname'
-ssh -i ~/.ssh/k3s_cluster k3s@192.168.1.42 'hostname'
-ssh -i ~/.ssh/k3s_cluster k3s@192.168.1.128 'hostname'
-```
-
-### Step 6: Configure SSH Client
-
-**Why SSH Config?** This creates friendly hostnames and sets default connection parameters, making it easier to connect to nodes.
-
-Edit your SSH config file:
-
-```bash
-# Create or edit SSH config file
-nano ~/.ssh/config
-```
-
-Add this configuration:
-
-```
-# K3s Cluster Nodes
-Host k3s-master
-    HostName 192.168.1.40
-    User k3s
-    IdentityFile ~/.ssh/k3s_cluster
-    StrictHostKeyChecking no
-
-Host k3s-worker1
-    HostName 192.168.1.41
-    User k3s
-    IdentityFile ~/.ssh/k3s_cluster
-    StrictHostKeyChecking no
-
-Host k3s-worker2
-    HostName 192.168.1.42
-    User k3s
-    IdentityFile ~/.ssh/k3s_cluster
-    StrictHostKeyChecking no
-
-Host testbed
-    HostName 192.168.1.128
-    User k3s
-    IdentityFile ~/.ssh/k3s_cluster
-    StrictHostKeyChecking no
-    UserKnownHostsFile /dev/null
-
-# Wildcard for all k3s nodes
-Host k3s-*
-    UserKnownHostsFile /dev/null
-    LogLevel ERROR
-```
-
-**Configuration Explanation:**
-- `HostName`: Actual IP address of the node
-- `User`: Username to connect as (k3s)
-- `IdentityFile`: Private key to use for authentication
-- `StrictHostKeyChecking no`: Don't prompt about host key verification
-- `UserKnownHostsFile /dev/null`: Don't save host keys
-- `LogLevel ERROR`: Reduce SSH output verbosity
-
-```bash
-# Set proper permissions on SSH config
-chmod 600 ~/.ssh/config
-
-# Test friendly hostnames
-ssh k3s-master 'hostname'
-ssh k3s-worker1 'hostname'
-ssh k3s-worker2 'hostname'
-ssh testbed 'hostname'
-```
-
-## Phase 3: Ansible Configuration
-
-### Step 7: Setup Ansible Inventory
-
-**What is Ansible Inventory?** An inventory file tells Ansible which hosts to manage and how to connect to them. It groups hosts by role (masters, workers) and sets connection parameters.
-
-Create the directory structure:
-
-```bash
-# Create Ansible directory structure
-mkdir -p k3s/bootstrap/ansible/inventory
-mkdir -p k3s/bootstrap/ansible/playbooks
-mkdir -p k3s/bootstrap/ansible/group_vars
-mkdir -p k3s/bootstrap/ansible/host_vars
-```
-
-Create the inventory file:
-
-```bash
-# Create inventory file
-nano k3s/bootstrap/ansible/inventory/hosts
-```
-
-Add this content:
-
-```ini
-# K3s Cluster Inventory
-# Groups hosts by role and defines connection parameters
-
-[k3s_cluster:children]
-masters
-workers
-
-[masters]
-k3s-master ansible_host=192.168.1.40
-
-[workers]
-k3s-worker1 ansible_host=192.168.1.41
-k3s-worker2 ansible_host=192.168.1.42
-
-# Global variables for all K3s cluster nodes
-[k3s_cluster:vars]
-ansible_user=k3s
-ansible_ssh_private_key_file=~/.ssh/k3s_cluster
-ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-ansible_python_interpreter=/usr/bin/python3
-
-# Master node specific variables
-[masters:vars]
-node_role=master
-k3s_server=true
-
-# Worker node specific variables
-[workers:vars]
-node_role=worker
-k3s_server=false
-```
-
-**Inventory Explanation:**
-- `[k3s_cluster:children]`: Creates a parent group containing masters and workers
-- `ansible_host`: Actual IP address to connect to
-- `ansible_user`: Username for SSH connections
-- `ansible_ssh_private_key_file`: Path to SSH private key
-- `ansible_python_interpreter`: Python path (required for Ubuntu)
-- `k3s_server`: Determines if node runs K3s server or agent
-
-### Step 8: Test Ansible Connectivity
-
-**What does this test?** The ping module verifies Ansible can connect to all nodes via SSH and execute Python commands.
-
-```bash
-# Navigate to Ansible directory
-cd k3s/bootstrap/ansible/
-
-# Test connectivity to all nodes
-ansible all -i inventory/hosts -m ping
-```
-
-**Expected Output:**
-```
-k3s-master | SUCCESS => {
-    "ansible_facts": {
-        "discovered_interpreter_python": "/usr/bin/python3"
-    },
-    "changed": false,
-    "ping": "pong"
-}
-k3s-worker1 | SUCCESS => {
-    "ansible_facts": {
-        "discovered_interpreter_python": "/usr/bin/python3"
-    },
-    "changed": false,
-    "ping": "pong"
-}
-k3s-worker2 | SUCCESS => {
-    "ansible_facts": {
-        "discovered_interpreter_python": "/usr/bin/python3"
-    },
-    "changed": false,
-    "ping": "pong"
-}
-```
-
-```bash
-# Test individual groups
-ansible masters -i inventory/hosts -m ping
-ansible workers -i inventory/hosts -m ping
-
-# Gather system information from all nodes
-ansible all -i inventory/hosts -m setup -a "filter=ansible_distribution*"
-```
-
-**Troubleshooting Ansible Connection Issues:**
-- **UNREACHABLE**: Check SSH connectivity manually: `ssh k3s-master`
-- **Authentication failure**: Verify SSH keys: `ssh-add -l`
-- **Python not found**: Install Python3: `ansible all -i inventory/hosts -m raw -a "sudo apt install python3 -y"`
-
-## Phase 4: Automated Bootstrap with Ansible
-
-### Step 9: Node Provisioning
-
-**What does provisioning do?** Prepares Ubuntu nodes for K3s by installing dependencies, configuring system settings, and ensuring all prerequisites are met.
-
-Before running the playbook, let's understand what will happen:
-
-**System Updates:**
-- Updates all packages to latest versions
-- Installs essential tools (curl, wget, git, etc.)
-
-**Kubernetes Prerequisites:**
-- Disables swap (Kubernetes requirement)
-- Loads required kernel modules (br_netfilter, overlay)
-- Configures sysctl settings for networking
-- Installs container runtime dependencies
-
-**Security Configuration:**
-- Configures UFW firewall rules for K3s ports
-- Sets up log rotation for K3s logs
-
-Run the node provisioning playbook:
-
-```bash
-ansible-playbook -i inventory/hosts playbooks/provision-nodes.yml -v
-```
-
-**Expected Duration:** 5-10 minutes depending on internet speed and system performance.
-
-**Key Ports Opened:**
-- `6443/tcp`: Kubernetes API server
-- `10250/tcp`: Kubelet API
-- `8472/udp`: Flannel VXLAN
-- `51820/udp`: Flannel Wireguard (if enabled)
-
-**Validation Commands:**
-```bash
-# Verify swap is disabled on all nodes
-ansible all -i inventory/hosts -m shell -a "free -h | grep Swap"
-# Should show 0B for swap
-
-# Check kernel modules are loaded
-ansible all -i inventory/hosts -m shell -a "lsmod | grep br_netfilter"
-
-# Verify firewall rules
-ansible all -i inventory/hosts -m shell -a "sudo ufw status numbered"
-```
-
-### Step 10: K3s Cluster Bootstrap
-
-**What happens during K3s bootstrap?**
-
-**Master Node Setup:**
-1. Downloads and installs K3s binary
-2. Starts K3s server with embedded etcd
-3. Generates cluster token for worker nodes
-4. Creates kubeconfig file for cluster access
-5. Configures local storage and networking
-
-**Worker Node Setup:**
-1. Downloads and installs K3s binary
-2. Connects to master using cluster token
-3. Starts K3s agent process
-4. Joins cluster and registers as available node
-
-**Storage Configuration:**
-1. Installs Longhorn distributed storage
-2. Creates storage classes for persistent volumes
-3. Configures 3-way replication for data safety
-
-Run the K3s bootstrap playbook:
-
-```bash
-ansible-playbook -i inventory/hosts playbooks/bootstrap-k3s.yml -v
-```
-
-**Expected Duration:** 10-15 minutes (depends on internet speed for downloading images)
-
-**What to watch for:**
-- Master node: Should show "K3s server started successfully"
-- Worker nodes: Should show "Joined cluster successfully"
-- Storage: Longhorn pods should enter Running state
-
-**Validation Commands:**
-```bash
-# Check K3s service status on all nodes
-ansible all -i inventory/hosts -m shell -a "sudo systemctl status k3s || sudo systemctl status k3s-agent"
-
-# Verify cluster token was generated
-ansible masters -i inventory/hosts -m shell -a "sudo cat /var/lib/rancher/k3s/server/node-token"
-
-# Check cluster nodes from master
-ansible masters -i inventory/hosts -m shell -a "sudo k3s kubectl get nodes -o wide"
-```
-
-**Expected Node Output:**
-```
-NAME          STATUS   ROLES                  AGE   VERSION        INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-k3s-master    Ready    control-plane,master   1m    v1.28.x+k3s1   192.168.1.40   <none>        Ubuntu 24.04.x LTS   6.8.0-xx-generic    containerd://1.7.x
-k3s-worker1   Ready    <none>                 1m    v1.28.x+k3s1   192.168.1.41   <none>        Ubuntu 24.04.x LTS   6.8.0-xx-generic    containerd://1.7.x
-k3s-worker2   Ready    <none>                 1m    v1.28.x+k3s1   192.168.1.42   <none>        Ubuntu 24.04.x LTS   6.8.0-xx-generic    containerd://1.7.x
-```
-
-### Step 11: Flux CD Bootstrap
-
-**What is Flux CD?** Flux is a GitOps operator that automatically syncs your Kubernetes cluster with a Git repository. When you commit changes to your repo, Flux deploys them to the cluster.
-
-**GitOps Benefits:**
-- **Declarative**: Infrastructure defined as code
-- **Versioned**: All changes tracked in Git
-- **Automated**: No manual kubectl commands needed
-- **Auditable**: Full change history and rollback capability
-
-**Prerequisites for Flux:**
-- GitHub repository (this homelab repository)
-- GitHub Personal Access Token with repo permissions
-- Flux CLI installed on control machine
-
-**Setup GitHub Token:**
-1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
-2. Generate new token with `repo` scope
-3. Save token securely
-
-```bash
-# Export GitHub token (replace with your actual token)
-export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Verify token works
-curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user
-```
-
-Run the Flux bootstrap playbook:
-
-```bash
-ansible-playbook -i inventory/hosts playbooks/bootstrap-flux.yml -v -e github_token=$GITHUB_TOKEN
-```
-
-**Expected Duration:** 5-10 minutes
-
-**What Flux Creates:**
-- `flux-system` namespace
-- Source controller (monitors Git repository)
-- Kustomize controller (applies Kubernetes manifests)
-- Helm controller (manages Helm charts)
-- Notification controller (sends alerts)
-
-**Validation Commands:**
-```bash
-# Check Flux components
-ansible masters -i inventory/hosts -m shell -a "sudo k3s kubectl get pods -n flux-system"
-
-# Check Flux sources (should show your Git repository)
-ansible masters -i inventory/hosts -m shell -a "sudo k3s kubectl get gitrepositories -A"
-
-# Check Flux kustomizations
-ansible masters -i inventory/hosts -m shell -a "sudo k3s kubectl get kustomizations -A"
-```
-
-**Expected Flux Pods:**
-```
-NAME                                       READY   STATUS    RESTARTS   AGE
-source-controller-xxx                      1/1     Running   0          2m
-kustomize-controller-xxx                   1/1     Running   0          2m
-helm-controller-xxx                        1/1     Running   0          2m
-notification-controller-xxx                1/1     Running   0          2m
-```
-
-## Phase 5: Verification
-
-### Step 12: Cluster Health Check
-
-**Why health checks?** These commands verify that all cluster components are working correctly and the cluster is ready for workloads.
-
-**Setup kubectl Access:**
-
-```bash
-# Copy kubeconfig from master node to control machine
-scp k3s-master:/etc/rancher/k3s/k3s.yaml ~/.kube/k3s-config
-
-# Update server IP in kubeconfig (K3s defaults to 127.0.0.1)
-sed -i 's/127.0.0.1/192.168.1.40/g' ~/.kube/k3s-config
-
-# Set KUBECONFIG environment variable
-export KUBECONFIG=~/.kube/k3s-config
-
-# Make this permanent by adding to ~/.bashrc
-echo "export KUBECONFIG=~/.kube/k3s-config" >> ~/.bashrc
-```
-
-**Essential Health Checks:**
-
-```bash
-# 1. Verify all nodes are Ready
-kubectl get nodes -o wide
-```
-
-**Expected Output:**
-```
-NAME          STATUS   ROLES                  AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
-k3s-master    Ready    control-plane,master   10m   v1.28.x   192.168.1.40   <none>        Ubuntu 24.04 LTS   6.8.0-xx-generic   containerd://1.7.x
-k3s-worker1   Ready    <none>                 10m   v1.28.x   192.168.1.41   <none>        Ubuntu 24.04 LTS   6.8.0-xx-generic   containerd://1.7.x
-k3s-worker2   Ready    <none>                 10m   v1.28.x   192.168.1.42   <none>        Ubuntu 24.04 LTS   6.8.0-xx-generic   containerd://1.7.x
-```
-
-```bash
-# 2. Check all system pods are running
+# Check system pods
 kubectl get pods -A
+
+# Verify Secrets encryption
+kubectl get secrets -A -o yaml | grep -c 'encrypted'
 ```
 
-**Expected System Pods:**
-- kube-system: coredns, local-path-provisioner, metrics-server, traefik
-- longhorn-system: longhorn-manager, longhorn-driver, longhorn-ui
-- flux-system: source-controller, kustomize-controller, helm-controller
+You should see:
+- One `Ready` node (the testbed)
+- System pods running: `local-path-provisioner`, `coredns`, `metrics-server`, `kube-proxy`
+- No Longhorn or Flux pods (those are future work)
+
+### Step 8: Use the Cluster
 
 ```bash
-# 3. Verify Longhorn storage system
-kubectl get pods -n longhorn-system
-kubectl get storageclass
+export KUBECONFIG=~/.kube/k3s-testbed.yaml
+
+# Deploy a test workload
+kubectl create deployment nginx --image=nginx:alpine --replicas=1
+kubectl expose deployment nginx --port=80 --target-port=80
+kubectl get pods,svc
+
+# Clean up
+kubectl delete deployment,svc nginx
 ```
 
-**Expected Storage Classes:**
-```
-NAME                   PROVISIONER          RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-longhorn (default)     driver.longhorn.io   Delete          Immediate              true                   5m
-local-path             rancher.io/local-path Delete          WaitForFirstConsumer   false                  10m
-```
+### Security Notes
+
+- **Kubeconfig on the node** is mode `0600` (root-only). On your control machine it is also `0600`.
+- **Node join token** is persisted at `~/.kube/k3s-testbed-token` (mode `0600`). You will need this token if you later add nodes for HA.
+- **Secrets at rest** are encrypted. Keep the encryption key safe — it lives at `/var/lib/rancher/k3s/server/encryption-config.json` on the node.
+- **UFW firewall** is configured with only the required ports open (SSH, API server, kubelet, Flannel).
+
+### Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|------|
+| `ansible all -m ping` fails | SSH not reachable or wrong key | Verify `~/.ssh/k3s_cluster` key, check IP in `hosts.yml` |
+| K3s install fails at download | `get.k3s.io` unreachable or wrong version string | Verify `k3s_version` in `group_vars/all.yml` matches a real K3s release |
+| Node stuck in `NotReady` | Flannel or kubelet not started | `sudo journalctl -u k3s -n 100` on the node |
+| `kubectl` cannot connect | Wrong IP in kubeconfig | Check `server:` line in `~/.kube/k3s-testbed.yaml` |
+| Re-run playbook restarts K3s | Config file changed | Normal — Ansible detects config drift and restarts the service |
+
+### Running the Full Entrypoint
+
+The `site.yml` playbook runs all phases in sequence:
 
 ```bash
-# 4. Check Flux CD status
-flux get all -A
+cd k3s/bootstrap/ansible
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml
 ```
 
-**Expected Flux Resources:**
-```
-NAMESPACE     NAME          REVISION        SUSPENDED       READY   MESSAGE
-flux-system   flux-system   main@sha1:xxx   False           True    Applied revision: main@sha1:xxx
+> **Note:** `site.yml` currently runs Phase 1 (provision) and Phase 2 (K3s bootstrap). Phase 3 (Flux) is not yet implemented and will fail with a clear message.
 
-NAMESPACE     NAME          REVISION        SUSPENDED       READY   MESSAGE  
-flux-system   flux-system   main@sha1:xxx   False           True    Applied revision: main@sha1:xxx
+---
+
+## Part 2: Scaling to HA (Future State)
+
+> **Warning:** This section describes a future upgrade path. None of this is implemented yet. The single-node cluster uses SQLite as its datastore, which does not support in-place migration to embedded etcd. Moving from single-node SQLite to multi-node HA **requires a fresh cluster install** — there is no upgrade path that preserves state.
+
+### Prerequisites Before Scaling
+
+Before adding nodes, you must:
+
+1. **Back up the SQLite datastore** from `/var/lib/rancher/k3s/server/db/state.db` on the testbed.
+2. **Save the node join token** — it is stored at `~/.kube/k3s-testbed-token` on your control machine.
+3. **Ensure all workloads have GitOps-managed definitions** so they can be re-applied after a fresh install.
+
+### Step 1: Provision Additional Nodes
+
+Add nodes to `inventory/hosts.yml`:
+
+```yaml
+all:
+  children:
+    k3s_servers:
+      hosts:
+        testbed:
+          ansible_host: 192.168.1.128
+        # Uncomment and re-IP after provisioning:
+        # k3s-node-1:
+        #   ansible_host: 192.168.1.40
+        # k3s-node-2:
+        #   ansible_host: 192.168.1.41
+        # k3s-node-3:
+        #   ansible_host: 192.168.1.42
 ```
+
+Run `provision-nodes.yml` on the new nodes to harden them.
+
+### Step 2: Restore etcd Ports in UFW
+
+Add these back to `inventory/group_vars/all.yml`:
+
+```yaml
+k3s_firewall_rules:
+  # ... existing rules ...
+  - { port: 2379, proto: tcp, comment: "etcd client requests" }   # HA only
+  - { port: 2380, proto: tcp, comment: "etcd peer communication" } # HA only
+```
+
+### Step 3: Initialize the First HA Node
+
+On the first server, set `k3s_init_cluster: true` in `group_vars/all.yml` or via the command line:
 
 ```bash
-# 5. Test cluster DNS resolution
-kubectl run test-dns --image=busybox:1.28 --rm -it --restart=Never -- nslookup kubernetes.default
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml \
+  -e "k3s_init_cluster=true"
 ```
 
-**Expected DNS Output:**
-```
-Server:    10.43.0.10
-Address 1: 10.43.0.10 kube-dns.kube-system.svc.cluster.local
+This reconfigures K3s to use embedded etcd instead of SQLite and starts the HA cluster.
 
-Name:      kubernetes.default
-Address 1: 10.43.0.1 kubernetes.default.svc.cluster.local
-```
+> **Destructive operation:** Enabling `cluster-init: true` on an existing SQLite node will not migrate data. Back up workloads and re-apply them after the cluster is re-initialized.
 
-### Step 13: Initial Application Deployment
+### Step 4: Join Additional Nodes
 
-**Testing GitOps Workflow:** This verifies that Flux can detect changes in your Git repository and deploy them to the cluster.
-
-**Manual Flux Reconciliation:**
+On each additional server:
 
 ```bash
-# Force Flux to check for new changes immediately
-flux reconcile source git flux-system
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml \
+  -e "k3s_server_url=https://192.168.1.128:6443" \
+  -e "k3s_token=<saved-join-token>"
 ```
 
-**Expected Output:**
-```
-✓ applied revision main@sha1:xxxxxxxxxxxxx
-```
+### Step 5: Verify HA Cluster
 
 ```bash
-# Check if any kustomizations need reconciliation
-flux reconcile kustomization flux-system
+kubectl get nodes
+# Expected: 3 (or more) nodes in Ready state
 
-# Monitor all pods across all namespaces
-kubectl get pods -A -w
-# Press Ctrl+C to stop watching
+kubectl get pods -n kube-system -l component=etcd
+# Expected: etcd pods on each server
 ```
 
-**Deploy a Test Application:**
+### Future Phases
 
-Create a simple test deployment to verify the cluster is working:
+These are not yet implemented and are listed here for planning purposes only:
 
-```bash
-# Create test namespace and deployment
-kubectl create namespace test
-kubectl create deployment nginx --image=nginx:alpine -n test
-kubectl expose deployment nginx --port=80 --target-port=80 -n test
+| Phase | Component | Status |
+|-------|-----------|--------|
+| Flux CD | GitOps automation | Stub only (`bootstrap-flux.yml`) |
+| Longhorn | Distributed block storage | Not started |
+| Nginx Ingress | HTTP load balancer | Not started (Traefik is the default K3s ingress) |
+| Cert Manager | TLS certificate automation | Not started |
+| SOPS + age | Secret encryption in Git | Not started |
+| CDK8s | TypeScript-defined manifests | Not started |
+| Velero | Backup/restore | Not started |
 
-# Check deployment status
-kubectl get pods -n test -w
-# Wait for pod to show "Running" status
-
-# Test internal connectivity
-kubectl run test-client --image=busybox:1.28 --rm -it --restart=Never -n test -- wget -qO- nginx
-# Should return HTML from nginx
-
-# Clean up test resources
-kubectl delete namespace test
-```
-
-**Verify Longhorn Storage:**
-
-```bash
-# Create a PVC to test storage
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: test-pvc
-  namespace: default
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  storageClassName: longhorn
-EOF
-
-# Check PVC status (should show "Bound")
-kubectl get pvc test-pvc
-
-# Check Longhorn volume was created
-kubectl get volumes -n longhorn-system
-
-# Clean up test PVC
-kubectl delete pvc test-pvc
-```
-
-**Access Cluster Services:**
-
-```bash
-# Get Traefik (ingress controller) service
-kubectl get svc -n kube-system traefik
-
-# Get Longhorn UI service (if enabled)
-kubectl get svc -n longhorn-system longhorn-frontend
-
-# Port forward to access Longhorn UI from control machine
-kubectl port-forward -n longhorn-system svc/longhorn-frontend 8080:80 &
-# Open browser to http://localhost:8080
-# Kill port-forward: killall kubectl
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **SSH Connection Refused**
-   - Verify SSH service is running: `sudo systemctl status ssh`
-   - Check firewall rules: `sudo ufw status`
-
-2. **Ansible Connection Timeout**
-   - Verify SSH key authentication: `ssh -i ~/.ssh/k3s_cluster k3s@<node-ip>`
-   - Check inventory file syntax
-
-3. **K3s Installation Failures**
-   - Check node system requirements (RAM, disk space)
-   - Verify network connectivity between nodes
-   - Review K3s logs: `sudo journalctl -u k3s`
-
-4. **Longhorn Storage Issues**
-   - Ensure nodes have required dependencies: `iscsiadm`, `multipath-tools`
-   - Check available disk space on each node
-
-5. **Flux Bootstrap Failures**
-   - Verify GitHub token permissions
-   - Check repository access and branch existence
-   - Review Flux controller logs: `kubectl logs -n flux-system -l app=source-controller`
-
-## Next Steps
-
-After successful bootstrap:
-1. Configure monitoring stack (Prometheus, Grafana, Loki)
-2. Set up ingress controller and certificates
-3. Deploy applications using CDK8s or direct manifests
-4. Configure backup strategies with Velero
-5. Implement network policies and RBAC
-
-## Required Ansible Playbooks
-
-The following playbooks need to be created/updated in `k3s/bootstrap/ansible/playbooks/`:
-- `provision-nodes.yml` - System preparation and dependencies
-- `bootstrap-k3s.yml` - K3s cluster installation and configuration
-- `bootstrap-flux.yml` - Flux CD setup and GitOps configuration
+Refer to `k3s/k3s.md` for the full target architecture.

--- a/k3s/BOOTSTRAP.md
+++ b/k3s/BOOTSTRAP.md
@@ -172,7 +172,7 @@ kubectl get nodes
 kubectl get pods -A
 
 # Verify Secrets encryption
-kubectl get secrets -A -o yaml | grep -c 'encrypted'
+k3s secrets-encrypt status
 ```
 
 You should see:

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -37,3 +37,7 @@ k3s_sysctl_params:
   net.bridge.bridge-nf-call-ip6tables: 1
   net.ipv4.ip_forward: 1
   vm.swappiness: 0
+
+# K3s version installed on all nodes — pin to a specific release.
+# Find the latest: https://github.com/k3s-io/k3s/releases
+k3s_version: "v1.32.4+k3s1"

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -23,8 +23,8 @@ k3s_firewall_rules:
   - { port: 10250, proto: tcp, comment: "Kubelet API" }
   - { port: 8472,  proto: udp, comment: "Flannel VXLAN" }
   - { port: 51820, proto: udp, comment: "Flannel WireGuard (optional)" }
-  - { port: 2379,  proto: tcp, comment: "etcd client requests" }
-  - { port: 2380,  proto: tcp, comment: "etcd peer communication" }
+  # Etcd peer/client ports are HA-only;
+  see BOOTSTRAP.md Part 2 for HA upgrade path
 
 # Kernel modules required for K3s / Kubernetes networking
 k3s_kernel_modules:

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -40,4 +40,4 @@ k3s_sysctl_params:
 
 # K3s version installed on all nodes — pin to a specific release.
 # Find the latest: https://github.com/k3s-io/k3s/releases
-k3s_version: "v1.32.4+k3s1"
+k3s_version: "v1.35.4+k3s1"

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -23,8 +23,7 @@ k3s_firewall_rules:
   - { port: 10250, proto: tcp, comment: "Kubelet API" }
   - { port: 8472,  proto: udp, comment: "Flannel VXLAN" }
   - { port: 51820, proto: udp, comment: "Flannel WireGuard (optional)" }
-  # Etcd peer/client ports are HA-only;
-  see BOOTSTRAP.md Part 2 for HA upgrade path
+# Etcd peer/client ports are HA-only; see BOOTSTRAP.md Part 2 for HA upgrade path.
 
 # Kernel modules required for K3s / Kubernetes networking
 k3s_kernel_modules:

--- a/k3s/bootstrap/ansible/inventory/hosts.yml
+++ b/k3s/bootstrap/ansible/inventory/hosts.yml
@@ -1,6 +1,6 @@
 ---
 # K3s Cluster Inventory
-# All nodes run as k3s servers with embedded etcd (HA mode)
+# Single-node K3s server (SQLite datastore). See BOOTSTRAP.md Part 2 for HA upgrade path.
 #
 # Testbed: i7-4770k at 192.168.1.128 — re-IP to 192.168.1.4x before joining cluster
 # Target cluster IPs: 192.168.1.40, 192.168.1.41, 192.168.1.42

--- a/k3s/bootstrap/ansible/playbooks/bootstrap-k3s.yml
+++ b/k3s/bootstrap/ansible/playbooks/bootstrap-k3s.yml
@@ -5,13 +5,8 @@
 #
 # Usage: ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml -v
 
-- name: Bootstrap K3s cluster (stub — not yet runnable)
-  hosts: all
+- name: Install and configure K3s server
+  hosts: k3s_servers
   become: true
-  tasks:
-    - name: Fail until the k3s-server role is implemented
-      ansible.builtin.fail:
-        msg: >-
-          bootstrap-k3s.yml is currently a stub. The k3s-server role is not
-          present in this repository, so this playbook cannot run yet.
-          Implement roles/k3s-server/ before using this entrypoint.
+  roles:
+    - k3s-server

--- a/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
@@ -40,3 +40,7 @@ k3s_tls_san: []
 # The file is fetched after K3s starts so you can run kubectl locally.
 k3s_kubeconfig_local_dir: "{{ lookup('env', 'HOME') }}/.kube"
 k3s_kubeconfig_local_file: "{{ k3s_kubeconfig_local_dir }}/k3s-{{ inventory_hostname }}.yaml"
+
+# Set true to print the node join token to Ansible output (disabled by default to avoid leaking
+# the token into logs/scrollback; it is always persisted locally to k3s_kubeconfig_local_dir).
+k3s_show_node_token: false

--- a/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
@@ -4,7 +4,7 @@
 
 # K3s version to install — pin to a specific release for reproducibility.
 # Find the latest release at: https://github.com/k3s-io/k3s/releases
-k3s_version: "v1.35.4+k3s1"
+# k3s_version: "v1.35.4+k3s1"  # Source of truth is inventory/group_vars/all.yml — edit there instead.
 
 k3s_install_script_url: "https://get.k3s.io"
 

--- a/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
@@ -4,7 +4,7 @@
 
 # K3s version to install — pin to a specific release for reproducibility.
 # Find the latest release at: https://github.com/k3s-io/k3s/releases
-k3s_version: "v1.32.4+k3s1"
+k3s_version: "v1.35.4+k3s1"
 
 k3s_install_script_url: "https://get.k3s.io"
 
@@ -22,6 +22,19 @@ k3s_init_cluster: false
 # Leave empty when starting a fresh cluster (single-node or first HA node).
 k3s_server_url: ""
 k3s_token: ""
+
+# Networking — explicitly set the CNI backend rather than relying on the default.
+# Options: vxlan (universal), host-gw (L2 networks, best perf), wireguard-native (encrypted).
+k3s_flannel_backend: "vxlan"
+
+# Primary IP for cluster traffic. Set this on multi-NIC hosts to avoid picking the wrong
+# interface. Leave empty to let K3s auto-detect (safe for single-NIC nodes).
+k3s_node_ip: ""
+
+# Extra TLS SANs added to the API server certificate. Required when accessing the cluster
+# via a load balancer VIP or DNS alias that is not the node's own hostname/IP.
+# Example: k3s_tls_san: ["k3s.example.com", "192.168.1.50"]
+k3s_tls_san: []
 
 # Kubeconfig destination on the Ansible control machine (your laptop/workstation).
 # The file is fetched after K3s starts so you can run kubectl locally.

--- a/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# roles/k3s-server/defaults/main.yml
+# Override these in group_vars/all.yml or host_vars/
+
+# K3s version to install — pin to a specific release for reproducibility.
+# Find the latest release at: https://github.com/k3s-io/k3s/releases
+k3s_version: "v1.32.4+k3s1"
+
+k3s_install_script_url: "https://get.k3s.io"
+
+# File paths
+k3s_config_dir: /etc/rancher/k3s
+k3s_config_file: /etc/rancher/k3s/config.yaml
+k3s_token_file: /var/lib/rancher/k3s/server/node-token
+
+# HA cluster init: set true on the FIRST server of a multi-node HA cluster.
+# This enables embedded etcd instead of the default SQLite backend.
+# Leave false for a single-node cluster (SQLite is sufficient and lighter).
+k3s_init_cluster: false
+
+# Join an existing cluster: provide both to connect this node to a running server.
+# Leave empty when starting a fresh cluster (single-node or first HA node).
+k3s_server_url: ""
+k3s_token: ""
+
+# Kubeconfig destination on the Ansible control machine (your laptop/workstation).
+# The file is fetched after K3s starts so you can run kubectl locally.
+k3s_kubeconfig_local_dir: "{{ lookup('env', 'HOME') }}/.kube"
+k3s_kubeconfig_local_file: "{{ k3s_kubeconfig_local_dir }}/k3s-{{ inventory_hostname }}.yaml"

--- a/k3s/bootstrap/ansible/roles/k3s-server/handlers/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# roles/k3s-server/handlers/main.yml
+
+- name: Restart k3s
+  ansible.builtin.systemd:
+    name: k3s
+    state: restarted
+    daemon_reload: true

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -1,0 +1,147 @@
+---
+# roles/k3s-server/tasks/main.yml
+# Installs and configures K3s server on a node.
+#
+# Single-node (default): k3s_init_cluster: false — uses SQLite, no join needed.
+# First HA node:         k3s_init_cluster: true  — initializes embedded etcd.
+# Joining a cluster:     set k3s_server_url and k3s_token.
+
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - k3s_version is defined
+      - k3s_version | length > 0
+    fail_msg: >-
+      k3s_version must be defined. Add it to group_vars/all.yml or pass it
+      via -e k3s_version=vX.Y.Z+k3sN on the command line.
+    quiet: true
+
+- name: Create K3s configuration directory
+  ansible.builtin.file:
+    path: "{{ k3s_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Write K3s server configuration
+  ansible.builtin.copy:
+    dest: "{{ k3s_config_file }}"
+    content: |
+      # K3s server configuration — managed by Ansible, do not edit manually.
+      # Re-run bootstrap-k3s.yml to apply changes.
+
+      # Permit reading the kubeconfig without sudo
+      write-kubeconfig-mode: "0644"
+      {% if k3s_init_cluster %}
+
+      # Start cluster with embedded etcd (HA mode)
+      cluster-init: true
+      {% endif %}
+      {% if k3s_server_url | length > 0 %}
+
+      # Join an existing cluster
+      server: "{{ k3s_server_url }}"
+      {% endif %}
+      {% if k3s_token | length > 0 %}
+      token: "{{ k3s_token }}"
+      {% endif %}
+    owner: root
+    group: root
+    mode: "0600"
+  notify: Restart k3s
+
+- name: Download K3s install script
+  ansible.builtin.get_url:
+    url: "{{ k3s_install_script_url }}"
+    dest: /tmp/k3s-install.sh
+    mode: "0700"
+    force: true
+
+- name: Check whether K3s binary is already present
+  ansible.builtin.stat:
+    path: /usr/local/bin/k3s
+  register: k3s_binary
+
+- name: Check installed K3s version (if binary exists)
+  ansible.builtin.command: k3s --version
+  register: k3s_installed_version
+  changed_when: false
+  failed_when: false
+  when: k3s_binary.stat.exists
+
+- name: Install K3s
+  ansible.builtin.command:
+    cmd: /tmp/k3s-install.sh
+  environment:
+    INSTALL_K3S_VERSION: "{{ k3s_version }}"
+    INSTALL_K3S_SKIP_START: "true"
+  when: >
+    not k3s_binary.stat.exists or
+    (k3s_installed_version.stdout is defined and
+     k3s_version not in k3s_installed_version.stdout)
+  changed_when: true
+
+- name: Enable and start K3s service
+  ansible.builtin.systemd:
+    name: k3s
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Wait for K3s API server port to open
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: 6443
+    delay: 10
+    timeout: 120
+    state: started
+
+- name: Wait for node to reach Ready state
+  ansible.builtin.command: k3s kubectl get nodes --no-headers
+  register: k3s_nodes
+  until: k3s_nodes.stdout is search('Ready')
+  retries: 12
+  delay: 10
+  changed_when: false
+
+- name: Read node token (needed to join additional nodes later)
+  ansible.builtin.slurp:
+    src: "{{ k3s_token_file }}"
+  register: k3s_node_token_raw
+
+- name: Display node token
+  ansible.builtin.debug:
+    msg: >-
+      K3s node token (save this to join more nodes later):
+      {{ k3s_node_token_raw.content | b64decode | trim }}
+
+- name: Ensure local kubeconfig directory exists
+  ansible.builtin.file:
+    path: "{{ k3s_kubeconfig_local_dir }}"
+    state: directory
+    mode: "0700"
+  delegate_to: localhost
+  become: false
+
+- name: Fetch kubeconfig from node to control machine
+  ansible.builtin.fetch:
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: "{{ k3s_kubeconfig_local_file }}"
+    flat: true
+
+- name: Fix kubeconfig server address (replace loopback with node IP)
+  ansible.builtin.replace:
+    path: "{{ k3s_kubeconfig_local_file }}"
+    regexp: 'https://127\.0\.0\.1:6443'
+    replace: "https://{{ ansible_host }}:6443"
+  delegate_to: localhost
+  become: false
+
+- name: Show kubeconfig location
+  ansible.builtin.debug:
+    msg: >-
+      Kubeconfig written to {{ k3s_kubeconfig_local_file }}.
+      Use it with: KUBECONFIG={{ k3s_kubeconfig_local_file }} kubectl get nodes
+  delegate_to: localhost
+  become: false

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -31,8 +31,11 @@
       # K3s server configuration — managed by Ansible, do not edit manually.
       # Re-run bootstrap-k3s.yml to apply changes.
 
-      # Permit reading the kubeconfig without sudo
-      write-kubeconfig-mode: "0644"
+      # Restrict kubeconfig to root-only (0600); fetched copy also secured locally
+      write-kubeconfig-mode: "0600"
+
+      # Encrypt Secrets at rest (one-way door — enable before first workloads)
+      secrets-encryption: true
 
       # CNI backend — vxlan is the universal default; use host-gw for L2-only networks.
       flannel-backend: "{{ k3s_flannel_backend }}"
@@ -140,11 +143,27 @@
   delegate_to: localhost
   become: false
 
+- name: Persist node join token locally
+  ansible.builtin.copy:
+    dest: "{{ k3s_kubeconfig_local_dir }}/k3s-{{ inventory_hostname }}-token"
+    content: "{{ k3s_node_token_raw.content | b64decode | trim }}"
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+  no_log: true
+
 - name: Fetch kubeconfig from node to control machine
   ansible.builtin.fetch:
     src: /etc/rancher/k3s/k3s.yaml
     dest: "{{ k3s_kubeconfig_local_file }}"
     flat: true
+
+- name: Secure local kubeconfig permissions
+  ansible.builtin.file:
+    path: "{{ k3s_kubeconfig_local_file }}"
+    mode: "0600"
+  delegate_to: localhost
+  become: false
 
 - name: Fix kubeconfig server address (replace loopback with node IP)
   ansible.builtin.replace:

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -16,6 +16,18 @@
       via -e k3s_version=vX.Y.Z+k3sN on the command line.
     quiet: true
 
+- name: Validate K3s mode flag combinations
+  ansible.builtin.assert:
+    that:
+      - not (k3s_server_url | length > 0 and k3s_token | length == 0)
+      - not (k3s_init_cluster and k3s_server_url | length > 0)
+    fail_msg: >-
+      Invalid K3s mode configuration. Rules:
+      (1) k3s_server_url requires k3s_token — both must be set to join a cluster.
+      (2) k3s_init_cluster: true and k3s_server_url are mutually exclusive;
+          a node cannot initialise and join simultaneously.
+    quiet: true
+
 - name: Create K3s configuration directory
   ansible.builtin.file:
     path: "{{ k3s_config_dir }}"
@@ -75,7 +87,7 @@
     url: "{{ k3s_install_script_url }}"
     dest: /tmp/k3s-install.sh
     mode: "0700"
-    force: true
+    force: false
 
 - name: Check whether K3s binary is already present
   ansible.builtin.stat:
@@ -83,7 +95,7 @@
   register: k3s_binary
 
 - name: Check installed K3s version (if binary exists)
-  ansible.builtin.command: k3s --version
+  ansible.builtin.command: /usr/local/bin/k3s --version
   register: k3s_installed_version
   changed_when: false
   failed_when: false
@@ -119,7 +131,10 @@
 - name: Wait for node to reach Ready state
   ansible.builtin.command: k3s kubectl get nodes --no-headers
   register: k3s_nodes
-  until: k3s_nodes.stdout is search('Ready')
+  until: >-
+    k3s_nodes.stdout | length > 0 and
+    'NotReady' not in k3s_nodes.stdout and
+    'Ready' in k3s_nodes.stdout
   retries: 12
   delay: 10
   changed_when: false
@@ -128,12 +143,14 @@
   ansible.builtin.slurp:
     src: "{{ k3s_token_file }}"
   register: k3s_node_token_raw
+  no_log: true
 
-- name: Display node token
+- name: Display node token (opt-in, set k3s_show_node_token=true to enable)
   ansible.builtin.debug:
     msg: >-
       K3s node token (save this to join more nodes later):
       {{ k3s_node_token_raw.content | b64decode | trim }}
+  when: k3s_show_node_token | default(false) | bool
 
 - name: Ensure local kubeconfig directory exists
   ansible.builtin.file:

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -33,6 +33,22 @@
 
       # Permit reading the kubeconfig without sudo
       write-kubeconfig-mode: "0644"
+
+      # CNI backend — vxlan is the universal default; use host-gw for L2-only networks.
+      flannel-backend: "{{ k3s_flannel_backend }}"
+      {% if k3s_node_ip | length > 0 %}
+
+      # Pin cluster traffic to this IP (important on multi-NIC hosts)
+      node-ip: "{{ k3s_node_ip }}"
+      {% endif %}
+      {% if k3s_tls_san | length > 0 %}
+
+      # Extra TLS SANs (load balancer VIP, DNS alias, etc.)
+      tls-san:
+      {% for san in k3s_tls_san %}
+        - "{{ san }}"
+      {% endfor %}
+      {% endif %}
       {% if k3s_init_cluster %}
 
       # Start cluster with embedded etcd (HA mode)

--- a/k3s/k3s.md
+++ b/k3s/k3s.md
@@ -1,3 +1,7 @@
+> **Current State (2026-05-02)**: This document describes the target architecture, not the current deployment. Today, only a single-node K3s server is running on the testbed (`192.168.1.128`) using SQLite as the datastore. Longhorn, Flux CD, CDK8s, Nginx Ingress, and embedded etcd HA are all future work. See `BOOTSTRAP.md` Part 1 for what is actually deployed, and Part 2 for the HA upgrade path.
+
+---
+
 # Homelab K3s GitOps Cluster
 
 3-node k3s cluster on Dell Optiplex micros with Longhorn distributed storage.


### PR DESCRIPTION
## Summary

- **Implements the `k3s-server` Ansible role** for bootstrapping a single-node K3s cluster (SQLite datastore, vxlan networking, idempotent install/version check, kubeconfig fetch)
- **Hardens the role**: kubeconfig permissions tightened to `0600`, `secrets-encryption: true` added, node join token persisted locally, local kubeconfig copy chmoded
- **Cleans up stale docs**: AGENTS files, BOOTSTRAP.md, k3s.md, and README.md all claimed a 3-node HA cluster with Longhorn/Flux was current state — now accurately describe single-node testbed with a documented upgrade path

## Changed Files

| File | Change |
|------|--------|
| `k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml` | `write-kubeconfig-mode` 0644→0600; add `secrets-encryption: true`; add token persist task; add local kubeconfig chmod task |
| `k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml` | Comment out duplicate `k3s_version`; add source-of-truth pointer to `group_vars/all.yml` |
| `k3s/bootstrap/ansible/inventory/group_vars/all.yml` | Remove etcd UFW ports 2379/2380 (single-node SQLite has no etcd) |
| `k3s/bootstrap/ansible/inventory/hosts.yml` | Fix misleading comment (was: "HA mode with embedded etcd"; now: SQLite single-node) |
| `k3s/BOOTSTRAP.md` | Full rewrite: Part 1 is a fresh single-node guide against real inventory; Part 2 documents the HA upgrade path with destructive-migration warning |
| `k3s/AGENTS.md` | Remove two false statements about k3s-server role not existing; update playbook status; add anti-pattern |
| `k3s/k3s.md` | Prepend Current State callout block (body untouched — target architecture preserved) |
| `README.md` | Fix K3s section: single-node testbed, not "3-node HA with Longhorn and Flux" |
| `AGENTS.md` (root) | Sync K3s lines to reflect role is implemented and bootstrap-k3s.yml is runnable |

## Security Notes

- `write-kubeconfig-mode: "0600"` — `/etc/rancher/k3s/k3s.yaml` is now root-only on the node
- Local kubeconfig copy enforced to `0600` via a separate `ansible.builtin.file` task (fetch does not support `mode`)
- `secrets-encryption: true` — added before any workloads; safe as a one-way door on first run
- Node join token persisted to `~/.kube/k3s-<hostname>-token` with `0600` and `no_log: true`

## HA Upgrade Path

BOOTSTRAP.md Part 2 documents the full path from single-node SQLite to 3-node embedded etcd, including:
- SQLite backup prerequisite
- Destructive-migration warning (SQLite→etcd is a full rebuild)
- Inventory changes for three Dell Optiplex nodes
- `k3s_init_cluster: true` on first HA node
- Node join flow via `k3s_server_url` + `k3s_token`
- Future phases table (Flux, Longhorn, Nginx ingress, CDK8s — all not started)

## Testing

`ansible-playbook --syntax-check` passes on both `bootstrap-k3s.yml` and `site.yml`. No live host execution was performed (testbed hardware not in CI).
