### PR TITLE
feat(headlamp): switch to ClusterIP with Traefik ingress and TLS

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -25,8 +25,23 @@ spec:
       interval: 12h
   values:
     service:
-      type: LoadBalancer
-      loadBalancerIP: 192.168.1.219
+      type: ClusterIP
+      port: 80
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-staging
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+      hosts:
+        - host: headlamp.homelab.properties
+          paths:
+            - path: /
+              type: Prefix
+      tls:
+        - secretName: headlamp-tls
+          hosts:
+            - headlamp.homelab.properties
     config:
       inCluster: true
       pluginsDir: /build/plugins


### PR DESCRIPTION
## Summary

- Replace Headlamp's dedicated MetalLB `LoadBalancer` service (static IP `192.168.1.219`) with `ClusterIP`, routing traffic through Traefik instead
- Enable Traefik ingress for `headlamp.homelab.properties` using `ingressClassName: traefik` with `websecure` entrypoint
- Wire cert-manager to provision a TLS certificate via `letsencrypt-staging` ClusterIssuer (DNS-01 via Cloudflare)

## Architecture After This Change

```
LAN client → Pi-hole DNS (headlamp.homelab.properties → Traefik MetalLB IP)
           → Traefik (TLS termination, routes by hostname)
           → Headlamp ClusterIP Service
```

## Notes

- Certificate issuer is `letsencrypt-staging` — intended as a first-pass validation; swap to `letsencrypt-prod` once confirmed working
- Requires a Pi-hole local DNS record pointing `headlamp.homelab.properties` to Traefik's MetalLB `EXTERNAL-IP` (find via `kubectl get svc -n kube-system traefik`)
- No public exposure; Cloudflare DNS-01 is used only for certificate issuance, not for routing traffic