### PR TITLE
feat(k3s): deploy kube-prometheus-stack via Flux GitOps

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
       enabled: false
 
     # -- Monitoring: Pi-hole v6 exposes Prometheus metrics at /metrics
-    # TODO: Add ServiceMonitor once kube-prometheus-stack is deployed to this cluster
+    # PodMonitor is used (not ServiceMonitor) because the pihole Helm chart natively generates a PodMonitor
     monitoring:
       podMonitor:
         enabled: true

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -106,7 +106,7 @@ spec:
     # TODO: Add ServiceMonitor once kube-prometheus-stack is deployed to this cluster
     monitoring:
       podMonitor:
-        enabled: false
+        enabled: true
       sidecar:
         enabled: false
 

--- a/k3s/clusters/homelab/infra-configs.yaml
+++ b/k3s/clusters/homelab/infra-configs.yaml
@@ -18,7 +18,7 @@ spec:
   path: ./k3s/infrastructure/configs
   prune: true
   wait: true
-  timeout: 5m
+  timeout: 20m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: ENC[AES256_GCM,data:TZ8=,iv:AjpJa+Sm74Ay1d0/M6eeXPAmueX7ITstULRU5/gPFbs=,tag:r99tGwW/FgppgiF3joywHg==,type:str]
+kind: ENC[AES256_GCM,data:WVZ+oE3i,iv:Mh5OBHz1jbFP5J5Fxjpdj9GZERyY2ccTiVltDk6/6Wc=,tag:8aRdC5xeVNTIYLV5JgtVeQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:0KxSyClIOQ2OdLBc4LCvZnJNRAc=,iv:xk+HFjlmCzoowMTorOBj17JYAkrjbWQbkGjJnJG0OCk=,tag:av+4K49KEdeDCllZHgXQAQ==,type:str]
+    namespace: ENC[AES256_GCM,data:GGOvLTKheS/1zQ==,iv:r53tEr+YIVxVMhF/5Sme0suWTnFGvcFoLzEODdt3S8c=,tag:NESR2M/bAhpITSSct5c2Yw==,type:str]
+stringData:
+    admin-user: ENC[AES256_GCM,data:viJL3LI=,iv:b+FOljBhITerHLy397/rDSPnszyzOhyoEqP1X830SnU=,tag:3MPKnJhKVCKbcq+1ffmQTA==,type:str]
+    admin-password: ENC[AES256_GCM,data:2GjopebGNqKfRNEN9G+tMsRBPxOMYpKpBUQTAWTgX0U=,iv:PeYvCKYcEzW9mWaKhNgLKP6F1vG2MIhk1FhS/opr7xY=,tag:kOYiqjOxffu0GeMTlch/qg==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VjBHZWwwWEV1bFFraGwx
+            V2R1V01rcVdFbGVTeEF3WGh5eWUycmVoWVNjCnNmQ3R0dTg2WXFwdGp4SkdDZkFO
+            RlZiK0RRR25ua3RpbFFIWDlkMitmQmcKLS0tIG9mdVVNTUw1MjhvWVVoY21lU2hD
+            SnJ5biswbCtoVzJzQ09WeE1Rb2FaZ2cKq9WHEu5RPMS08TLziOvLlTZCArCvCbOk
+            A5ZUChIkZg3J7Ig9wkN5HNMruYr5PCGIRSpvch4oYJKeWOiTRRj5tw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-06T23:22:29Z"
+    mac: ENC[AES256_GCM,data:vylwu6ddjTDf2R2IKHNf2mcBReIKnV+YacfIZHXo2II8xvveBtFwfeTKWzBjPhplZCbGOpHfz0YXVzk2JHG8TIu0CN+8mrOjmMhNyDF7+uVFIU4sF7CTrVb8KrwXZR7wtXEa+k6QJ9Mawrhttax/STYI7tbRYfOilHchVprvRAM=,iv:0ZKX/obxyiw2dgL2bfzVePmkBTzZpzenlXzWcywk6fE=,tag:OigN9eP1D494pRBO4ptygQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml.example
+++ b/k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml.example
@@ -1,0 +1,10 @@
+# Copy to grafana-secret.sops.yaml, fill in password, then encrypt:
+# sops -e -i k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-secret
+  namespace: monitoring
+stringData:
+  admin-user: admin
+  admin-password: REPLACE_ME

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 1h
+  timeout: 15m
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: ">=84.0.0 <85.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      interval: 12h
+  values:
+    # K3s-specific: disable scrapers that bind to 127.0.0.1 or use SQLite
+    kubeEtcd:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeControllerManager:
+      enabled: false
+    kubeProxy:
+      enabled: false
+
+    # Prometheus configuration
+    prometheus:
+      prometheusSpec:
+        scrapeInterval: "60s"
+        retention: 30d
+        podMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              storageClassName: local-path
+              resources:
+                requests:
+                  storage: 20Gi
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+        hosts:
+          - prometheus.homelab.properties
+        tls:
+          - secretName: prometheus-tls
+            hosts:
+              - prometheus.homelab.properties
+
+    # Alertmanager: null receiver only, emptyDir storage
+    alertmanager:
+      alertmanagerSpec:
+        storage: {}
+      config:
+        global:
+          resolve_timeout: 5m
+        route:
+          group_by:
+            - namespace
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          receiver: "null"
+        receivers:
+          - name: "null"
+        inhibit_rules: []
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+        hosts:
+          - alertmanager.homelab.properties
+        tls:
+          - secretName: alertmanager-tls
+            hosts:
+              - alertmanager.homelab.properties
+
+    # Grafana: SOPS-backed secret, persistent storage
+    grafana:
+      admin:
+        existingSecret: grafana-admin-secret
+        userKey: admin-user
+        passwordKey: admin-password
+      persistence:
+        enabled: true
+        type: pvc
+        accessModes:
+          - ReadWriteOnce
+        size: 5Gi
+        storageClassName: local-path
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+        hosts:
+          - grafana.homelab.properties
+        tls:
+          - secretName: grafana-tls
+            hosts:
+              - grafana.homelab.properties

--- a/k3s/infrastructure/configs/monitoring/helmrepository.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://prometheus-community.github.io/helm-charts

--- a/k3s/infrastructure/configs/monitoring/kustomization.yaml
+++ b/k3s/infrastructure/configs/monitoring/kustomization.yaml
@@ -2,6 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - metallb
-  - cert-manager
-  - monitoring
+  - grafana-secret.sops.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - headlamp.yaml
   - cert-manager.yaml
+  - monitoring.yaml
   - pihole.yaml

--- a/k3s/platform/namespaces/monitoring.yaml
+++ b/k3s/platform/namespaces/monitoring.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring


### PR DESCRIPTION
## Summary
- Deploy kube-prometheus-stack through Flux in the k3s infra-configs layer.
- Add the monitoring namespace, HelmRepository, HelmRelease, and kustomization wiring.
- Enable the pihole PodMonitor and extend the Flux reconciliation timeout for the longer install.

## Notes
- The Grafana admin secret is SOPS-encrypted; the password is stored encrypted, not in plaintext.

## Post-merge verification
Run the Task 9 checks after merge to confirm Flux, Helm, Grafana, Prometheus, TLS, and pihole scraping are healthy.

## Acceptance criteria commands
```bash
kubectl get kustomization -n flux-system infra-configs
kubectl get helmrelease -n monitoring kube-prometheus-stack
kubectl get pods -n monitoring
curl -sk https://grafana.homelab.properties/api/health | grep '"database": "ok"'
curl -s 'https://prometheus.homelab.properties/api/v1/query?query=up' | grep '"status":"success"'
echo | openssl s_client -connect grafana.homelab.properties:443 2>/dev/null | openssl x509 -noout -issuer | grep "Let's Encrypt"
curl -s https://prometheus.homelab.properties/api/v1/targets | python3 -c "import json,sys; targets=json.load(sys.stdin)['data']['activeTargets']; print([t for t in targets if 'pihole' in t.get('labels',{}).get('job','')])"