### PR TITLE
feat(k3s): add pihole v6 flux manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,17 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-05-02  
+**Generated:** 2026-05-05  
 **Branch:** master  
 
 ## OVERVIEW
-Homelab infrastructure managing 9 Docker services on a Synology NAS (macvlan networking), with a single-node K3s cluster (Ansible-bootstrapped) and Flux CD v2 GitOps scaffolding committed. Docker stack is operational; K3s server role implemented; Flux bootstrapped with empty stubs for platform/infra/apps; CDK8s/Nx remain future work.
+Homelab infrastructure managing 9 Docker services on a Synology NAS (macvlan networking), with a single-node K3s cluster (Ansible-bootstrapped) and Flux CD v2 GitOps with infrastructure deployed (cert-manager, metallb, headlamp). Docker stack is operational; K3s cluster running with Flux managing controllers and one application (headlamp). CDK8s/Nx workspace initialized but contains only a stub chart.
 
 ## STRUCTURE
 ```
 homelab/
-├── docker/             # All Docker-based services
-│   ├── media/          # Sonarr, Radarr, Prowlarr, NZBGet + exportarr exporters
-│   ├── prometheus/     # Prometheus + Node Exporter + alerting + SNMP config
+├── docker/             # All Docker-based services — see docker/AGENTS.md
+│   ├── media/          # Sonarr, Radarr, Prowlarr, NZBGet + exporters — see media/AGENTS.md
+│   ├── prometheus/     # Prometheus + Node Exporter + alerting — see prometheus/AGENTS.md
 │   ├── grafana/        # Grafana with Prometheus datasource provisioning
 │   ├── pihole/         # Pi-hole + cloudflared (DoH) + exporter
 │   ├── transmission/   # Transmission-OpenVPN + exporter
@@ -20,7 +20,9 @@ homelab/
 │   ├── sense-exporter/ # Sense home energy monitor Prometheus exporter
 │   ├── netgear-cm1000-exporter/  # Netgear CM1000 cable modem exporter
 │   └── scripts/        # network-setup.sh: creates macvlan Docker network
-├── k3s/                # K3s bootstrap (Ansible) + Flux GitOps scaffolding (clusters/homelab/ committed)
+├── k3s/                # K3s bootstrap (Ansible) + Flux GitOps with deployed infrastructure
+├── applications/
+│   └── cdk8s/          # CDK8s TypeScript stub (HelloChart only) — see cdk8s/AGENTS.md
 ├── .sops.yaml          # SOPS age encryption rules for K3s secrets
 └── README.md
 ```
@@ -28,7 +30,7 @@ homelab/
 ## WHERE TO LOOK
 | Task | Location | Notes |
 |------|----------|-------|
-| Add/modify a Docker service | `docker/<service>/<service>-compose.yml` | Except: `docker/sense-exporter/sense-exporter.yml` |
+| Add/modify a Docker service | `docker/<service>/<service>-compose.yml` | Except: `docker/sense-exporter/sense-exporter.yml`; see `docker/AGENTS.md` for full service table |
 | Prometheus scrape targets | `docker/prometheus/etc/prometheus.yml` | Static configs, bridge IPs |
 | Alerting rules | `docker/prometheus/etc/alerts.yml` | Currently only InstanceDown alert |
 | SNMP exporter config | `docker/prometheus/snmp_exporter/snmp.yml` | Auto-generated; job commented out in compose |
@@ -38,6 +40,8 @@ homelab/
 | Flux Kustomizations | `k3s/clusters/homelab/` | Reconciliation graph: platform → infra-controllers → infra-configs → apps |
 | Flux system manifests | `k3s/clusters/homelab/flux-system/` | Flux v2.3.0; GitRepository watches `master` branch |
 | SOPS/age config | `.sops.yaml` | age key encryption; see k3s/AGENTS.md for key fingerprint |
+| Headlamp app | `k3s/applications/headlamp/` | headlamp.homelab.properties; TLS via letsencrypt-prod |
+| K3s infrastructure controllers | `k3s/infrastructure/controllers/` | cert-manager + metallb HelmReleases; see `k3s/infrastructure/AGENTS.md` |
 
 ## NETWORKING
 Two external Docker networks (must exist before services start):
@@ -89,8 +93,9 @@ docker-compose -f prometheus-compose.yml up -d
 ```
 
 ## NOTES
-- **K3s + Flux**: `bootstrap-k3s.yml` installs single-node K3s; Flux bootstrapped at `k3s/clusters/homelab/` (Kustomizations committed, stubs only for platform/infra/apps). `bootstrap-flux.yml` Ansible playbook is still a stub. See `k3s/AGENTS.md`.
+- **K3s + Flux**: `bootstrap-k3s.yml` installs single-node K3s; Flux bootstrapped at `k3s/clusters/homelab/` with cert-manager, metallb (infra controllers), and headlamp (application) deployed. `bootstrap-flux.yml` Ansible playbook is still a stub. See `k3s/AGENTS.md` and `k3s/infrastructure/AGENTS.md`.
 - **Prowlarr healthcheck is commented out** — its health endpoint wasn't stable.
 - **SNMP scrape is commented out** in `prometheus-compose.yml` — the config exists but the job is disabled.
 - **Nginx proxy config** (`docker/prometheus/syno-prom-proxy.conf`) is co-located with Prometheus, not in a separate nginx service.
 - Required env vars per service documented in each `*-compose.yml` — no centralized `.env.example`.
+- **CDK8s/Nx**: Workspace initialized (Yarn 4.14.1, nx.json); `applications/cdk8s/src/main.ts` is a HelloChart stub only. Synth target configured. No real workloads; dist/ → k3s/applications/ promotion not yet designed. See `applications/cdk8s/AGENTS.md`.

--- a/applications/cdk8s/AGENTS.md
+++ b/applications/cdk8s/AGENTS.md
@@ -1,0 +1,58 @@
+# CDK8S DIRECTORY
+
+**Generated:** 2026-05-05
+
+## OVERVIEW
+
+CDK8s TypeScript application for generating Kubernetes manifests. Currently a **stub** — `main.ts` contains only a `HelloChart` that creates the `hello-cdk8s` namespace. The Nx `synth` target is configured and cached. Output in `dist/` is gitignored and not yet wired into `k3s/applications/`.
+
+## STATUS
+
+| Component | Status |
+|-----------|--------|
+| Nx workspace | ✓ Initialized (`nx.json`, `package.json`, Yarn 4.14.1) |
+| CDK8s project | ✓ Scaffolded (`cdk8s.yaml`, `project.json`, `tsconfig.json`) |
+| `synth` Nx target | ✓ Configured + cached |
+| `main.ts` | ✓ HelloChart stub (creates `hello-cdk8s` namespace only) |
+| Real workload manifests | ❌ Not implemented |
+| Wired to `k3s/applications/` | ❌ Not implemented |
+
+## STRUCTURE
+
+```
+cdk8s/
+├── src/
+│   └── main.ts         # HelloChart stub — creates hello-cdk8s namespace only
+├── dist/               # Synthesized YAML output (gitignored)
+│   └── hello.k8s.yaml
+├── cdk8s.yaml          # CDK8s app config
+├── package.json        # CDK8s + constructs dependencies
+├── project.json        # Nx project config (defines synth target)
+└── tsconfig.json       # TypeScript config (inherits tsconfig.base.json)
+```
+
+## INTENDED WORKFLOW (future state)
+
+1. Author workloads as CDK8s constructs in `src/main.ts`
+2. Run `nx run cdk8s:synth` — synthesizes YAML to `dist/`
+3. Copy/promote manifests from `dist/` into `k3s/applications/`
+4. Commit to `master` — Flux picks up `k3s/applications/` and applies to cluster
+
+The promotion step (dist/ → k3s/applications/) is not yet designed. See `.sisyphus/plans/nx-cdk8s-init.md` for planning notes.
+
+## COMMANDS
+
+```bash
+# From repo root:
+yarn nx run cdk8s:synth
+
+# Or from this directory:
+yarn cdk8s synth
+```
+
+## ANTI-PATTERNS
+
+- **Do not add real workloads to `main.ts`** until the CDK8s ↔ `k3s/applications/` promotion workflow is designed and documented.
+- **Do not commit `dist/` output** — it is gitignored (`applications/cdk8s/dist/`). Manifests go to `k3s/applications/` instead.
+- **Do not import CDK8s constructs** before running `cdk8s import` — generated imports go to `applications/cdk8s/imports/` (also gitignored).
+- **Do not describe HelloChart as a deployed workload** — it is a scaffolding stub only.

--- a/docker/AGENTS.md
+++ b/docker/AGENTS.md
@@ -1,0 +1,97 @@
+# DOCKER DIRECTORY
+
+**Generated:** 2026-05-05
+
+## OVERVIEW
+
+All Docker-based homelab services running on a Synology NAS with macvlan + bridge dual networking. 9 service groups; most stateful services have a paired Prometheus exporter. Physical LAN IPs are assigned to services that need to be addressable on the LAN (Prometheus, Pi-hole). All others use bridge-only networking.
+
+## STRUCTURE
+
+```
+docker/
+├── media/                          # media-compose.yml — 4 services + 3 exporters
+├── prometheus/                     # prometheus-compose.yml + etc/ + snmp_exporter/ — see prometheus/AGENTS.md
+├── grafana/                        # grafana-compose.yml
+├── pihole/                         # pihole-compose.yml — Pi-hole + cloudflared + exporter
+├── transmission/                   # transmission-compose.yml — OpenVPN + exporter
+├── portainer/                      # portainer-compose.yml
+├── watchtower/                     # watchtower-compose.yml
+├── sense-exporter/                 # sense-exporter.yml  ← EXCEPTION: not *-compose.yml
+├── netgear-cm1000-exporter/        # cm1000-compose.yml
+└── scripts/                        # network-setup.sh + README.md
+```
+
+## SERVICE INVENTORY
+
+| Service | Compose File | Physical IP | Bridge IP | Port | Exporter Bridge IP | Exporter Port |
+|---------|-------------|-------------|-----------|------|--------------------|---------------|
+| prometheus | prometheus-compose.yml | 192.168.1.3 | 172.20.1.3 | 9090 | — | — |
+| syno_node_exporter | prometheus-compose.yml | — | bridge_mode | 9100 | — | — |
+| pihole | pihole-compose.yml | 192.168.1.2 | 172.20.1.2 | DNS/80 | bridge_mode | 33302 |
+| cloudflared | pihole-compose.yml | — | 172.20.1.1 | 5053,33301 | — | — |
+| grafana | grafana-compose.yml | — | bridge_mode | 3000 | — | — |
+| nzbget | media-compose.yml | — | 172.20.0.15 | 6789 | 172.20.1.15 | 9452 |
+| radarr | media-compose.yml | — | 172.20.0.16 | 7878 | 172.20.1.16 | 9708 |
+| sonarr | media-compose.yml | — | 172.20.0.17 | 8989 | 172.20.1.17 | 9709 |
+| prowlarr | media-compose.yml | — | 172.20.0.18 | 9696 | — | — |
+| transmission | transmission-compose.yml | — | bridge_mode | 9091 | bridge_mode | 19091 |
+| portainer | portainer-compose.yml | — | bridge_mode | 8000,9000 | — | — |
+| watchtower | watchtower-compose.yml | — | bridge_mode | 8080 | — | — |
+| sense-exporter | sense-exporter.yml | — | bridge_mode | 9993 | — | — |
+| cm1000-exporter | cm1000-compose.yml | — | bridge_mode | 9527 | — | — |
+
+## NETWORK MEMBERSHIP
+
+Services on **both** networks (macvlan + bridge):
+- `prometheus`: 192.168.1.3 (physical) + 172.20.1.3 (bridge)
+- `pihole`: 192.168.1.2 (physical) + 172.20.1.2 (bridge)
+- `cloudflared`: bridge static IP 172.20.1.1 only
+
+All other services: bridge network only (`network_mode: homelab_bridge_network` or static bridge IP).
+
+Media stack IP pattern: service at 172.20.0.1X, exporter at 172.20.1.1X.
+
+## NON-OBVIOUS QUIRKS
+
+| Service | Quirk |
+|---------|-------|
+| watchtower | Metrics at `/v1/metrics`, requires `Authorization: Bearer <token>` — different from all others |
+| sense-exporter | Metrics path is `/` not `/metrics` |
+| cm1000-exporter | Metrics path is `/` not `/metrics`; polls modem at 192.168.100.1 |
+| prowlarr | Healthcheck disabled (commented out) — endpoint was unstable |
+| transmission | `cap_add: NET_ADMIN` + NordVPN; uses `links:` to reference openvpn container; LOCAL_NETWORK=192.168.1.0/24 |
+| portainer | Mounts `/var/run/docker.sock` — requires Docker socket access |
+| pihole | DNS chain: Pi-hole → cloudflared (172.20.1.1#5053 DoH to 1.1.1.1); DNS2=no |
+| node exporter | privileged:true; mounts proc/sys; explicitly excludes Synology /volumeX mountpoints |
+
+## CONVENTIONS
+
+- **Compose naming**: `<service>-compose.yml`. Exceptions: `sense-exporter.yml` (no `*-compose.yml` alias exists — use as-is).
+- **LinuxServer.io containers**: `PUID=1027`, `PGID=100`, `TZ=America/New_York` always.
+- **Data paths**: `/volume1/data/<service>` and `/volume1/docker/config/<service>` on Synology.
+- **Secrets**: `${VAR}` in compose referencing a sibling `.env` file (gitignored via `**/*.env`).
+- **External networks**: always `external: name: homelab_bridge_network`.
+
+## ANTI-PATTERNS
+
+- **Do not** rename `sense-exporter.yml` to follow the convention without updating any tooling that references it.
+- **Do not** use `docker-compose.yml` naming — breaks the project convention.
+- **Do not** hardcode secrets in compose files — use `${VAR}` referencing `.env`.
+- **Do not** use host networking or named volumes — bind mounts to `/volume1/` only.
+- **WATHCTOWER_REVIVE_STOPPED** is intentionally misspelled in watchtower-compose.yml — do not fix it.
+
+## COMMANDS
+
+```bash
+# Initialize networks once before first deploy
+./docker/scripts/network-setup.sh
+
+# Start any service
+cd docker/<service>/
+docker-compose -f <service>-compose.yml up -d
+
+# Exception — sense exporter
+cd docker/sense-exporter/
+docker-compose -f sense-exporter.yml up -d
+```

--- a/docker/media/AGENTS.md
+++ b/docker/media/AGENTS.md
@@ -1,0 +1,67 @@
+# MEDIA DIRECTORY
+
+**Generated:** 2026-05-05
+
+## OVERVIEW
+
+Consolidated media automation stack: NZBGet (Usenet), Radarr (movies), Sonarr (TV), Prowlarr (indexers). All 4 services plus 3 exporters (Radarr, Sonarr, NZBGet) live in a single `media-compose.yml`. Prowlarr has no exporter. All containers use static bridge IPs.
+
+## STRUCTURE
+
+```
+media/
+└── media-compose.yml   # 4 services + 3 exporters (7 containers)
+```
+
+No `.env.example` — required env vars are documented by comments inside `media-compose.yml`.
+
+## SERVICE TABLE
+
+| Container | Image | Bridge IP | Port | Exporter IP | Exporter Port |
+|-----------|-------|-----------|------|-------------|---------------|
+| nzbget | linuxserver/nzbget | 172.20.0.15 | 6789 | 172.20.1.15 | 9452 |
+| radarr | linuxserver/radarr | 172.20.0.16 | 7878 | 172.20.1.16 | 9708 |
+| sonarr | linuxserver/sonarr | 172.20.0.17 | 8989 | 172.20.1.17 | 9709 |
+| prowlarr | linuxserver/prowlarr | 172.20.0.18 | 9696 | — | — |
+
+IP pattern: service at `172.20.0.1X`, exporter at `172.20.1.1X`.
+
+## EXPORTER IMAGES
+
+- **Radarr/Sonarr**: `ghcr.io/onedr0p/exportarr` — same image, different entrypoint command (`radarr` or `sonarr`)
+- **NZBGet**: `frebib/nzbget-exporter` — connects to NZBGet via `NZBGET_HOST=http://172.20.0.15:6789`
+- **Prowlarr**: no exporter exists; no stable metrics endpoint available
+
+## REQUIRED ENV VARS (in sibling `.env` file)
+
+| Variable | Used By |
+|----------|---------|
+| `NZBGET_USER` | nzbget healthcheck + nzbget-exporter |
+| `NZBGET_PASS` | nzbget healthcheck + nzbget-exporter |
+| `RADARR_API_KEY` | radarr healthcheck + exportarr |
+| `SONARR_API_KEY` | sonarr healthcheck + exportarr |
+| `PUID=1027`, `PGID=100`, `TZ=America/New_York` | all LinuxServer.io containers |
+
+## DATA PATHS
+
+| Service | Config | Data |
+|---------|--------|------|
+| nzbget | `/volume1/docker/config/nzbget` | `/volume1/data/usenet` → `/data/usenet` |
+| radarr | `/volume1/docker/config/radarr` | `/volume1/data` → `/data` |
+| sonarr | `/volume1/docker/config/sonarr` | `/volume1/data` → `/data` |
+| prowlarr | `/volume1/docker/config/prowlarr` | `/volume1/data` → `/data` |
+
+Radarr/Sonarr/Prowlarr share the `/volume1/data` bind mount so they can access the same media library.
+
+## ANTI-PATTERNS
+
+- **Prowlarr healthcheck is commented out** — its health endpoint was not stable; do not uncomment.
+- **Do not add a Prowlarr exporter** — no stable metrics endpoint exists for Prowlarr.
+- **Do not add media containers to the physical network** — bridge-only for all media services.
+- **Do not change exporter IPs** without also updating `docker/prometheus/etc/prometheus.yml` scrape targets.
+
+## NOTES
+
+- Prowlarr acts as the indexer aggregator for Radarr and Sonarr; it does not have its own download client.
+- All *arr services healthcheck via their own `/api/v3/system/status?apikey=` endpoint.
+- NZBGet uses basic auth for the healthcheck; exportarr uses API key auth.

--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -12,7 +12,7 @@ k3s/
 ├── clusters/homelab/         # ✓ Flux Kustomization manifests committed
 │   ├── flux-system/            # gotk-components, gotk-sync, kustomization.yaml
 │   └── *.yaml                  # 5x Kustomization CRs (platform → infra-controllers → infra-configs → apps)
-├── platform/                 # ✓ kustomization.yaml + namespaces/ (cert-manager, headlamp)
+├── platform/                 # ✓ kustomization.yaml + namespaces/ (cert-manager, headlamp, pihole)
 ├── infrastructure/
 │   ├── controllers/            # ✓ cert-manager + metallb HelmReleases — see infrastructure/AGENTS.md
 │   └── configs/                # ✓ ClusterIssuers + IPAddressPool + SOPS-encrypted Cloudflare token
@@ -26,7 +26,7 @@ k3s/
 |-----------|----------|--------|
 | Ansible playbooks | `k3s/bootstrap/ansible/` | ✓ provision-nodes + bootstrap-k3s runnable |
 | Flux cluster root | `k3s/clusters/homelab/` | ✓ Kustomizations committed (Flux v2.3.0) |
-| Platform manifests | `k3s/platform/` | ✓ Namespace manifests (cert-manager + headlamp) |
+| Platform manifests | `k3s/platform/` | ✓ Namespace manifests (cert-manager, headlamp, pihole) |
 | Infrastructure manifests | `k3s/infrastructure/` | ✓ Implemented — cert-manager + metallb controllers + configs |
 | CDK8s TypeScript | `applications/cdk8s/src/` | ✓ HelloChart stub (creates hello-cdk8s namespace only) |
 | Application manifests | `k3s/applications/` | ✓ Headlamp deployed via Flux (headlamp.homelab.properties) |

--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -1,7 +1,7 @@
 # K3S DIRECTORY
 
 ## OVERVIEW
-**K3s bootstrap is implemented; Flux CD v2 GitOps is scaffolded.** Ansible provisions OS and installs K3s single-node. Flux is bootstrapped with Kustomizations committed — all layer stubs (platform/infra/apps) are empty. CDK8s/Nx authoring layer remains unimplemented.
+**K3s bootstrap is implemented; Flux CD v2 GitOps is scaffolded with real infrastructure manifests deployed.** Ansible provisions OS and installs K3s single-node. Flux is bootstrapped with Kustomizations committed — infrastructure controllers (cert-manager, metallb) and headlamp application are deployed. CDK8s/Nx workspace is initialized but contains only a stub chart; manifest promotion workflow is not yet designed.
 
 ## WHAT EXISTS
 ```
@@ -12,25 +12,25 @@ k3s/
 ├── clusters/homelab/         # ✓ Flux Kustomization manifests committed
 │   ├── flux-system/            # gotk-components, gotk-sync, kustomization.yaml
 │   └── *.yaml                  # 5x Kustomization CRs (platform → infra-controllers → infra-configs → apps)
-├── platform/                 # ✓ kustomization.yaml (stub: resources: [])
+├── platform/                 # ✓ kustomization.yaml + namespaces/ (cert-manager, headlamp)
 ├── infrastructure/
-│   ├── controllers/            # ✓ kustomization.yaml (stub)
-│   └── configs/                # ✓ kustomization.yaml (stub)
-└── applications/             # ✓ kustomization.yaml (stub; CDK8s output destination)
+│   ├── controllers/            # ✓ cert-manager + metallb HelmReleases — see infrastructure/AGENTS.md
+│   └── configs/                # ✓ ClusterIssuers + IPAddressPool + SOPS-encrypted Cloudflare token
+└── applications/             # ✓ headlamp HelmRelease deployed (headlamp.homelab.properties)
 ```
 
-> Last verified: 2026-05-02
+> Last verified: 2026-05-05
 
 ## LAYER STATUS
 | Component | Location | Status |
 |-----------|----------|--------|
 | Ansible playbooks | `k3s/bootstrap/ansible/` | ✓ provision-nodes + bootstrap-k3s runnable |
 | Flux cluster root | `k3s/clusters/homelab/` | ✓ Kustomizations committed (Flux v2.3.0) |
-| Platform manifests | `k3s/platform/` | ✓ Stub (resources: []) |
-| Infrastructure manifests | `k3s/infrastructure/` | ✓ Stubs (controllers + configs) |
-| CDK8s TypeScript | `applications/cdk8s/src/` | ❌ Not created |
-| Application manifests | `k3s/applications/` | ✓ Stub (CDK8s output destination) |
-| Nx orchestration | `nx.json`, `project.json` | ❌ Not created |
+| Platform manifests | `k3s/platform/` | ✓ Namespace manifests (cert-manager + headlamp) |
+| Infrastructure manifests | `k3s/infrastructure/` | ✓ Implemented — cert-manager + metallb controllers + configs |
+| CDK8s TypeScript | `applications/cdk8s/src/` | ✓ HelloChart stub (creates hello-cdk8s namespace only) |
+| Application manifests | `k3s/applications/` | ✓ Headlamp deployed via Flux (headlamp.homelab.properties) |
+| Nx orchestration | `nx.json`, `project.json` | ✓ Workspace initialized; synth target configured (Yarn 4.14.1) |
 | SOPS secrets | `.sops.yaml` | ✓ Created (age key encryption) |
 
 ## TARGET CLUSTER
@@ -38,14 +38,14 @@ k3s/
 - **Datastore**: embedded etcd after the HA rebuild
 - **GitOps**: Flux CD v2 watching this repo (`master` branch) via `k3s/clusters/homelab/`
 - **Authoring**: Nx + CDK8s render workload manifests into `k3s/applications/`
-- **Ingress**: Nginx + cert-manager (Let's Encrypt)
+- **Ingress**: Traefik + cert-manager (Let's Encrypt)
 - **Secrets**: SOPS + age key encryption
 - **Storage**: keep manifests storage-class-light until a real CSI decision is made
 
 ## ANTI-PATTERNS
 - **Do not create files here expecting them to be deployed** — the K3s cluster may not exist yet.
 - **Do not treat `k3s.md` as current state** — it describes the target, not reality.
-- **Do not describe planned components as implemented** — CDK8s, Nx, and HA are future state only. Flux manifests are committed but stubs only.
+- **Do not describe CDK8s as unimplemented** — HelloChart stub exists at `applications/cdk8s/src/main.ts`. Nx workspace is initialized. What's missing is real workloads and the dist/ → k3s/applications/ promotion workflow.
 - **Do not hardcode a speculative storage vendor into new planning docs unless the repo actually adopts one.**
 - **Do not run `ansible-playbook` commands from `BOOTSTRAP.md`** without verifying nodes are provisioned.
 

--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - headlamp/
+  - pihole/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -42,8 +42,8 @@ spec:
       externalTrafficPolicy: Local
       loadBalancerIP: "192.168.1.201"
       annotations:
-        metallb.universe.tf/allow-shared-ip: pihole-svc
-        metallb.universe.tf/loadBalancerIPs: "192.168.1.201"
+        metallb.io/allow-shared-ip: pihole-svc
+        metallb.io/loadBalancerIPs: "192.168.1.201"
 
     # -- DHCP: disabled (K3s cluster, no DHCP needed)
     serviceDhcp:

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole
+  namespace: pihole
+spec:
+  interval: 1h
+  timeout: 5m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: pihole
+      version: "2.35.*"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600-pihole
+        namespace: flux-system
+      interval: 12h
+  values:
+    # Pi-hole v6 (appVersion: 2025.11.1) — chart version 2.35.0
+    replicaCount: 1
+
+    # -- Native DoT upstreams (Pi-hole v6 FTL supports host#port format)
+    DNS1: "1.1.1.1#853"
+    DNS2: "1.0.0.1#853"
+
+    # -- Web UI virtual host (must match ingress host to avoid redirects)
+    virtualHost: "pihole.homelab.properties"
+
+    # -- DNS service: LoadBalancer at 192.168.1.201 via MetalLB, TCP+UDP combined
+    serviceDns:
+      mixedService: true
+      type: LoadBalancer
+      port: 53
+      externalTrafficPolicy: Local
+      loadBalancerIP: "192.168.1.201"
+      annotations:
+        metallb.universe.tf/allow-shared-ip: pihole-svc
+        metallb.universe.tf/loadBalancerIPs: "192.168.1.201"
+
+    # -- DHCP: disabled (K3s cluster, no DHCP needed)
+    serviceDhcp:
+      enabled: false
+
+    # -- Web service: ClusterIP only (accessed via Ingress)
+    serviceWeb:
+      type: ClusterIP
+      http:
+        enabled: true
+        port: 80
+      https:
+        enabled: false
+
+    # -- Ingress: Traefik + letsencrypt-prod TLS
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+      path: /
+      pathType: Prefix
+      hosts:
+        - pihole.homelab.properties
+      tls:
+        - secretName: pihole-tls
+          hosts:
+            - pihole.homelab.properties
+
+    # -- Admin password from SOPS-decrypted secret
+    admin:
+      existingSecret: "pihole-admin-password"
+      passwordKey: "password"
+
+    # -- PVC persistence: local-path, 1Gi, for /etc/pihole
+    persistentVolumeClaim:
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+      size: "1Gi"
+      storageClass: "local-path"
+
+    # -- Probes: generous initial delay for slow Pi-hole startup
+    probes:
+      liveness:
+        enabled: true
+        initialDelaySeconds: 120
+        failureThreshold: 10
+        timeoutSeconds: 5
+      readiness:
+        enabled: true
+        initialDelaySeconds: 120
+        failureThreshold: 10
+        timeoutSeconds: 5
+
+    # -- DoH sidecar: disabled (using native DoT via DNS1/DNS2 instead)
+    doh:
+      enabled: false
+
+    # -- Monitoring: Pi-hole v6 exposes Prometheus metrics at /metrics
+    # TODO: Add ServiceMonitor once kube-prometheus-stack is deployed to this cluster
+    monitoring:
+      podMonitor:
+        enabled: false
+      sidecar:
+        enabled: false
+
+    # -- Pod DNS config: ensure pihole pod uses external DNS, not itself
+    podDnsConfig:
+      enabled: true
+      policy: "None"
+      nameservers:
+        - 127.0.0.1
+        - 8.8.8.8
+
+    # -- Required for Pi-hole to listen on all interfaces in K3s CNI
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: "all"

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -117,7 +117,6 @@ spec:
       enabled: true
       policy: "None"
       nameservers:
-        - 127.0.0.1
         - 8.8.8.8
 
     # -- Required for Pi-hole to listen on all interfaces in K3s CNI

--- a/k3s/applications/pihole/helmrepository.yaml
+++ b/k3s/applications/pihole/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mojo2600-pihole
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://mojo2600.github.io/pihole-kubernetes/

--- a/k3s/applications/pihole/kustomization.yaml
+++ b/k3s/applications/pihole/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - pihole-admin-password.sops.yaml

--- a/k3s/applications/pihole/pihole-admin-password.sops.yaml
+++ b/k3s/applications/pihole/pihole-admin-password.sops.yaml
@@ -1,0 +1,41 @@
+#ENC[AES256_GCM,data:XrBw25jloF+FifODSw2q88ncVv3wZ6RfPkxOOGsEWIyagLj7Uj5TtzbTBCXD8BSTT1te2LTaNRkbGZjOFXWiA5gZIMEkqpp5dS/Rkb3e,iv:dF0hNdZ+cnpi4SBBb8puZTKLVnjPbKtPWgeIO8vAA6U=,tag:3yCkV0b4rlYLEgQduTl1Bg==,type:comment]
+#ENC[AES256_GCM,data:QfblzB/CQKg3JgB3wJW4RyMcVvabdMM/6676akGsN7S3gdjPZOsDzJVAKvKpQ3GPcQMp3zTDyy6WhSWXd9uRB+o=,iv:c/Gohowdd6MkVopjMdcTbfmsI1/WpdAfcMk52eESBSA=,tag:+1/eTkwpItQy3p5a6TGgww==,type:comment]
+#ENC[AES256_GCM,data:EIFoqqa8z2JQasy3Ws+Lq7+Py+NFahAUkBv9l4eqZGH1gJNk9j2BtGvp8Xh3LtkqukyLe4drgTFWfFQ+60Y5sXh1LlgCFg6OMuSd2wEN,iv:VtYb3euXaeHF2QTKS9tTUf9nScCv4dmO9teH+WUq3ZU=,tag:hSNbX322s87gzcznIqkyhw==,type:comment]
+#ENC[AES256_GCM,data:n0Kz6h4z48xHUjMZaS/8Jb6pmRDWilXrnAFiJ+Ml7oA/fyUJs+jXyjFEASxp1LBk,iv:/d0dxlydu2C689E/sq1HfI4rwwwaeEbclOiBNPNSAy4=,tag:PVqBoq2bR5IF+CPSPzqrgw==,type:comment]
+#
+#ENC[AES256_GCM,data:KvYnFlJ2C5nPGfgimu1AH78HG58r+RZMAIYYK7qCnow0vy/rUR6gs5wJ2k7ufMA0fexX4nWRefKqVIvf2NXMDRq7LNSXQF4gxPE=,iv:OJAHozZr3X49rH2zCRFbsPX6Pao1af6qoMR3Ryie08M=,tag:4cc27dkLd9errQElFyXB7Q==,type:comment]
+#ENC[AES256_GCM,data:KN+Y02xnT+Giwplo50SaNUCWi2p6faYZnVAOF7udncDWRtggZW6MXTpfXb9Vxb9jO8/3yXyHra968mBqoGhRrb3Id8RVGVzJ,iv:yDNN9Vpr36mj+dPpegbaTMJ3KLNB8kWKxZsWlQct9c8=,tag:lxotuHflvHFHmV/M87LpBQ==,type:comment]
+#
+#ENC[AES256_GCM,data:6LvhG5ljtZ0d1pAnw7ucp/fQUg6NbZN9,iv:SflZOoMIevhRJys77WTqN9nXVvQfbjprv+3I+q8hTBE=,tag:4LWBs1dm9GuHYvK7Ap4xvw==,type:comment]
+#ENC[AES256_GCM,data:uSMLGKu8K6d7+FiV0cWMrD+3AQySxhM+db6HEZEEmqkXnWjzhMBJ6w0+IcLxWCfXorOctdDQQztKQcnn9kOH87U15QzzzKsdzGBxaMvOe9LSGTjOSH7k,iv:HKgMcEUVu/0eQqVcyU6vpjWGVveEdNKIJyNH4uMCSsY=,tag:DZOFzk1nnTCNjdvWUSl1BQ==,type:comment]
+#
+#ENC[AES256_GCM,data:Cq30+fV7jppJ3XiRv1F0E8vuPChOeGZPst2vIAfgK12bbqC94T7nURkOjAvWxWcXfFEIAFMYxTS8bACxkHdjRb3ZrqNRUIFAFQ==,iv:3P+RZbeTSc78LpynZxEYKv/+B+ZuoKROSIMAlfE+fd4=,tag:NXSoxfqe6Fk88l4ChWpXqg==,type:comment]
+#ENC[AES256_GCM,data:wZ1krKBGGLX1Aj8zpfJeAA6P6g4cdPsFm8JRajjlR6V45woFtnZGg6cE3PaMPNjzhBH0dkw5GUoSQQ==,iv:XmkZPQwRwKHTxN35hbJWoY8IXXUgeesbN4BaNZG4G2k=,tag:PoHMaxbx1dmac/81QI9k8w==,type:comment]
+#
+#ENC[AES256_GCM,data:jShHyMEoMqrnfdWAC8VYQ2J08apOPQeOgUWrocpEHHQfwBc6c6TfTg4=,iv:z8dZ3zqKlTCHdOxTMdFSOhVnY/OZLblsflTwNok1XPk=,tag:JSe6EwGYq4mXnTfqrD+T4w==,type:comment]
+#
+#ENC[AES256_GCM,data:N/SCQQvnWBBcCb2ITQdRxFwzppNqd3SyvO8/iWosDYC8jNpVknonJnm411tSX/qDUGPtAnX5jiKEmpq4AdPy5Acyn4qSbvZ3xnJiElHtvMArxcmzvt/fzwjGOmIj,iv:+Wo30A0iYst5BDHuIKAfrpG/uKBcORHNgctc1h6+aWw=,tag:RwzrIfjh+C0dQkLWH+NpNQ==,type:comment]
+#ENC[AES256_GCM,data:9MOPB0Y5xhmqfKvxgzcXIMxa55XP6PLIdUnAxZtJwMz15f8HdEjDNATdePUK,iv:h27sj90IFccv+/C7kdlDd6i1gyxxufGD5jeRBPKVHe4=,tag:+ExluljrkR6sXu4BqgsGvQ==,type:comment]
+#ENC[AES256_GCM,data:G1Pq7o8k0elCA7+TCyp3m7NQ8x8pbKB7GboBapoQaLMk9bD85UCKKTE29MPyPr0p7MUelFLX6w7v9JLEVVNKIc5PlhlvuY8dkSNHCQB4,iv:3N36lY6ligayBuIux4CeMOYDZ5u7ObdA246JPwKem40=,tag:+iHpXNFNVQ2yMYEIACLlcQ==,type:comment]
+apiVersion: ENC[AES256_GCM,data:EHQ=,iv:szvyFa6gi6d7f1DisEI4BLOkLtIzLpHQBrkxhA21X5U=,tag:zdqks7urfoqecptqalYD2g==,type:str]
+kind: ENC[AES256_GCM,data:JxEMbf5f,iv:f55J9rVbcfTRW5iaDLKva85izV75cNrfPhgyMf/U83I=,tag:UlakXrpqfT6wrMTKjMuzjA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:d9qV+8XdExESTN60UC7J0HKTBV/g,iv:51Oc0PNNWp7Alu5bincwjUZ/w3jBaF57tYplWeVjxic=,tag:V66YDlHFFTxJdQGAnjZGMg==,type:str]
+    namespace: ENC[AES256_GCM,data:WOJMrWpU,iv:3X3by4WCLE5owzRjfWofLvHxSIPlowVPRgzB5j0GbJA=,tag:wP7BVdOkWF4meHLfBWnYtw==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:4+KULxUG9Hj1sF8nSw==,iv:B50j6Z/2qatCrgXeB/9/fArPvdGCDnJf4fsWLh3LGLs=,tag:p2dWrrF62fbaXpoKq6xlgg==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXa0JvSEFzanJjcDFLcEtI
+            dHhIakxwYVdZdktYRHlXNkhOSzB3OTJCZ1RvCmc3cGd6WmRiY3dhcThuT1FBdkRJ
+            dG9JOWlUK0F4OWpXb2NKTStNaG9UQjgKLS0tIE54dFQyK0NjVXo2UW5iVnJjZzlH
+            TzZ5M3BNNG5mb2w5cHhKNVdlRHJ4bEkKk6Zno0P0bLVRtz0SFjcdBmEtMZU0/QS3
+            4ZYx0pz4zeO4Nl9+IWT/ipWsHONB/E1v/55yYeuZ5fv1yNRk5vYG9Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-06T12:04:18Z"
+    mac: ENC[AES256_GCM,data:TeQWM8n4pqt1ziy157cg0wdvKbo/xmalQ8nMf5GAaSc8NenS0eM1MHGpmWwntR6WrQc5Dwd0VCNATIKNp+hwCR+8ASNJa2FEsjtn033WLOO7zOKQS/MZCQSmTkWQSdRWfB91o5aDiNbWHeI9zaXzJC9MXzuobR2ZKKakothFkaI=,iv:3CXiqeWNQCcdbV0AHqWzmgkHPeAjFlrtRuY4XrmHerg=,tag:9sGRR6NiUZuu6cLSZ0nlkg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/pihole/pihole-admin-password.sops.yaml
+++ b/k3s/applications/pihole/pihole-admin-password.sops.yaml
@@ -1,0 +1,27 @@
+# =============================================================================
+# OPERATOR ACTION REQUIRED — DO NOT COMMIT THIS FILE UNENCRYPTED
+# =============================================================================
+# Steps to prepare this secret before committing:
+#
+#   1. Replace CHANGE_ME_BEFORE_ENCRYPTING with your desired admin password
+#      (plaintext is fine — Pi-hole v6 hashes it internally on startup)
+#
+#   2. Encrypt this file:
+#      sops --encrypt --in-place k3s/applications/pihole/pihole-admin-password.sops.yaml
+#
+#   3. Verify the file now contains a `sops:` metadata block at the bottom
+#      and the password value is ciphertext (not plaintext)
+#
+#   4. ONLY THEN commit and push this file
+#
+# The SOPS age key fingerprint: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+# SOPS path_regex matches: k3s/.*\.sops\.yaml$
+# =============================================================================
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole-admin-password
+  namespace: pihole
+stringData:
+  password: CHANGE_ME_BEFORE_ENCRYPTING

--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -28,7 +28,7 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 
 ### cert-manager
 - **Chart**: `jetstack/cert-manager` `>=1.14.0 <2.0.0` | namespace: `cert-manager`
-- **CRDs**: `installCRDs: true`, policy: `CreateReplace` on install and upgrade
+- **CRDs**: `crds.enabled: true`, policy: `CreateReplace` on install and upgrade
 - **Issuers**: `letsencrypt-prod` and `letsencrypt-staging` ClusterIssuers (Cloudflare DNS-01 challenge)
 - **Secret**: `cloudflare-token.sops.yaml` — SOPS age-encrypted Cloudflare API token; Flux decrypts via `flux-system/sops-age` Secret in cluster
 

--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -1,0 +1,64 @@
+# INFRASTRUCTURE DIRECTORY
+
+**Generated:** 2026-05-05
+
+## OVERVIEW
+
+Flux-managed infrastructure layer split into two reconciliation stages:
+- **controllers/**: HelmRelease + HelmRepository manifests that install cluster controllers and their CRDs.
+- **configs/**: Supporting resources (ClusterIssuers, IPAddressPools, SOPS-encrypted secrets) that depend on those CRDs existing first.
+
+## STRUCTURE
+
+```
+infrastructure/
+├── controllers/
+│   ├── cert-manager/   # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
+│   └── metallb/        # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
+└── configs/
+    ├── cert-manager/   # cloudflare-token.sops.yaml, clusterissuer-{prod,staging}.yaml, kustomization.yaml
+    └── metallb/        # ipaddresspool.yaml, l2advertisement.yaml, kustomization.yaml
+```
+
+## RECONCILIATION ORDER
+
+Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This guarantees HelmReleases (and their CRDs) install before ClusterIssuers or IPAddressPools are applied. Do not bypass this ordering.
+
+## WHAT'S DEPLOYED
+
+### cert-manager
+- **Chart**: `jetstack/cert-manager` `>=1.14.0 <2.0.0` | namespace: `cert-manager`
+- **CRDs**: `installCRDs: true`, policy: `CreateReplace` on install and upgrade
+- **Issuers**: `letsencrypt-prod` and `letsencrypt-staging` ClusterIssuers (Cloudflare DNS-01 challenge)
+- **Secret**: `cloudflare-token.sops.yaml` — SOPS age-encrypted Cloudflare API token; Flux decrypts via `flux-system/sops-age` Secret in cluster
+
+### metallb
+- **Chart**: `metallb` from metallb Helm repository | namespace: `metallb-system`
+- **IPAddressPool**: defined in `configs/metallb/ipaddresspool.yaml`
+- **L2Advertisement**: defined in `configs/metallb/l2advertisement.yaml`
+
+### Headlamp (reference — lives in `k3s/applications/headlamp/`)
+- Uses `cert-manager.io/cluster-issuer: letsencrypt-prod` in Traefik ingress
+- URL: `headlamp.homelab.properties`
+
+## WHERE TO LOOK
+
+| Task | File |
+|------|------|
+| Add a new controller chart | `controllers/<name>/helmrelease.yaml` + `helmrepository.yaml` + `kustomization.yaml` |
+| Add a ClusterIssuer | `configs/cert-manager/` |
+| Change IP address pool | `configs/metallb/ipaddresspool.yaml` |
+| Edit Cloudflare token secret | `configs/cert-manager/cloudflare-token.sops.yaml` via `sops` CLI |
+
+## ANTI-PATTERNS
+
+- **Do not hand-edit `cloudflare-token.sops.yaml`** — SOPS-encrypted; edit only with `sops cloudflare-token.sops.yaml` using the age key at `~/.kube/k3s-homelab-age.agekey`.
+- **Do not add configs/ resources that need CRDs from controllers/** without ensuring `infra-configs` dependsOn remains correct.
+- **Do not duplicate ClusterIssuers** — `letsencrypt-prod` and `letsencrypt-staging` already exist; reference by name in ingress annotations.
+- **Do not add a new controller without a matching entry** in the `infra-controllers` Kustomization's `resources:` list at `k3s/clusters/homelab/infra-controllers.yaml`.
+
+## NOTES
+
+- `cloudflare-token.sops.yaml.example` is an unencrypted reference template — safe to read/edit.
+- The age key fingerprint is in `.sops.yaml` at the repo root. The private key is **not** in git; it lives at `~/.kube/k3s-homelab-age.agekey` on the Ansible controller and as `flux-system/sops-age` Secret in the cluster.
+- cert-manager's `HelmRelease` uses `helm.toolkit.fluxcd.io/v2` API (Flux v2.3.0 compatible).

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - headlamp.yaml
   - cert-manager.yaml
+  - pihole.yaml

--- a/k3s/platform/namespaces/pihole.yaml
+++ b/k3s/platform/namespaces/pihole.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pihole


### PR DESCRIPTION
## Summary\n\n- Deploys Pi-hole v6 (chart: mojo2600/pihole v2.35.*, appVersion: 2025.11.1) via Flux HelmRelease on K3s\n- DNS LoadBalancer at `192.168.1.201` (MetalLB pool), DoT upstream to `1.1.1.1:853` / `1.0.0.1:853`\n- Web UI at `pihole.homelab.properties` via Traefik + cert-manager letsencrypt-prod\n- Runs **in parallel** with existing Docker Pi-hole at `192.168.1.2` — no cutover until operator confirms DNS is working\n\n## Files Changed\n\n| File | Purpose |\n|------|---------|\n| `k3s/platform/namespaces/pihole.yaml` | Namespace |\n| `k3s/applications/pihole/helmrepository.yaml` | HelmRepository (mojo2600) |\n| `k3s/applications/pihole/pihole-admin-password.sops.yaml` | SOPS admin secret template (**operator must encrypt**) |\n| `k3s/applications/pihole/helmrelease.yaml` | HelmRelease (Pi-hole v6) |\n| `k3s/applications/pihole/kustomization.yaml` | Local kustomization |\n| `k3s/applications/kustomization.yaml` | Adds `- pihole/` |\n| `k3s/platform/namespaces/kustomization.yaml` | Adds `- pihole.yaml` |\n\n## Operator Steps Before Merging\n\n1. **Encrypt the SOPS secret**:\n   \n2. After merge, verify:  → READY=True\n3. Test DNS: ;; communications error to 192.168.1.201#53: timed out
;; communications error to 192.168.1.201#53: timed out
;; communications error to 192.168.1.201#53: timed out

; <<>> DiG 9.18.39-0ubuntu0.24.04.3-Ubuntu <<>> @192.168.1.201 google.com +short
; (1 server found)
;; global options: +cmd
;; no servers could be reached\n4. Test web UI: \n5. Switch router primary DNS to  (keep  as secondary during transition)\n\n## MetalLB Annotation Note\n\nUses  prefix (legacy). Verify your MetalLB version:\n\nIf MetalLB ≥ v0.13 in native mode, change annotations to  prefix in helmrelease.yaml.