### PR TITLE
docs: update AGENTS.md files to reflect monitoring stack deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-05-05  
+**Generated:** 2026-05-06  
 **Branch:** master  
 
 ## OVERVIEW
-Homelab infrastructure managing 9 Docker services on a Synology NAS (macvlan networking), with a single-node K3s cluster (Ansible-bootstrapped) and Flux CD v2 GitOps with infrastructure deployed (cert-manager, metallb, headlamp). Docker stack is operational; K3s cluster running with Flux managing controllers and one application (headlamp). CDK8s/Nx workspace initialized but contains only a stub chart.
+Homelab infrastructure managing 9 Docker services on a Synology NAS (macvlan networking), with a single-node K3s cluster (Ansible-bootstrapped) and Flux CD v2 GitOps with infrastructure deployed (cert-manager, metallb, headlamp, kube-prometheus-stack). Docker stack is operational; K3s cluster running on testbed node (192.168.1.128) with Flux managing controllers, a full monitoring stack (Prometheus + Grafana + Alertmanager), and applications (headlamp, pihole). CDK8s/Nx workspace initialized but contains only a stub chart.
 
 ## STRUCTURE
 ```
@@ -41,6 +41,10 @@ homelab/
 | Flux system manifests | `k3s/clusters/homelab/flux-system/` | Flux v2.3.0; GitRepository watches `master` branch |
 | SOPS/age config | `.sops.yaml` | age key encryption; see k3s/AGENTS.md for key fingerprint |
 | Headlamp app | `k3s/applications/headlamp/` | headlamp.homelab.properties; TLS via letsencrypt-prod |
+| Pihole app | `k3s/applications/pihole/` | pihole.homelab.properties; DNS + PodMonitor enabled |
+| Monitoring stack (K3s) | `k3s/infrastructure/configs/monitoring/` | kube-prometheus-stack HelmRelease; grafana/prometheus/alertmanager.homelab.properties |
+| Grafana (K3s) | https://grafana.homelab.properties | Credentials in BitWarden; SOPS secret at `grafana-secret.sops.yaml` |
+| K3s infrastructure controllers | `k3s/infrastructure/controllers/` | cert-manager + metallb HelmReleases; see `k3s/infrastructure/AGENTS.md` |
 | K3s infrastructure controllers | `k3s/infrastructure/controllers/` | cert-manager + metallb HelmReleases; see `k3s/infrastructure/AGENTS.md` |
 
 ## NETWORKING
@@ -93,7 +97,7 @@ docker-compose -f prometheus-compose.yml up -d
 ```
 
 ## NOTES
-- **K3s + Flux**: `bootstrap-k3s.yml` installs single-node K3s; Flux bootstrapped at `k3s/clusters/homelab/` with cert-manager, metallb (infra controllers), and headlamp (application) deployed. `bootstrap-flux.yml` Ansible playbook is still a stub. See `k3s/AGENTS.md` and `k3s/infrastructure/AGENTS.md`.
+- **K3s + Flux**: `bootstrap-k3s.yml` installs single-node K3s on testbed (192.168.1.128); Flux bootstrapped at `k3s/clusters/homelab/` with cert-manager, metallb (infra controllers), kube-prometheus-stack (infra configs), pihole, and headlamp (applications) deployed. `bootstrap-flux.yml` Ansible playbook is still a stub. See `k3s/AGENTS.md` and `k3s/infrastructure/AGENTS.md`.
 - **Prowlarr healthcheck is commented out** — its health endpoint wasn't stable.
 - **SNMP scrape is commented out** in `prometheus-compose.yml` — the config exists but the job is disabled.
 - **Nginx proxy config** (`docker/prometheus/syno-prom-proxy.conf`) is co-located with Prometheus, not in a separate nginx service.

--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -1,7 +1,7 @@
 # K3S DIRECTORY
-
+**Generated:** 2026-05-06  
 ## OVERVIEW
-**K3s bootstrap is implemented; Flux CD v2 GitOps is scaffolded with real infrastructure manifests deployed.** Ansible provisions OS and installs K3s single-node. Flux is bootstrapped with Kustomizations committed — infrastructure controllers (cert-manager, metallb) and headlamp application are deployed. CDK8s/Nx workspace is initialized but contains only a stub chart; manifest promotion workflow is not yet designed.
+**K3s bootstrap is implemented; Flux CD v2 GitOps is active with real infrastructure and applications deployed to the testbed node.** Ansible provisions OS and installs K3s single-node. Flux manages: cert-manager + metallb (controllers), kube-prometheus-stack + pihole (configs/apps), and headlamp (application). CDK8s/Nx workspace is initialized but contains only a stub chart; manifest promotion workflow is not yet designed.
 
 ## WHAT EXISTS
 ```
@@ -12,24 +12,24 @@ k3s/
 ├── clusters/homelab/         # ✓ Flux Kustomization manifests committed
 │   ├── flux-system/            # gotk-components, gotk-sync, kustomization.yaml
 │   └── *.yaml                  # 5x Kustomization CRs (platform → infra-controllers → infra-configs → apps)
-├── platform/                 # ✓ kustomization.yaml + namespaces/ (cert-manager, headlamp, pihole)
+├── platform/                 # ✓ kustomization.yaml + namespaces/ (cert-manager, headlamp, monitoring, pihole)
 ├── infrastructure/
 │   ├── controllers/            # ✓ cert-manager + metallb HelmReleases — see infrastructure/AGENTS.md
-│   └── configs/                # ✓ ClusterIssuers + IPAddressPool + SOPS-encrypted Cloudflare token
-└── applications/             # ✓ headlamp HelmRelease deployed (headlamp.homelab.properties)
-```
+│   └── configs/                # ✓ ClusterIssuers + IPAddressPool + SOPS secrets + kube-prometheus-stack
+└── applications/             # ✓ headlamp + pihole HelmReleases deployed
 
-> Last verified: 2026-05-05
+> Last verified: 2026-05-06
 
 ## LAYER STATUS
 | Component | Location | Status |
-|-----------|----------|--------|
+|-----------|----------|---------|
 | Ansible playbooks | `k3s/bootstrap/ansible/` | ✓ provision-nodes + bootstrap-k3s runnable |
 | Flux cluster root | `k3s/clusters/homelab/` | ✓ Kustomizations committed (Flux v2.3.0) |
-| Platform manifests | `k3s/platform/` | ✓ Namespace manifests (cert-manager, headlamp, pihole) |
+| Platform manifests | `k3s/platform/` | ✓ Namespace manifests (cert-manager, headlamp, monitoring, pihole) |
 | Infrastructure manifests | `k3s/infrastructure/` | ✓ Implemented — cert-manager + metallb controllers + configs |
+| Monitoring stack | `k3s/infrastructure/configs/monitoring/` | ✓ kube-prometheus-stack@84.5.0; grafana/prometheus/alertmanager.homelab.properties |
 | CDK8s TypeScript | `applications/cdk8s/src/` | ✓ HelloChart stub (creates hello-cdk8s namespace only) |
-| Application manifests | `k3s/applications/` | ✓ Headlamp deployed via Flux (headlamp.homelab.properties) |
+| Application manifests | `k3s/applications/` | ✓ Headlamp + pihole deployed via Flux |
 | Nx orchestration | `nx.json`, `project.json` | ✓ Workspace initialized; synth target configured (Yarn 4.14.1) |
 | SOPS secrets | `.sops.yaml` | ✓ Created (age key encryption) |
 
@@ -43,18 +43,20 @@ k3s/
 - **Storage**: keep manifests storage-class-light until a real CSI decision is made
 
 ## ANTI-PATTERNS
-- **Do not create files here expecting them to be deployed** — the K3s cluster may not exist yet.
 - **Do not treat `k3s.md` as current state** — it describes the target, not reality.
 - **Do not describe CDK8s as unimplemented** — HelloChart stub exists at `applications/cdk8s/src/main.ts`. Nx workspace is initialized. What's missing is real workloads and the dist/ → k3s/applications/ promotion workflow.
 - **Do not hardcode a speculative storage vendor into new planning docs unless the repo actually adopts one.**
 - **Do not run `ansible-playbook` commands from `BOOTSTRAP.md`** without verifying nodes are provisioned.
-
+- **Do not add namespaces inside `k3s/infrastructure/configs/`** — namespaces belong in `k3s/platform/namespaces/` (established pattern; all existing namespaces follow this).
 ## NOTES
 - `BOOTSTRAP.md` is the authoritative guide for standing up the cluster when ready.
 - `k3s.md` contains the concrete repo blueprint, Flux kustomization graph, and Nx/CDK8s workflow.
 - Current Docker services on Synology NAS are the live production environment — K3s migration is future work.
-- **Testbed node** (i7-4770k) at 192.168.1.128 is the first node to provision. Re-IP to 192.168.1.4x before joining the cluster.
+- **Testbed node** (i7-4770k) at 192.168.1.128 is the current active single-node cluster. Target architecture is 3x Dell Optiplex (192.168.1.40-42) with embedded etcd — not yet provisioned.
 - `provision-nodes.yml` is runnable — runs `common` + `k3s-prereqs` roles.
 - `bootstrap-k3s.yml` is runnable — runs `k3s-server` role to install and configure a single K3s server node.
 - `bootstrap-flux.yml` is a stub Ansible playbook — Flux was bootstrapped manually; manifests live in `k3s/clusters/homelab/`.
 - `group_vars/` lives at `inventory/group_vars/all.yml` (not at the ansible root) — required for `ansible-playbook` variable loading to work correctly.
+- **SOPS age key**: `~/.kube/k3s-homelab-age.agekey` on the Ansible controller. Required to decrypt/edit any `*.sops.yaml` file. Set `SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey` in shell profile. Recoverable from cluster: `kubectl get secret sops-age -n flux-system`.
+- **Grafana credentials**: stored in BitWarden; Grafana accessible at https://grafana.homelab.properties.
+- **infra-configs.yaml timeout** is 20m (raised from 5m for kube-prometheus-stack). This affects all infra-configs reconciliation; dedicated Kustomization is the proper long-term fix.

--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -1,6 +1,6 @@
 # INFRASTRUCTURE DIRECTORY
 
-**Generated:** 2026-05-05
+**Generated:** 2026-05-06
 
 ## OVERVIEW
 
@@ -17,8 +17,8 @@ infrastructure/
 │   └── metallb/        # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
 └── configs/
     ├── cert-manager/   # cloudflare-token.sops.yaml, clusterissuer-{prod,staging}.yaml, kustomization.yaml
-    └── metallb/        # ipaddresspool.yaml, l2advertisement.yaml, kustomization.yaml
-```
+    ├── metallb/        # ipaddresspool.yaml, l2advertisement.yaml, kustomization.yaml
+    └── monitoring/     # helmrelease.yaml, helmrepository.yaml, grafana-secret.sops.yaml, kustomization.yaml
 
 ## RECONCILIATION ORDER
 
@@ -37,10 +37,22 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 - **IPAddressPool**: defined in `configs/metallb/ipaddresspool.yaml`
 - **L2Advertisement**: defined in `configs/metallb/l2advertisement.yaml`
 
+### kube-prometheus-stack
+- **Chart**: `prometheus-community/kube-prometheus-stack` `>=84.0.0 <85.0.0` (deployed: 84.5.0) | namespace: `monitoring`
+- **Components**: Prometheus Operator, Prometheus, Alertmanager, Grafana, kube-state-metrics, node-exporter
+- **Ingresses**: grafana.homelab.properties, prometheus.homelab.properties, alertmanager.homelab.properties (all TLS via letsencrypt-prod)
+- **Storage**: Prometheus 20Gi PVC (local-path), Grafana 5Gi PVC (local-path), Alertmanager emptyDir
+- **Secret**: `grafana-secret.sops.yaml` — SOPS age-encrypted Grafana admin credentials (`admin-user` / `admin-password` keys)
+- **K3s scrapers disabled**: kubeEtcd, kubeScheduler, kubeControllerManager, kubeProxy (K3s uses SQLite; control plane binds to 127.0.0.1)
+- **PodMonitor discovery**: `podMonitorSelectorNilUsesHelmValues: false` + `serviceMonitorSelectorNilUsesHelmValues: false`
+
 ### Headlamp (reference — lives in `k3s/applications/headlamp/`)
 - Uses `cert-manager.io/cluster-issuer: letsencrypt-prod` in Traefik ingress
 - URL: `headlamp.homelab.properties`
 
+### Pihole (reference — lives in `k3s/applications/pihole/`)
+- PodMonitor enabled via `monitoring.sidecar.enabled: true` (ekofr/pihole-exporter:v1.0.0 on port 9617)
+- URL: `pihole.homelab.properties`
 ## WHERE TO LOOK
 
 | Task | File |
@@ -49,13 +61,16 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 | Add a ClusterIssuer | `configs/cert-manager/` |
 | Change IP address pool | `configs/metallb/ipaddresspool.yaml` |
 | Edit Cloudflare token secret | `configs/cert-manager/cloudflare-token.sops.yaml` via `sops` CLI |
-
+| Edit Grafana admin secret | `configs/monitoring/grafana-secret.sops.yaml` via `sops` CLI |
+| Modify monitoring stack values | `configs/monitoring/helmrelease.yaml` |
 ## ANTI-PATTERNS
 
-- **Do not hand-edit `cloudflare-token.sops.yaml`** — SOPS-encrypted; edit only with `sops cloudflare-token.sops.yaml` using the age key at `~/.kube/k3s-homelab-age.agekey`.
+- **Do not hand-edit `*.sops.yaml` files** — SOPS-encrypted; edit only with `sops <file>` using the age key at `~/.kube/k3s-homelab-age.agekey`.
 - **Do not add configs/ resources that need CRDs from controllers/** without ensuring `infra-configs` dependsOn remains correct.
 - **Do not duplicate ClusterIssuers** — `letsencrypt-prod` and `letsencrypt-staging` already exist; reference by name in ingress annotations.
 - **Do not add a new controller without a matching entry** in the `infra-controllers` Kustomization's `resources:` list at `k3s/clusters/homelab/infra-controllers.yaml`.
+- **Do not place namespaces inside `configs/`** — namespaces belong in `k3s/platform/namespaces/` (see monitoring namespace as the established pattern).
+- **Do not enable kubeEtcd/kubeScheduler/kubeControllerManager/kubeProxy scrapers** — K3s binds these to 127.0.0.1 and uses SQLite; they will always fail to scrape.
 
 ## NOTES
 


### PR DESCRIPTION
## Summary

- Updates `AGENTS.md` (root), `k3s/AGENTS.md`, and `k3s/infrastructure/AGENTS.md` to reflect the monitoring stack deployed in PRs #23 and #24
- Documents kube-prometheus-stack deployment: chart version, ingress hostnames, storage, SOPS secret location, K3s-specific scraper configuration
- Documents pihole PodMonitor sidecar pattern (ekofr/pihole-exporter:v1.0.0)
- Records SOPS age key location and recovery method
- Clarifies testbed node (192.168.1.128) vs. target cluster (3x Dell Optiplex, not yet provisioned)
- Adds anti-patterns for namespace placement and K3s scrapers
- Updates generated/verified dates to 2026-05-06