### PR TITLE
feat(k3s): add ServiceMonitor for headlamp

### DIFF
--- a/k3s/applications/headlamp/kustomization.yaml
+++ b/k3s/applications/headlamp/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - helmrepository.yaml
   - helmrelease.yaml
+  - servicemonitor.yaml

--- a/k3s/applications/headlamp/servicemonitor.yaml
+++ b/k3s/applications/headlamp/servicemonitor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 60s


### PR DESCRIPTION
## Summary

- Adds `ServiceMonitor` CR for headlamp so kube-prometheus-stack scrapes its `/metrics` endpoint
- Headlamp chart has no native `serviceMonitor` values, so this is a standalone manifest
- Targets the `http` port (port 80 on the service) at `/metrics`, 60s interval
- Updates `kustomization.yaml` to include the new resource

The `serviceMonitorSelectorNilUsesHelmValues: false` setting already applied to the kube-prometheus-stack HelmRelease means this ServiceMonitor will be discovered automatically without label changes.