### PR TITLE
Fix flux-bootstrap install dir — use ~/.local/bin to avoid sudo

### DIFF
--- a/k3s/bootstrap/ansible/roles/flux-bootstrap/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-bootstrap/defaults/main.yml
@@ -12,7 +12,7 @@ flux_cli_version: "2.3.0"
 flux_cli_checksum: ""
 
 # Directory where the flux binary is installed on the Ansible controller.
-flux_install_dir: "/usr/local/bin"
+flux_install_dir: "{{ lookup('env', 'HOME') }}/.local/bin"
 
 # GitHub repository settings ──────────────────────────────────────────────
 # Leaving these empty here prevents accidentally bootstrapping against the wrong repo when the role is reused.
@@ -41,7 +41,7 @@ sops_secret_namespace: "flux-system"
 age_key_file: "{{ lookup('env', 'HOME') }}/.kube/k3s-homelab-age.agekey"
 
 # Directory where age and age-keygen are installed on the Ansible controller.
-age_install_dir: "/usr/local/bin"
+age_install_dir: "{{ lookup('env', 'HOME') }}/.local/bin"
 
 # Pinned age version — check https://github.com/FiloSottile/age/releases for updates.
 age_version: "1.2.0"

--- a/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
@@ -53,7 +53,7 @@
 # ─── Flux CLI ─────────────────────────────────────────────────────────────────
 
 - name: Check if flux CLI is installed at the expected version
-  ansible.builtin.command: flux version --client
+  ansible.builtin.command: "{{ flux_install_dir }}/flux version --client"
   register: flux_version_check
   changed_when: false
   failed_when: false
@@ -81,11 +81,12 @@
   delegate_to: localhost
   become: false
 
-- name: Ensure install directory exists on controller
+- name: Ensure install directories exist on controller
   ansible.builtin.file:
-    path: "{{ flux_install_dir }}"
+    path: "{{ item }}"
     state: directory
     mode: "0755"
+  loop: "{{ [flux_install_dir, age_install_dir] | unique }}"
   delegate_to: localhost
   become: false
 
@@ -122,7 +123,7 @@
 # ─── Age CLI ──────────────────────────────────────────────────────────────────
 
 - name: Check if age-keygen is installed
-  ansible.builtin.command: age-keygen --version
+  ansible.builtin.command: "{{ age_install_dir }}/age-keygen --version"
   register: age_check
   changed_when: false
   failed_when: false
@@ -204,7 +205,7 @@
   become: false
 
 - name: Generate age key (first run only)
-  ansible.builtin.command: "age-keygen -o {{ age_key_file }}"
+  ansible.builtin.command: "{{ age_install_dir }}/age-keygen -o {{ age_key_file }}"
   when: sops_secret_check.rc != 0
   changed_when: true
   delegate_to: localhost
@@ -259,7 +260,7 @@
 
 - name: Bootstrap Flux CD via GitHub
   ansible.builtin.command: >
-    flux bootstrap github
+    {{ flux_install_dir }}/flux bootstrap github
     --kubeconfig={{ flux_kubeconfig }}
     --owner={{ flux_github_owner }}
     --repository={{ flux_github_repo }}
@@ -276,7 +277,7 @@
 
 - name: Wait for Flux controllers to become healthy
   ansible.builtin.command: >
-    flux --kubeconfig={{ flux_kubeconfig }} check
+    {{ flux_install_dir }}/flux --kubeconfig={{ flux_kubeconfig }} check
   register: flux_ready_check
   retries: 20
   delay: 15

--- a/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
@@ -81,6 +81,14 @@
   delegate_to: localhost
   become: false
 
+- name: Ensure install directory exists on controller
+  ansible.builtin.file:
+    path: "{{ flux_install_dir }}"
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  become: false
+
 - name: Download flux CLI archive
   ansible.builtin.get_url:
     url: "https://github.com/fluxcd/flux2/releases/download/v{{ flux_cli_version }}/flux_{{ flux_cli_version }}_linux_{{ flux_arch }}.tar.gz"
@@ -101,7 +109,7 @@
     mode: "0755"
   when: flux_needs_install | bool
   delegate_to: localhost
-  become: true
+  become: false
 
 - name: Remove flux CLI download archive
   ansible.builtin.file:
@@ -151,7 +159,7 @@
     - age-keygen
   when: age_check.rc != 0
   delegate_to: localhost
-  become: true
+  become: false
 
 - name: Remove age download artifacts
   ansible.builtin.file:


### PR DESCRIPTION
## Problem

When running `bootstrap-flux.yml`, the playbook failed with:

```
sudo: no password was provided
sudo: a password is required
```

This happened because `flux_install_dir` and `age_install_dir` both defaulted to `/usr/local/bin`, which requires root. The `unarchive` and `copy` install tasks used `become: true` to write there, which triggered a sudo prompt on `delegate_to: localhost` — a machine with no passwordless sudo configured.

## Fix

- Change `flux_install_dir` and `age_install_dir` defaults to `{{ lookup('env', 'HOME') }}/.local/bin`
- Remove `become: true` from the flux extract and age copy tasks (no longer needed)
- Add a task that creates `~/.local/bin` before the first download

`~/.local/bin` is the standard location for user-space CLI tools (no sudo, always writable by the running user).