### PR TITLE
fix(pihole): enable monitoring sidecar so PodMonitor targets are active

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -102,13 +102,14 @@ spec:
     doh:
       enabled: false
 
-    # -- Monitoring: Pi-hole v6 exposes Prometheus metrics at /metrics
+    # -- Monitoring: Pi-hole v6 does not expose native Prometheus metrics on port 80.
+    # The monitoring sidecar (prometheus-exporter) is required to scrape pi-hole's API
     # PodMonitor is used (not ServiceMonitor) because the pihole Helm chart natively generates a PodMonitor
     monitoring:
       podMonitor:
         enabled: true
       sidecar:
-        enabled: false
+        enabled: true
 
     # -- Pod DNS config: ensure pihole pod uses external DNS, not itself
     podDnsConfig:


### PR DESCRIPTION
## Summary

- Enable `monitoring.sidecar.enabled: true` in the pihole HelmRelease
- Update comment to accurately document that Pi-hole v6 does not expose native Prometheus metrics on port 80

## Root Cause

Post-merge verification of PR #23 (kube-prometheus-stack deployment) revealed that all 7 acceptance criteria passed except AC7 (pihole scraping). Investigation showed:

- The pihole Helm chart creates a PodMonitor (`podMonitor/pihole/pihole-prometheus-exporter/0`) that targets a port named `prometheus`
- That port only exists on the **monitoring sidecar** container (prometheus-exporter)
- `monitoring.sidecar.enabled` was set to `false`, so no sidecar ran, no `prometheus` port existed
- Result: 5 pihole targets in **dropped targets**, 0 in active targets

Pi-hole v6 does not expose native Prometheus metrics on its web port (port 80), so the sidecar exporter is required.

## Verification

After merge, confirm pihole targets are active:
```bash
curl -s https://prometheus.homelab.properties/api/v1/targets | grep -i pihole | grep '"health":"up"'
```