### PR TITLE
Document the Flux/CDK8s GitOps blueprint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,14 @@ This is a homelab infrastructure repository managing both Docker services and a 
 - `/netgear-cm1000-exporter/` - Custom modem metrics exporter
 - `/sense-exporter/` - Home energy monitoring exporter
 
-**K3s Cluster** (Target Architecture):
+**K3s Cluster** (Planned Target Architecture):
 - 3-node HA cluster (192.168.1.40-42) with embedded etcd
-- Longhorn distributed storage with 3-way replication
-- Flux CD v2 for GitOps automation
-- CDK8s for TypeScript-based Kubernetes manifest generation
-- Comprehensive monitoring with Prometheus + Grafana + Loki
+- Flux CD v2 for GitOps automation rooted at `k3s/clusters/homelab/`
+- Nx + CDK8s for TypeScript-based manifest authoring and render orchestration
+- Manual platform and infrastructure manifests under `k3s/platform/` and `k3s/infrastructure/`
+- Rendered workload manifests committed under `k3s/applications/`
+- Monitoring remains centered on Prometheus + Grafana unless the repo later adopts additional tooling
+- Storage decisions kept vendor-neutral until a real CSI choice is needed
 
 ### Network Architecture
 
@@ -68,27 +70,33 @@ This creates the macvlan network for physical IP assignment to containers.
 **Bootstrap Process**:
 ```bash
 # Full cluster bootstrap (from k3s/bootstrap/ansible/)
-ansible-playbook -i inventory/hosts site.yml
+# Phase 1 and Phase 2 are runnable today; Phase 3 still stops at the Flux stub.
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml
 
 # Individual components
-ansible-playbook -i inventory/hosts playbooks/provision-nodes.yml
-ansible-playbook -i inventory/hosts playbooks/bootstrap-k3s.yml
-ansible-playbook -i inventory/hosts playbooks/bootstrap-flux.yml
+ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml
 ```
 
 **GitOps Workflow**:
-1. Commit changes to Git repository
-2. Flux CD automatically syncs changes (1m interval for GitRepository)
-3. Kustomizations handle infrastructure (10m), platform, and applications
+1. Change manual cluster manifests or CDK8s source in Git
+2. Run `nx run cdk8s:synth` to render workload YAML into `k3s/applications/`
+3. Commit both source and rendered output
+4. Flux CD syncs `k3s/clusters/homelab/`
+5. Kustomizations reconcile platform, infrastructure, then applications
 
 **CDK8s Development**:
 ```bash
-cd applications/cdk8s/
-# Generate manifests from TypeScript
-cdk8s synth
-# Commit generated manifests for Flux to deploy
-git add manifests/ && git commit -m "Update manifests"
+# From the repo root
+nx run cdk8s:synth
+nx run cdk8s:validate
+
+# Review rendered manifests before commit
+git diff -- k3s/applications
 ```
+
+Flux should never watch `applications/cdk8s/` directly; it should only reconcile the committed YAML under `k3s/`.
 
 ### Monitoring and Troubleshooting
 
@@ -101,13 +109,14 @@ flux get all -A
 flux reconcile source git flux-system
 ```
 
-**Longhorn Storage**:
-- Monitor volume health through Longhorn UI
-- Failed replicas trigger automatic rebuilds
-- Use CRDs for programmatic backup/restore operations
+**Storage Guidance**:
+- Keep shared manifests and constructs vendor-neutral
+- Only set `storageClassName` when a workload actually needs it
+- If a future CSI is adopted, isolate provider-specific config under `k3s/infrastructure/`
 
 **Common Issues**:
-- Volume degradation: Delete failed replicas to trigger rebuilds
+- Rendered manifest drift: Re-run `nx run cdk8s:synth` and review `git diff -- k3s/applications`
+- Kustomize build failures: Run `kustomize build k3s/clusters/homelab`
 - Node join failures: Check k3s service status and firewall rules
 - Flux sync issues: Check GitRepository and Kustomization status
 
@@ -117,7 +126,7 @@ The repository supports gradual migration from Docker to K3s:
 
 1. **Assessment**: Document existing Docker service configurations
 2. **Preparation**: Create K8s namespaces, PVCs, secrets, and networking
-3. **Data Migration**: Use Jobs to copy data from Docker volumes to Longhorn PVCs
+3. **Data Migration**: Use Jobs or one-off tooling to copy data from Docker volumes into the target PVCs or mounts required by the workload
 4. **Deployment**: Deploy K8s manifests with thorough testing
 5. **Cutover**: Stop Docker services and update routing
 
@@ -131,8 +140,10 @@ The repository supports gradual migration from Docker to K3s:
 
 ## Security Considerations
 
-- SOPS encryption with age keys for secrets management
-- Network policies enforce default deny ingress
-- RBAC limits developer access to read-only operations
-- Let's Encrypt certificates via cert-manager for TLS
-- Regular automated backups with Velero and Longhorn snapshots
+These are target-state controls for the planned GitOps cluster, not capabilities that already exist in the repo today:
+
+- SOPS + age is the planned secrets model once Flux bootstrap is implemented
+- Network policies should default to deny when cluster workloads start landing in K3s
+- RBAC should be introduced with the platform layer rather than assumed to exist already
+- cert-manager is the planned TLS automation layer when ingress moves to K3s
+- Backups should be defined once the cluster storage and recovery approach are real, whether that ends up being Velero or something provider-specific

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,14 @@ ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
 ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml
 ```
 
-**GitOps Workflow**:
+**GitOps Workflow** _(target-state, once Nx workspace and cluster root exist)_:
 1. Change manual cluster manifests or CDK8s source in Git
 2. Run `nx run cdk8s:synth` to render workload YAML into `k3s/applications/`
 3. Commit both source and rendered output
 4. Flux CD syncs `k3s/clusters/homelab/`
 5. Kustomizations reconcile platform, infrastructure, then applications
 
-**CDK8s Development**:
+**CDK8s Development** _(target-state — `nx.json` and `applications/cdk8s/` do not exist yet)_:
 ```bash
 # From the repo root
 nx run cdk8s:synth
@@ -96,11 +96,12 @@ nx run cdk8s:validate
 git diff -- k3s/applications
 ```
 
-Flux should never watch `applications/cdk8s/` directly; it should only reconcile the committed YAML under `k3s/`.
+Flux must never watch `applications/cdk8s/` directly; it should only reconcile the committed YAML under `k3s/clusters/homelab/`.
+Until the Nx workspace and cluster root are created, skip the CDK8s commands above.
 
 ### Monitoring and Troubleshooting
 
-**Flux Operations**:
+**Flux Operations** _(target-state — Flux is not yet bootstrapped; `k3s/clusters/homelab/` does not exist)_:
 ```bash
 # Check all Flux resources
 flux get all -A
@@ -115,10 +116,10 @@ flux reconcile source git flux-system
 - If a future CSI is adopted, isolate provider-specific config under `k3s/infrastructure/`
 
 **Common Issues**:
-- Rendered manifest drift: Re-run `nx run cdk8s:synth` and review `git diff -- k3s/applications`
-- Kustomize build failures: Run `kustomize build k3s/clusters/homelab`
+- Rendered manifest drift _(future, once CDK8s workspace exists)_: Re-run `nx run cdk8s:synth` and review `git diff -- k3s/applications`
+- Kustomize build failures _(future, once cluster root exists)_: Run `kustomize build k3s/clusters/homelab`
 - Node join failures: Check k3s service status and firewall rules
-- Flux sync issues: Check GitRepository and Kustomization status
+- Flux sync issues _(future, once Flux is bootstrapped)_: Check GitRepository and Kustomization status
 
 ## Migration Strategy
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,14 @@ docker-compose -f <service>-compose.yml up -d
 ```
 
 ### K3s Cluster
-Bootstrap the single-node cluster:
+Bootstrap the single-node cluster (run in order):
 ```bash
 cd k3s/bootstrap/ansible/
+
+# Step 1: OS hardening and K3s prerequisites (required first)
+ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml
+
+# Step 2: Install K3s server
 ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,18 @@ This repository manages Docker-based services on a Synology NAS and a single-nod
 
 ```
 homelab/
-├── docker-services/           # Docker Compose services
-│   ├── media/                # Media automation stack (Sonarr, Radarr, etc.)
-│   ├── prometheus/           # Monitoring and metrics collection
-│   ├── grafana/              # Dashboards and visualization
-│   ├── pihole/               # DNS ad-blocking
-│   ├── transmission/         # BitTorrent client
-│   ├── portainer/            # Docker management UI
-│   ├── watchtower/           # Automated container updates
-│   ├── sense-exporter/       # Energy monitoring metrics
-│   └── netgear-cm1000-exporter/ # Modem metrics
-├── k3s/                      # Kubernetes cluster configuration
+├── media/                    # Media automation stack (Sonarr, Radarr, etc.)
+├── prometheus/               # Monitoring and metrics collection
+├── grafana/                  # Dashboards and visualization
+├── pihole/                   # DNS ad-blocking
+├── transmission/             # BitTorrent client
+├── portainer/                # Docker management UI
+├── watchtower/               # Automated container updates
+├── sense-exporter/           # Energy monitoring metrics
+├── netgear-cm1000-exporter/  # Modem metrics
+├── k3s/                      # Kubernetes cluster configuration and docs
 ├── scripts/                  # Infrastructure automation
-└── k3s.md                   # Detailed K3s cluster documentation
+└── README.md
 ```
 
 ## K3s Kubernetes Cluster
@@ -35,15 +34,17 @@ homelab/
 - **Node**: Single testbed machine at 192.168.1.128
 - **Datastore**: SQLite (default for single node)
 - **GitOps**: Not yet implemented (Flux CD stub exists)
-- **Storage**: Local-path provisioner (Longhorn planned)
+- **Storage**: Local-path provisioner only; future CSI choice is intentionally undecided
 - **Networking**: Flannel VXLAN CNI
 - **Ingress**: Traefik (default K3s ingress; Nginx planned)
 
 ### Planned (see `k3s/BOOTSTRAP.md` Part 2 and `k3s/k3s.md`)
 - 3-node HA with embedded etcd
-- Longhorn distributed storage
-- Flux CD v2 GitOps
+- Flux CD v2 GitOps rooted at `k3s/clusters/homelab/`
+- Nx + CDK8s workflow that renders workload manifests into `k3s/applications/`
 - Nginx Ingress + cert-manager
+
+See `k3s/k3s.md` for the concrete repo blueprint and Flux reconciliation graph.
 
 ## Docker Services
 
@@ -65,7 +66,7 @@ Network-wide ad blocking DNS server running on physical network IP.
 
 Complete media management pipeline:
 - **Sonarr**: TV series management and automation
-- **Radarr**: Movie management and automation  
+- **Radarr**: Movie management and automation
 - **Prowlarr**: Indexer management for *arr applications
 - **NZBGet**: Usenet downloader
 - **Transmission**: BitTorrent client
@@ -94,7 +95,7 @@ Initialize Docker networks:
 
 ### Required Environment Variables
 - `IP_ADDR`: Host IP address
-- `HOSTNAME`: Host hostname  
+- `HOSTNAME`: Host hostname
 - Service-specific API keys and credentials
 
 ## Getting Started

--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -1,13 +1,13 @@
 # K3S DIRECTORY
 
 ## OVERVIEW
-**Single-node K3s bootstrap is implemented.** Ansible provisions OS nodes and installs K3s server role. Flux CD and CDK8s remain unimplemented — see Part 2 of `BOOTSTRAP.md` for the HA upgrade path.
+**Single-node K3s bootstrap is implemented.** Ansible provisions OS nodes and installs the K3s server role. Flux CD, the Nx workspace, and the CDK8s authoring layer remain unimplemented — see Part 2 of `BOOTSTRAP.md` for the upgrade path.
 
 ## WHAT EXISTS
 ```
 k3s/
-├── k3s.md          # Architecture docs: CDK8s constructs, Flux structure, networking (186 lines)
-├── BOOTSTRAP.md    # Step-by-step bootstrap guide: Ansible playbooks, inventory, K3s install (805 lines)
+├── k3s.md          # Architecture docs: Flux graph, CDK8s/Nx blueprint, networking
+├── BOOTSTRAP.md    # Step-by-step bootstrap guide: Ansible playbooks, inventory, K3s install
 └── bootstrap/ansible/   # ✅ Initialized — OS provisioning for testbed (192.168.1.128)
     ├── ansible.cfg
     ├── inventory/hosts.yml      # Testbed node; add cluster nodes here
@@ -29,28 +29,33 @@ k3s/
 | Component | Planned Location | Status |
 |-----------|-----------------|--------|
 | Ansible playbooks | `k3s/bootstrap/ansible/` | ✅ Initialized (provision-nodes, bootstrap-k3s runnable) |
-| Flux CD configs | `k3s/clusters/`, `k3s/infrastructure/` | ❌ Not created |
+| Flux cluster root | `k3s/clusters/homelab/` | ❌ Not created |
+| Platform manifests | `k3s/platform/` | ❌ Not created |
+| Infrastructure manifests | `k3s/infrastructure/` | ❌ Not created |
 | CDK8s TypeScript | `applications/cdk8s/src/` | ❌ Not created |
-| Generated manifests | `applications/cdk8s/manifests/` | ❌ Not created |
+| Rendered application manifests | `k3s/applications/` | ❌ Not created |
+| Nx orchestration | `nx.json`, `applications/cdk8s/project.json` | ❌ Not created |
 | SOPS secrets | `*.sops.yaml` files | ❌ Not created |
-| Longhorn storage | K3s manifests | ❌ Not created |
 
 ## TARGET CLUSTER
 - **Nodes**: 3x Dell Optiplex at 192.168.1.40, 192.168.1.41, 192.168.1.42
-- **Storage**: Longhorn on `/dev/nvme0n1`, 3-way replication
-- **GitOps**: Flux CD v2 watching this repo (`master` branch)
+- **Datastore**: embedded etcd after the HA rebuild
+- **GitOps**: Flux CD v2 watching this repo (`master` branch) via `k3s/clusters/homelab/`
+- **Authoring**: Nx + CDK8s render workload manifests into `k3s/applications/`
 - **Ingress**: Nginx + cert-manager (Let's Encrypt)
 - **Secrets**: SOPS + age key encryption
+- **Storage**: keep manifests storage-class-light until a real CSI decision is made
 
 ## ANTI-PATTERNS
 - **Do not create files here expecting them to be deployed** — the K3s cluster may not exist yet.
 - **Do not treat `k3s.md` as current state** — it describes the target, not reality.
-- **Do not describe planned components as implemented** — Flux, Longhorn, CDK8s, and HA are future state only.
+- **Do not describe planned components as implemented** — Flux, Nx/CDK8s, and HA are future state only.
+- **Do not hardcode a speculative storage vendor into new planning docs unless the repo actually adopts one.**
 - **Do not run `ansible-playbook` commands from `BOOTSTRAP.md`** without verifying nodes are provisioned.
 
 ## NOTES
 - `BOOTSTRAP.md` is the authoritative guide for standing up the cluster when ready.
-- `k3s.md` contains CDK8s TypeScript construct API and Flux kustomization patterns.
+- `k3s.md` contains the concrete repo blueprint, Flux kustomization graph, and Nx/CDK8s workflow.
 - Current Docker services on Synology NAS are the live production environment — K3s migration is future work.
 - **Testbed node** (i7-4770k) at 192.168.1.128 is the first node to provision. Re-IP to 192.168.1.4x before joining the cluster.
 - `provision-nodes.yml` is runnable — runs `common` + `k3s-prereqs` roles.

--- a/k3s/BOOTSTRAP.md
+++ b/k3s/BOOTSTRAP.md
@@ -2,7 +2,7 @@
 
 This guide covers bootstrapping a single-node K3s cluster using Ansible, then optionally scaling to a multi-node HA setup.
 
-> **Current state**: Single-node K3s server on the testbed (`192.168.1.128`) with SQLite datastore. HA cluster, Longhorn, and Flux CD are future work — see [Part 2](#part-2-scaling-to-ha-future-state) for the upgrade path.
+> **Current state**: Single-node K3s server on the testbed (`192.168.1.128`) with SQLite datastore. HA cluster, Flux CD, and the CDK8s/Nx workflow are future work — see [Part 2](#part-2-scaling-to-ha-future-state) for the upgrade path.
 
 ---
 
@@ -178,7 +178,7 @@ k3s secrets-encrypt status
 You should see:
 - One `Ready` node (the testbed)
 - System pods running: `local-path-provisioner`, `coredns`, `metrics-server`, `kube-proxy`
-- No Longhorn or Flux pods (those are future work)
+- No Flux pods yet (GitOps is future work)
 
 ### Step 8: Use the Cluster
 
@@ -304,16 +304,16 @@ kubectl get pods -n kube-system -l component=etcd
 
 ### Future Phases
 
-These are not yet implemented and are listed here for planning purposes only:
+These are not yet implemented and are listed here for planning purposes only. Storage-provider decisions are intentionally deferred until workloads actually need them.
 
 | Phase | Component | Status |
 |-------|-----------|--------|
-| Flux CD | GitOps automation | Stub only (`bootstrap-flux.yml`) |
-| Longhorn | Distributed block storage | Not started |
+| Flux CD | GitOps cluster root and reconciliation | Stub only (`bootstrap-flux.yml`) |
 | Nginx Ingress | HTTP load balancer | Not started (Traefik is the default K3s ingress) |
 | Cert Manager | TLS certificate automation | Not started |
 | SOPS + age | Secret encryption in Git | Not started |
-| CDK8s | TypeScript-defined manifests | Not started |
+| Nx + CDK8s | TypeScript authoring and render pipeline | Not started |
+| Application manifests | Rendered output under `k3s/applications/` | Not started |
 | Velero | Backup/restore | Not started |
 
-Refer to `k3s/k3s.md` for the full target architecture.
+Refer to `k3s/k3s.md` for the full target architecture and concrete repo blueprint.

--- a/k3s/bootstrap/ansible/playbooks/site.yml
+++ b/k3s/bootstrap/ansible/playbooks/site.yml
@@ -1,9 +1,9 @@
 ---
 # site.yml
 # Full cluster bootstrap — runs all phases in order.
-# NOTE: Phase 1 (provision-nodes) is runnable. Phase 2 (bootstrap-k3s) and
-#       Phase 3 (bootstrap-flux) are stubs — they will fail with clear messages
-#       until roles/k3s-server/ and Flux configuration are implemented.
+# NOTE: Phase 1 (provision-nodes) and Phase 2 (bootstrap-k3s) are runnable.
+#       Phase 3 (bootstrap-flux) is still a stub and will fail with a clear
+#       message until Flux configuration is implemented.
 #
 # Usage: ansible-playbook -i inventory/hosts.yml playbooks/site.yml -v
 

--- a/k3s/bootstrap/ansible/roles/k3s-prereqs/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-prereqs/tasks/main.yml
@@ -22,7 +22,7 @@
   ansible.builtin.copy:
     dest: /etc/modules-load.d/k3s.conf
     content: |
-      # Kernel modules required by K3s / Kubernetes / Longhorn
+      # Kernel modules required by K3s / Kubernetes
       {% for mod in k3s_kernel_modules %}
       {{ mod }}
       {% endfor %}

--- a/k3s/k3s.md
+++ b/k3s/k3s.md
@@ -11,7 +11,7 @@ This is the concrete repo blueprint for the planned K3s GitOps setup. It turns t
 These are the choices worth being opinionated about up front:
 
 - **Monorepo**: cluster bootstrap, rendered manifests, and CDK8s source stay in this repo.
-- **Flux consumes committed YAML only**: Flux watches `k3s/`; it never watches TypeScript source.
+- **Flux consumes committed YAML only**: Flux watches `k3s/clusters/homelab/` specifically; it never watches the broader `k3s/` tree directly or TypeScript source.
 - **CDK8s is the workload authoring layer**: application manifests are defined in TypeScript and rendered before commit.
 - **Nx is orchestration, not truth**: Nx runs synth and validation locally or in CI, but the committed YAML is the deployment contract.
 - **Single cluster root first**: start with `k3s/clusters/homelab/` and avoid `dev`/`staging` overlays until a second cluster exists.

--- a/k3s/k3s.md
+++ b/k3s/k3s.md
@@ -1,190 +1,204 @@
-> **Current State (2026-05-02)**: This document describes the target architecture, not the current deployment. Today, only a single-node K3s server is running on the testbed (`192.168.1.128`) using SQLite as the datastore. Longhorn, Flux CD, CDK8s, Nginx Ingress, and embedded etcd HA are all future work. See `BOOTSTRAP.md` Part 1 for what is actually deployed, and Part 2 for the HA upgrade path.
+> **Current State (2026-05-02)**: This document describes the target GitOps architecture, not the current deployment. Today only a single-node K3s server is running on the testbed (`192.168.1.128`) using SQLite as the datastore. Flux CD, the Nx workspace, the CDK8s authoring layer, and HA embedded etcd are all future work. See `BOOTSTRAP.md` Part 1 for what is actually deployed, and Part 2 for the upgrade path.
 
 ---
 
-# Homelab K3s GitOps Cluster
+# Homelab K3s GitOps Blueprint
 
-3-node k3s cluster on Dell Optiplex micros with Longhorn distributed storage.
+This is the concrete repo blueprint for the planned K3s GitOps setup. It turns the earlier "Flux + CDK8s + Nx" direction into a specific filesystem layout, reconciliation graph, and bootstrap order.
 
-## Hardware & Infrastructure
-- **Nodes**: 3x Dell Optiplex (i5-8500T/8600T, 32GB RAM, SATA+NVMe storage)
-- **IPs**: 192.168.1.40-42 (expandable to .43-.60)
-- **Storage**: Longhorn on NVMe drives, 3-way replication, ~1.5TB usable
-- **Resources**: ~84GB RAM, 12-15 cores available for workloads
-- **Network**: Flannel CNI, 10.42.0.0/16 pod CIDR, 10.43.0.0/16 service CIDR
+## Decisions Locked In Now
 
-## Architecture & Stack
-- **OS**: Ubuntu LTS, k3s (embedded etcd HA)
-- **GitOps**: Flux CD v2, CDK8s (TypeScript), Ansible automation
-- **Monitoring**: Prometheus + Grafana + Loki
-- **Networking**: Nginx Ingress, cert-manager + Let's Encrypt
+These are the choices worth being opinionated about up front:
 
-## Repository Structure
-```
+- **Monorepo**: cluster bootstrap, rendered manifests, and CDK8s source stay in this repo.
+- **Flux consumes committed YAML only**: Flux watches `k3s/`; it never watches TypeScript source.
+- **CDK8s is the workload authoring layer**: application manifests are defined in TypeScript and rendered before commit.
+- **Nx is orchestration, not truth**: Nx runs synth and validation locally or in CI, but the committed YAML is the deployment contract.
+- **Single cluster root first**: start with `k3s/clusters/homelab/` and avoid `dev`/`staging` overlays until a second cluster exists.
+- **Secrets use SOPS + age**: keep the decryption model simple and Flux-native.
+- **Storage stays intentionally abstract**: keep shared constructs and manifests storage-class-light until a real CSI decision is needed.
+
+## Target Cluster
+
+- **Nodes**: 3x Dell Optiplex at `192.168.1.40`, `192.168.1.41`, `192.168.1.42`
+- **Datastore**: embedded etcd once the cluster moves from single-node SQLite to HA
+- **GitOps root**: `k3s/clusters/homelab/`
+- **Ingress/TLS**: Nginx Ingress + cert-manager
+- **Secrets**: SOPS + age
+- **Storage posture**: do not hardcode a future storage vendor into the blueprint; only set `storageClassName` when a workload truly needs it
+
+## Repository Blueprint
+
+```text
 homelab/
 ├── k3s/
-│   ├── bootstrap/ansible/     # Node provisioning & k3s install
-│   ├── infrastructure/        # Longhorn, ingress, monitoring
-│   ├── platform/             # Flux system & namespaces
-│   ├── applications/         # CDK8s outputs & manifests
-│   └── environments/         # dev/staging/prod overrides
-├── docker/                   # Existing Docker services (migration reference)
-└── scripts/                  # Network setup & utilities
+│   ├── bootstrap/
+│   │   └── ansible/
+│   │       ├── inventory/
+│   │       ├── playbooks/
+│   │       └── roles/
+│   ├── clusters/
+│   │   └── homelab/
+│   │       ├── flux-system/
+│   │       │   ├── gotk-components.yaml
+│   │       │   ├── gotk-sync.yaml
+│   │       │   └── kustomization.yaml
+│   │       ├── kustomization.yaml
+│   │       ├── platform.yaml
+│   │       ├── infra-controllers.yaml
+│   │       ├── infra-configs.yaml
+│   │       └── apps.yaml
+│   ├── platform/
+│   │   ├── namespaces/
+│   │   │   ├── media.yaml
+│   │   │   ├── observability.yaml
+│   │   │   └── kustomization.yaml
+│   │   ├── rbac/
+│   │   │   └── kustomization.yaml
+│   │   └── kustomization.yaml
+│   ├── infrastructure/
+│   │   ├── controllers/
+│   │   │   ├── cert-manager/
+│   │   │   ├── ingress-nginx/
+│   │   │   └── kustomization.yaml
+│   │   ├── configs/
+│   │   │   ├── cluster-issuers/
+│   │   │   └── kustomization.yaml
+│   │   └── kustomization.yaml
+│   └── applications/
+│       ├── media/
+│       ├── observability/
+│       ├── networking/
+│       └── kustomization.yaml
+├── applications/
+│   └── cdk8s/
+│       ├── cdk8s.yaml
+│       ├── package.json
+│       ├── project.json
+│       └── src/
+│           ├── main.ts
+│           ├── charts/
+│           └── constructs/
+├── nx.json
+├── package.json
+└── tsconfig.base.json
 ```
 
-## GitOps Workflow
-**Bootstrap**: Ansible → k3s → Flux CD → Git-managed everything
-**Deploy**: CDK8s TypeScript → manifests → Git commit → Flux sync
-**Migrate**: Gradual Docker-to-k8s migration with rollback capability
+## Source-of-Truth Boundaries
 
-## Quick Start
-```bash
-# Bootstrap cluster: ansible-playbook -i inventory/hosts site.yml
-# Deploy changes: commit to Git, Flux auto-syncs
+Keep the boundaries strict:
+
+- **Manual cluster plumbing lives in `k3s/platform/` and `k3s/infrastructure/`**.
+- **Rendered workload manifests live in `k3s/applications/`**.
+- **CDK8s source lives in `applications/cdk8s/src/`**.
+- **Flux points only at `k3s/clusters/homelab/`**.
+- **Nx points at the CDK8s workspace and writes rendered output into `k3s/applications/`**.
+
+That means:
+
+- Editing `applications/cdk8s/src/` changes the authoring layer.
+- Running synth updates `k3s/applications/`.
+- Flux reconciles only the committed output plus the manually managed platform and infrastructure layers.
+
+## Flux Reconciliation Graph
+
+Use one cluster root and a small, explicit dependency chain:
+
+| Flux object | Path | Depends on | Purpose |
+|-------------|------|------------|---------|
+| `flux-system` | `./k3s/clusters/homelab/flux-system` | none | Flux controllers and source config |
+| `platform` | `./k3s/platform` | `flux-system` | namespaces, RBAC, shared policies |
+| `infra-controllers` | `./k3s/infrastructure/controllers` | `platform` | cert-manager, ingress-nginx, other controllers |
+| `infra-configs` | `./k3s/infrastructure/configs` | `infra-controllers` | ClusterIssuers and controller-specific config |
+| `apps` | `./k3s/applications` | `platform`, `infra-configs` | rendered workload manifests |
+
+### Why this graph
+
+- **`platform` first** so namespaces and shared RBAC exist before anything relies on them.
+- **Controllers before configs** so CRDs and controller APIs exist before related resources are applied.
+- **Applications last** so workloads only land after the cluster plumbing exists.
+
+## CDK8s + Nx Workflow
+
+Nx should stay thin and predictable. A single `cdk8s` project is enough to start.
+
+### Suggested Nx Targets
+
+| Target | Purpose | Notes |
+|--------|---------|-------|
+| `nx run cdk8s:synth` | render manifests | writes output into `k3s/applications/` |
+| `nx run cdk8s:validate` | verify rendered tree | runs after synth; builds the cluster root with `kustomize` |
+| `nx run cdk8s:diff` | review rendered changes | wrapper around `git diff -- k3s/applications` |
+
+### Suggested `project.json` Shape
+
+```json
+{
+  "name": "cdk8s",
+  "targets": {
+    "synth": {
+      "command": "cd applications/cdk8s && cdk8s synth --output ../../k3s/applications"
+    },
+    "validate": {
+      "dependsOn": ["synth"],
+      "command": "kustomize build k3s/clusters/homelab >/dev/null"
+    },
+    "diff": {
+      "dependsOn": ["synth"],
+      "command": "git diff -- k3s/applications"
+    }
+  }
+}
 ```
 
-## Ansible Configuration
+### Rendered Output Rules
 
-### Structure & Key Components
-```
-bootstrap/ansible/
-├── inventory/hosts.yml       # Node definitions (IPs, roles, storage)
-├── playbooks/
-│   ├── provision-nodes.yml   # OS setup & prerequisites  
-│   ├── bootstrap-k3s.yml     # K3s installation
-│   ├── bootstrap-flux.yml    # Flux CD installation
-│   └── site.yml             # Full cluster bootstrap
-├── roles/                   # common, k3s-server, storage-prep
-└── ansible.cfg
-```
+- Commit both **source** and **rendered output** in the same change.
+- Treat `k3s/applications/` as generated code: it is reviewable, committed, and reproducible.
+- Do not hand-edit rendered manifests unless you are fixing generation immediately afterward.
+- If a workload cannot yet be expressed cleanly in CDK8s, keep it as a manual manifest temporarily rather than weakening the Flux boundary.
 
-### Inventory Overview
-- 3 nodes (192.168.1.40-42) as k3s servers with embedded etcd
-- Each node uses `/dev/nvme0n1` for Longhorn storage
-- Configures kernel modules (br_netfilter, overlay, iscsi_tcp)
-- Sets required sysctl parameters for k8s networking
+## Secrets Strategy
 
-## Flux CD Setup
+Use SOPS from the beginning so the shape does not have to change later.
 
-### Structure & Components
-```
-k3s/
-├── clusters/homelab/           # Flux controllers & cluster entrypoint
-├── infrastructure/             # Core services (cert-manager, nginx, longhorn)
-├── platform/                  # Namespaces & RBAC
-└── applications/               # App manifests with dev/prod overlays
-```
+- Commit encrypted secrets as `*.sops.yaml`.
+- Keep the age **private key out of Git**.
+- Bootstrap Flux with the age decryption secret in `flux-system`.
+- Store secrets near the layer that consumes them:
+  - cluster-scoped secrets near `k3s/clusters/homelab/`
+  - controller secrets near `k3s/infrastructure/`
+  - application secrets near the rendered app manifests or their source inputs
 
-### Configuration
-- GitRepository watches `master` branch with 1m interval
-- Kustomizations sync infrastructure (10m), platform, and applications
-- SOPS encryption for secrets with age keys
+## Minimal Bootstrap Sequence
 
-## Longhorn Configuration
-- **Default**: 3 replicas, /var/lib/longhorn path, S3 backups
-- **Storage Classes**: longhorn (default, 3-replica) + longhorn-single-replica  
-- **Nodes**: NVMe disks with 20Gi reserved space
+This is the smallest useful path from today's single-node testbed to the planned GitOps shape:
 
-## CDK8s Configuration
+1. **Bootstrap K3s with Ansible** using the existing `provision-nodes.yml` and `bootstrap-k3s.yml`.
+2. **Create the cluster root** at `k3s/clusters/homelab/`.
+3. **Bootstrap Flux** so it writes `flux-system/` into that cluster root and watches the `master` branch.
+4. **Add the top-level Flux Kustomizations** for `platform`, `infra-controllers`, `infra-configs`, and `apps`.
+5. **Generate an age key**, keep the private key outside Git, and wire Flux decryption before any real secret-bearing workloads land.
+6. **Create the Nx + CDK8s workspace** under `applications/cdk8s/`.
+7. **Render the first app manifests into `k3s/applications/`**, commit them, and let Flux reconcile them.
+8. **Migrate services incrementally** once each workload has a GitOps-managed definition and a tested rollback path.
 
-### TypeScript-based Kubernetes Manifests
-```
-applications/cdk8s/
-├── src/
-│   ├── main.ts                  # App entry point
-│   ├── constructs/              # base-app.ts, stateful-app.ts, media-stack.ts
-│   └── charts/                  # prometheus.ts, grafana.ts, arr-stack.ts
-└── manifests/                   # Generated YAML output
-```
+## Guardrails for Future Changes
 
-### BaseApp Construct Features
-- Generates Deployment, Service, and Ingress resources
-- Configurable replicas, environment variables, and domains
-- Auto-configured TLS with Let's Encrypt and cert-manager
-- Build workflow: `cdk8s synth` → commit manifests → Flux sync
+These are the things to avoid because they are noisy or expensive to unwind later:
 
-## Ingress & Certificate Management
+- **Do not add multi-environment overlays** until there is a second real cluster or environment.
+- **Do not let Flux watch `applications/cdk8s/`** or run synth in-cluster.
+- **Do not make shared constructs depend on a specific storage vendor**.
+- **Do not mix cluster plumbing and application output in the same directory**.
+- **Do not make Nx responsible for deployment state**; it is just the build and validation wrapper.
+- **Do not hand-wave naming**: choose stable names for the cluster root, namespaces, and app folders early and keep them boring.
 
-### Nginx Ingress
-- **Deployment**: DaemonSet with hostNetwork for direct node access
-- **Configuration**: Forward headers enabled, Prometheus metrics
-- **Resources**: 100m CPU request, 512Mi memory limit
+## Migration Notes
 
-### Cert-Manager
-- **Issuers**: Let's Encrypt production & staging ClusterIssuers
-- **Solver**: HTTP01 challenge via nginx ingress
-- **Wildcard**: Optional wildcard certificate for `*.homelab.local`
+When Docker services move into K3s:
 
-## Security Configuration
-
-### RBAC & Network Policies
-- **Developer Role**: Read-only access to pods, services, deployments
-- **Network Policies**: Default deny ingress, allow only ingress controller traffic
-- **Secrets**: SOPS with age encryption for Git-stored secrets
-
-### SOPS Encryption
-```bash
-# Encrypt: sops -e -i cluster-secrets.yaml
-# Edit: sops cluster-secrets.yaml
-```
-
-## Backup & Disaster Recovery
-
-### Velero Setup
-- **Storage**: MinIO S3-compatible backend
-- **Schedule**: Daily backups at 2 AM, 30-day retention
-- **Scope**: All namespaces except kube-system/longhorn-system
-- **Plugins**: AWS & CSI volume snapshot support
-
-### Etcd Backups
-- Automated snapshots on all control plane nodes
-- 7-day retention policy
-- Manual recovery: stop k3s → restore snapshot → rejoin cluster
-
-### Longhorn Recovery
-- Auto-healing replicas with health monitoring
-- Snapshot-based point-in-time recovery
-- S3 backups for disaster scenarios
-
-## Service Migration Guide
-
-### Migration Process
-1. **Assessment**: Document Docker configs, volume requirements, dependencies
-2. **Preparation**: Create k8s namespaces, configure PVCs, secrets, networking
-3. **Data Migration**: Use Jobs to copy data from Docker volumes to Longhorn PVCs
-4. **Deployment**: Deploy k8s manifests, test functionality, validate rollback
-5. **Cutover**: Stop Docker service, final sync, update routing
-
-### Migration Pattern
-- Create PVC with Longhorn storage class
-- Use migration Job to copy data from NFS/local mounts to PVC
-- Deploy StatefulSet/Deployment with proper volume mounts
-- Test thoroughly before final cutover
-
-## Monitoring & Observability
-
-### Prometheus Stack
-- **Prometheus**: 30-day retention, 50Gi Longhorn storage, 2-4Gi memory
-- **Grafana**: 10Gi persistent storage, dashboard auto-provisioning
-- **Scraping**: k3s nodes (kubelet metrics) + ServiceMonitor discovery
-
-### Loki Stack
-- **Storage**: MinIO S3 backend with boltdb-shipper
-- **Promtail**: Deployed as DaemonSet for log collection
-- **Retention**: Configurable via storage policies
-
-## Troubleshooting
-
-### Common Issues & Solutions
-1. **Longhorn Volume Degraded**: Check volume/replica status, delete failed replicas to trigger rebuilds
-2. **Flux Sync Failures**: Use `flux get all -A` and `flux reconcile source git flux-system`
-3. **Node Join Issues**: Verify k3s service status, node token, and firewall rules
-4. **Storage Issues**: Monitor disk usage, clean up detached volumes and failed replicas
-5. **Backup/Restore**: Use Longhorn CRDs to create/list backups programmatically
-
-### Performance Tuning
-```yaml
-# /etc/rancher/k3s/config.yaml - Key optimizations
-kube-proxy-arg: ["proxy-mode=ipvs", "ipvs-strict-arp=true"]
-kubelet-arg: ["max-pods=250", "eviction-hard=memory.available<500Mi,nodefs.available<10%"]
-```
+1. Define the workload in CDK8s when possible.
+2. Render the manifest into `k3s/applications/`.
+3. Keep persistence requirements explicit, but avoid product-specific storage assumptions in shared code.
+4. Migrate one service at a time so Flux can re-apply everything if the cluster is rebuilt during the HA move.


### PR DESCRIPTION
## Summary
- turn the K3s planning docs into a concrete Flux + Nx + CDK8s GitOps blueprint, including repo layout, reconciliation boundaries, bootstrap sequence, and guardrails
- remove Longhorn-biased planning language so future storage decisions stay vendor-neutral and less likely to pollute later agent output
- align README, agent guidance, and Ansible comments with the current single-node reality and the planned Flux bootstrap path

## Testing
- GIT_MASTER=1 git diff --check master...HEAD
- grep -RInE 'Longhorn|longhorn|Loki' --include '*.md' .