### PR TITLE
fix(pihole): use plain DNS upstreams instead of port 853

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -27,9 +27,11 @@ spec:
     # Pi-hole v6 (appVersion: 2025.11.1) — chart version 2.35.0
     replicaCount: 1
 
-    # -- Native DoT upstreams (Pi-hole v6 FTL supports host#port format)
-    DNS1: "1.1.1.1#853"
-    DNS2: "1.0.0.1#853"
+    # -- Upstream DNS servers (plain DNS on port 53)
+    # NOTE: Pi-hole v6 FTL does not support DoT via the #port syntax.
+    # DoT can be configured via the web UI (Settings > DNS) if needed.
+    DNS1: "1.1.1.1"
+    DNS2: "1.0.0.1"
 
     # -- Web UI virtual host (must match ingress host to avoid redirects)
     virtualHost: "pihole.homelab.properties"

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -27,11 +27,10 @@ spec:
     # Pi-hole v6 (appVersion: 2025.11.1) — chart version 2.35.0
     replicaCount: 1
 
-    # -- Upstream DNS servers (plain DNS on port 53)
-    # NOTE: Pi-hole v6 FTL does not support DoT via the #port syntax.
-    # DoT can be configured via the web UI (Settings > DNS) if needed.
-    DNS1: "1.1.1.1"
-    DNS2: "1.0.0.1"
+    # -- Upstream DNS: cloudflared DoH sidecar on localhost:5053
+    # Pi-hole v6 FTL does not support DoT natively; DoH via sidecar is required.
+    DNS1: "127.0.0.1#5053"
+    DNS2: "no"
 
     # -- Web UI virtual host (must match ingress host to avoid redirects)
     virtualHost: "pihole.homelab.properties"
@@ -44,7 +43,6 @@ spec:
       externalTrafficPolicy: Local
       loadBalancerIP: "192.168.1.201"
       annotations:
-        metallb.io/allow-shared-ip: pihole-svc
         metallb.io/loadBalancerIPs: "192.168.1.201"
 
     # -- DHCP: disabled (K3s cluster, no DHCP needed)
@@ -102,9 +100,11 @@ spec:
         failureThreshold: 10
         timeoutSeconds: 5
 
-    # -- DoH sidecar: disabled (using native DoT via DNS1/DNS2 instead)
+    # -- DoH sidecar: cloudflared forwarding to Cloudflare and Quad9 over HTTPS
     doh:
-      enabled: false
+      enabled: true
+      envVars:
+        TUNNEL_DNS_UPSTREAM: "https://1.1.1.1/dns-query,https://1.0.0.1/dns-query,https://9.9.9.9/dns-query,https://149.112.112.9/dns-query"
 
     # -- Monitoring: Pi-hole v6 exposes Prometheus metrics at /metrics
     # TODO: Add ServiceMonitor once kube-prometheus-stack is deployed to this cluster

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -27,10 +27,9 @@ spec:
     # Pi-hole v6 (appVersion: 2025.11.1) — chart version 2.35.0
     replicaCount: 1
 
-    # -- Upstream DNS: cloudflared DoH sidecar on localhost:5053
-    # Pi-hole v6 FTL does not support DoT natively; DoH via sidecar is required.
-    DNS1: "127.0.0.1#5053"
-    DNS2: "no"
+    # -- Upstream DNS: plain DNS to Cloudflare
+    DNS1: "1.1.1.1"
+    DNS2: "1.0.0.1"
 
     # -- Web UI virtual host (must match ingress host to avoid redirects)
     virtualHost: "pihole.homelab.properties"
@@ -100,11 +99,9 @@ spec:
         failureThreshold: 10
         timeoutSeconds: 5
 
-    # -- DoH sidecar: cloudflared forwarding to Cloudflare and Quad9 over HTTPS
+    # -- DoH sidecar: disabled (cloudflared proxy-dns deprecated Nov 2025)
     doh:
-      enabled: true
-      envVars:
-        TUNNEL_DNS_UPSTREAM: "https://1.1.1.1/dns-query,https://1.0.0.1/dns-query,https://9.9.9.9/dns-query,https://149.112.112.9/dns-query"
+      enabled: false
 
     # -- Monitoring: Pi-hole v6 exposes Prometheus metrics at /metrics
     # TODO: Add ServiceMonitor once kube-prometheus-stack is deployed to this cluster


### PR DESCRIPTION
## Problem

DNS was completely unresponsive. `dig @127.0.0.1 google.com` from inside the pod timed out despite FTL listening on port 53.

**Root cause**: `DNS1: "1.1.1.1#853"` sends plain UDP/TCP DNS queries to Cloudflare port 853. Cloudflare's port 853 is TLS-only (DoT). Every upstream query hung waiting for a response that never came, causing FTL to stop answering all DNS queries.

## Fix

Remove the `#853` port suffix. Pi-hole v6 FTL does not support DoT via the `host#port` syntax — that format only overrides the port number, not the protocol.

DNS1/DNS2 now point to 1.1.1.1 and 1.0.0.1 on standard port 53. DoT can be configured via the Pi-hole web UI (Settings → DNS) if desired.

## Also fixed

- Removed `metallb.io/allow-shared-ip` annotation from the service (applied manually on cluster; `mixedService: true` creates a single combined TCP+UDP service — the shared-IP annotation was not needed and blocked MetalLB IP assignment)