### PR TITLE
feat: install headlamp-plugin-flux via initContainer

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -29,5 +29,34 @@ spec:
       loadBalancerIP: 192.168.1.219
     config:
       inCluster: true
+      pluginsDir: /build/plugins
     clusterRoleBinding:
       clusterRoleName: cluster-admin
+    initContainers:
+      - name: headlamp-plugins
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest
+        imagePullPolicy: Always
+        command:
+          - /bin/sh
+          - -c
+          - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/ && chown -R 100:101 /build
+        securityContext:
+          runAsNonRoot: false
+          privileged: false
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+          - mountPath: /build/plugins
+            name: headlamp-plugins
+    persistentVolumeClaim:
+      accessModes:
+        - ReadWriteOnce
+      enabled: true
+      size: 1Gi
+    volumeMounts:
+      - mountPath: /build/plugins
+        name: headlamp-plugins
+    volumes:
+      - name: headlamp-plugins
+        persistentVolumeClaim:
+          claimName: headlamp


### PR DESCRIPTION
## Summary

- Adds the [Flux CD plugin for Headlamp](https://github.com/headlamp-k8s/headlamp-plugin-flux) via an initContainer that copies plugin files from `ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest` into a shared PVC
- Enables a 1Gi PersistentVolumeClaim for plugin storage (mounted at `/build/plugins`)
- Sets `config.pluginsDir: /build/plugins` so Headlamp loads plugins from that path

## Changes

`k3s/applications/headlamp/helmrelease.yaml`:
- `config.pluginsDir: /build/plugins`
- `initContainers`: copies plugin files from the plugin image into the shared volume
- `persistentVolumeClaim`: 1Gi RWO PVC enabled
- `volumeMounts` + `volumes`: wire the PVC into both the initContainer and the main container

No ingress or service type changes — LoadBalancer at 192.168.1.219 is preserved.