### PR TITLE
feat(infra): add MetalLB for bare-metal LoadBalancer support

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -41,6 +41,12 @@ k3s_sysctl_params:
 # Find the latest: https://github.com/k3s-io/k3s/releases
 k3s_version: "v1.35.4+k3s1"
 
+# K3s built-in components to disable — these are replaced by external controllers.
+# servicelb (klipper-lb) must be disabled when MetalLB is installed to prevent
+# both controllers competing for LoadBalancer services.
+k3s_disable_components:
+  - servicelb
+
 # ─── Flux CD bootstrap settings ─────────────────────────────────────────────
 # Environment-specific values for the flux-bootstrap role.
 # These override the empty role defaults in roles/flux-bootstrap/defaults/main.yml.

--- a/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/defaults/main.yml
@@ -44,3 +44,8 @@ k3s_kubeconfig_local_file: "{{ k3s_kubeconfig_local_dir }}/k3s-{{ inventory_host
 # Set true to print the node join token to Ansible output (disabled by default to avoid leaking
 # the token into logs/scrollback; it is always persisted locally to k3s_kubeconfig_local_dir).
 k3s_show_node_token: false
+
+# K3s built-in components to disable. Use this to replace K3s defaults with
+# external controllers. Example: disable servicelb when using MetalLB.
+# k3s_disable_components: [servicelb, traefik]
+k3s_disable_components: []

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -77,6 +77,14 @@
       {% if k3s_token | length > 0 %}
       token: "{{ k3s_token }}"
       {% endif %}
+      {% if k3s_disable_components | length > 0 %}
+
+      # Disable built-in K3s components replaced by external controllers.
+      disable:
+      {% for component in k3s_disable_components %}
+        - "{{ component }}"
+      {% endfor %}
+      {% endif %}
     owner: root
     group: root
     mode: "0600"

--- a/k3s/infrastructure/configs/metallb/ipaddresspool.yaml
+++ b/k3s/infrastructure/configs/metallb/ipaddresspool.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: homelab-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.1.200-192.168.1.220

--- a/k3s/infrastructure/configs/metallb/kustomization.yaml
+++ b/k3s/infrastructure/configs/metallb/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - metallb
+  - ipaddresspool.yaml
+  - l2advertisement.yaml

--- a/k3s/infrastructure/configs/metallb/l2advertisement.yaml
+++ b/k3s/infrastructure/configs/metallb/l2advertisement.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: homelab
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - homelab-pool

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
-# Add infrastructure controller resources here: cert-manager, nginx-ingress, etc.
+resources:
+  - metallb

--- a/k3s/infrastructure/controllers/metallb/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/metallb/helmrelease.yaml
@@ -3,9 +3,10 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: metallb
-  namespace: metallb-system
+  namespace: flux-system
 spec:
   interval: 30m
+  targetNamespace: metallb-system
   chart:
     spec:
       chart: metallb

--- a/k3s/infrastructure/controllers/metallb/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/metallb/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: metallb
+      version: ">=0.14.0 <1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: metallb
+        namespace: flux-system
+      interval: 12h
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/k3s/infrastructure/controllers/metallb/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/metallb/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metallb
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://metallb.github.io/metallb

--- a/k3s/infrastructure/controllers/metallb/kustomization.yaml
+++ b/k3s/infrastructure/controllers/metallb/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - metallb
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary

- Adds MetalLB via Flux `HelmRelease` in the `infra-controllers` layer
- Configures L2 mode with an `IPAddressPool` (192.168.1.200–192.168.1.220) in the `infra-configs` layer
- Wires both layers into their respective parent `kustomization.yaml` files so Flux reconciles them automatically on merge

## Files Changed

**Controllers layer** (`k3s/infrastructure/controllers/metallb/`)
- `helmrepository.yaml` — points Flux at `https://metallb.github.io/metallb`
- `helmrelease.yaml` — installs MetalLB chart `>=0.14.0 <1.0.0`, creates `metallb-system` namespace
- `kustomization.yaml` — lists the two resources above

**Configs layer** (`k3s/infrastructure/configs/metallb/`)
- `ipaddresspool.yaml` — pool `192.168.1.200–192.168.1.220` (outside DHCP scope, clear of existing static IPs)
- `l2advertisement.yaml` — advertises `homelab-pool` via ARP
- `kustomization.yaml` — lists the two CRs above

**Parent kustomizations updated**
- `k3s/infrastructure/controllers/kustomization.yaml`
- `k3s/infrastructure/configs/kustomization.yaml`

## Notes

- IP pool assumes DHCP scope ends before .200. Adjust `ipaddresspool.yaml` if your router's DHCP range differs.
- `infra-configs` depends on `infra-controllers` in the Flux graph, so MetalLB CRDs will exist before the `IPAddressPool`/`L2Advertisement` CRs are applied.
