### PR TITLE
Add .sops.yaml with age creation rule for k3s secrets

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,17 +2,17 @@
 # .sops.yaml — SOPS encryption configuration
 #
 # Any file matching the path_regex below will be encrypted using the homelab
-# age key when you run: sops -e <file>
+# age key when you run: sops <file>
 #
 # The corresponding private key lives in:
 #   ~/.kube/k3s-homelab-age.agekey  (Ansible controller)
 #   flux-system/sops-age Secret     (K3s cluster — Flux uses this to decrypt)
 #
-# To create an encrypted secret:
+# To create or edit an encrypted secret (opens $EDITOR, saves encrypted in-place):
 #   sops k3s/infrastructure/configs/my-secret.sops.yaml
 #
-# To decrypt for editing:
-#   sops k3s/infrastructure/configs/my-secret.sops.yaml
+# To encrypt an existing plaintext file in-place:
+#   sops -e -i k3s/infrastructure/configs/my-secret.sops.yaml
 #
 # SOPS will use SOPS_AGE_KEY_FILE or the default age key location.
 # Set it explicitly if needed:

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,23 @@
+---
+# .sops.yaml — SOPS encryption configuration
+#
+# Any file matching the path_regex below will be encrypted using the homelab
+# age key when you run: sops -e <file>
+#
+# The corresponding private key lives in:
+#   ~/.kube/k3s-homelab-age.agekey  (Ansible controller)
+#   flux-system/sops-age Secret     (K3s cluster — Flux uses this to decrypt)
+#
+# To create an encrypted secret:
+#   sops k3s/infrastructure/configs/my-secret.sops.yaml
+#
+# To decrypt for editing:
+#   sops k3s/infrastructure/configs/my-secret.sops.yaml
+#
+# SOPS will use SOPS_AGE_KEY_FILE or the default age key location.
+# Set it explicitly if needed:
+#   export SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey
+
+creation_rules:
+  - path_regex: k3s/.*\.sops\.yaml$
+    age: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085


### PR DESCRIPTION
## What

Adds `.sops.yaml` at the repo root to configure SOPS encryption for homelab secrets.

## Why

Without this file, running `sops -e` on a file doesn't know which key to use and will prompt or error. This wires up the age public key that was generated and loaded into the cluster during the Flux bootstrap playbook (`flux-bootstrap` Ansible role, PR #9/#10).

## Scope

The `path_regex` covers `k3s/.*\.sops\.yaml$` — any file under `k3s/` named `*.sops.yaml`. This is where Flux-managed secrets will live (e.g., `k3s/infrastructure/configs/some-secret.sops.yaml`).

## Key locations

| Location | Purpose |
|----------|---------|
| `~/.kube/k3s-homelab-age.agekey` | Private key on Ansible controller |
| Bitwarden | Private key backup |
| `flux-system/sops-age` Secret in cluster | Flux uses this to decrypt during reconciliation |
| `.sops.yaml` (this PR) | Tells local `sops` CLI which public key to encrypt with |

## Usage

```bash
export SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey

# Create/edit an encrypted secret
sops k3s/infrastructure/configs/my-secret.sops.yaml

# Commit the encrypted file — Flux will decrypt it in-cluster
```