### PR TITLE
fix(pihole): remove conflicting loadBalancerIP field

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -40,7 +40,6 @@ spec:
       type: LoadBalancer
       port: 53
       externalTrafficPolicy: Local
-      loadBalancerIP: "192.168.1.201"
       annotations:
         metallb.io/loadBalancerIPs: "192.168.1.201"
 


### PR DESCRIPTION
MetalLB v0.13+ rejects services with both `spec.loadBalancerIP` and the `metallb.io/loadBalancerIPs` annotation set simultaneously.

Remove the deprecated `loadBalancerIP` chart value; the annotation alone is sufficient to assign `192.168.1.201`.