### PR TITLE
feat(monitoring): drop duplicate and low-value histogram buckets (~48k series reduction)

### DIFF
--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -36,6 +36,26 @@ spec:
     kubeProxy:
       enabled: false
 
+    # Drop non-essential high-cardinality _bucket metrics from the API server job.
+    # Keeps the two most useful histograms (request latency + SLI) while removing
+    # watch internals and request body size that are rarely dashboarded.
+    kubeApiServer:
+      serviceMonitor:
+        metricRelabelings:
+          - sourceLabels: [__name__]
+            regex: "apiserver_request_body_size_bytes_bucket|apiserver_watch_cache_read_wait_seconds_bucket|apiserver_watch_events_sizes_bucket|apiserver_watch_list_duration_seconds_bucket"
+            action: drop
+
+    # K3s bundles apiserver + scheduler in the same binary, so the kubelet scrape
+    # endpoint exposes those metrics too — creating duplicates of what the
+    # kubeApiServer job already collects (~38k series).  Drop them here.
+    kubelet:
+      serviceMonitor:
+        metricRelabelings:
+          - sourceLabels: [__name__]
+            regex: "apiserver_.*|scheduler_.*"
+            action: drop
+
     # Prometheus configuration
     prometheus:
       prometheusSpec:


### PR DESCRIPTION
## Summary

- **Drop `apiserver_.*` and `scheduler_.*` from the kubelet ServiceMonitor** — K3s runs apiserver, scheduler, and etcd in the same binary, so the kubelet scrape endpoint re-exposes these metrics that the dedicated `kubeApiServer` job already collects. This was causing ~38k duplicate series.
- **Drop 4 non-essential `_bucket` metrics from the apiserver ServiceMonitor** — `apiserver_request_body_size_bytes_bucket`, `apiserver_watch_cache_read_wait_seconds_bucket`, `apiserver_watch_events_sizes_bucket`, and `apiserver_watch_list_duration_seconds_bucket` are not used by any standard kube-prometheus-stack dashboards or alerts.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Active series | 112,255 | ~64,000 |
| Reduction | — | ~48k series (43%) |
| Ingestion rate | ~1,985 samples/sec | ~1,100 samples/sec (est.) |
| Estimated disk growth | ~165–327 MB/day | ~95–190 MB/day (est.) |

## What is preserved

- `apiserver_request_duration_seconds_bucket` — API latency percentiles (used in Grafana dashboards)
- `apiserver_request_sli_duration_seconds_bucket` — SLI dashboards
- `etcd_request_duration_seconds_bucket` — etcd latency (only source since `kubeEtcd: enabled: false`)
- All `kubelet_*`, `container_*`, and cAdvisor metrics
- All node-exporter, kube-state-metrics, and coredns metrics unchanged

## Files changed

- `k3s/infrastructure/configs/monitoring/helmrelease.yaml` — added `metricRelabelings` under `kubeApiServer.serviceMonitor` and `kubelet.serviceMonitor`