### PR TITLE
Harden Flux bootstrap docs and linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ docker-compose -f prometheus-compose.yml up -d
 ```
 
 ## NOTES
-- **K3s + Flux**: `bootstrap-k3s.yml` installs single-node K3s on testbed (192.168.1.128); Flux bootstrapped at `k3s/clusters/homelab/` with cert-manager, metallb (infra controllers), kube-prometheus-stack (infra configs), pihole, and headlamp (applications) deployed. `bootstrap-flux.yml` Ansible playbook is still a stub. See `k3s/AGENTS.md` and `k3s/infrastructure/AGENTS.md`.
+- **K3s + Flux**: `bootstrap-k3s.yml` installs single-node K3s on testbed (192.168.1.128); `bootstrap-flux.yml` bootstraps Flux against `k3s/clusters/homelab/` with cert-manager, metallb (infra controllers), kube-prometheus-stack (infra configs), pihole, and headlamp (applications) deployed. See `k3s/AGENTS.md` and `k3s/infrastructure/AGENTS.md`.
 - **Prowlarr healthcheck is commented out** — its health endpoint wasn't stable.
 - **SNMP scrape is commented out** in `prometheus-compose.yml` — the config exists but the job is disabled.
 - **Nginx proxy config** (`docker/prometheus/syno-prom-proxy.conf`) is co-located with Prometheus, not in a separate nginx service.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository manages Docker-based services on a Synology NAS and a single-nod
 ### Current Setup
 - **Docker Services**: Legacy services running on Docker with macvlan networking
 - **K3s Cluster**: Single-node testbed (192.168.1.128) with SQLite datastore; HA cluster planned — see `k3s/BOOTSTRAP.md` Part 2
+- **GitOps**: Flux CD v2 manages cluster infrastructure and applications from `k3s/clusters/homelab/`
 - **Monitoring**: Comprehensive observability with Prometheus, Grafana, and custom exporters
 - **Network**: 192.168.1.0/24 physical network with bridge networking for containers
 
@@ -34,16 +35,15 @@ homelab/
 ### Current State
 - **Node**: Single testbed machine at 192.168.1.128
 - **Datastore**: SQLite (default for single node)
-- **GitOps**: Not yet implemented (Flux CD stub exists)
+- **GitOps**: Flux CD v2 rooted at `k3s/clusters/homelab/`
+- **Deployed via Flux**: cert-manager, MetalLB, kube-prometheus-stack, Headlamp, and Pi-hole
 - **Storage**: Local-path provisioner only; future CSI choice is intentionally undecided
 - **Networking**: Flannel VXLAN CNI
-- **Ingress**: Traefik (default K3s ingress; Nginx planned)
+- **Ingress**: Traefik (default K3s ingress)
 
 ### Planned (see `k3s/BOOTSTRAP.md` Part 2 and `k3s/k3s.md`)
 - 3-node HA with embedded etcd
-- Flux CD v2 GitOps rooted at `k3s/clusters/homelab/`
 - Nx + CDK8s workflow that renders workload manifests into `k3s/applications/`
-- Nginx Ingress + cert-manager
 
 See `k3s/k3s.md` for the concrete repo blueprint and Flux reconciliation graph.
 
@@ -118,6 +118,10 @@ ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml
 
 # Step 2: Install K3s server
 ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
+
+# Step 3: Bootstrap Flux CD GitOps
+export GITHUB_TOKEN=ghp_xxxx
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml
 ```
 
 ## Migration to K3s
@@ -128,5 +132,4 @@ The repository documents a future migration from Docker to Kubernetes with:
 - Service-by-service transition capability (planned)
 
 See [`k3s/k3s.md`](k3s/k3s.md) for the full target architecture and [`k3s/BOOTSTRAP.md`](k3s/BOOTSTRAP.md) for current deployment status.
-
 

--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -55,7 +55,7 @@ k3s/
 - **Testbed node** (i7-4770k) at 192.168.1.128 is the current active single-node cluster. Target architecture is 3x Dell Optiplex (192.168.1.40-42) with embedded etcd — not yet provisioned.
 - `provision-nodes.yml` is runnable — runs `common` + `k3s-prereqs` roles.
 - `bootstrap-k3s.yml` is runnable — runs `k3s-server` role to install and configure a single K3s server node.
-- `bootstrap-flux.yml` is a stub Ansible playbook — Flux was bootstrapped manually; manifests live in `k3s/clusters/homelab/`.
+- `bootstrap-flux.yml` is implemented and uses the `flux-bootstrap` role. It requires `GITHUB_TOKEN`, the kubeconfig fetched by `bootstrap-k3s.yml`, and Flux GitHub settings in `inventory/group_vars/all.yml`.
 - `group_vars/` lives at `inventory/group_vars/all.yml` (not at the ansible root) — required for `ansible-playbook` variable loading to work correctly.
 - **SOPS age key**: `~/.kube/k3s-homelab-age.agekey` on the Ansible controller. Required to decrypt/edit any `*.sops.yaml` file. Set `SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey` in shell profile. Recoverable from cluster: `kubectl get secret sops-age -n flux-system`.
 - **Grafana credentials**: stored in BitWarden; Grafana accessible at https://grafana.homelab.properties.

--- a/k3s/BOOTSTRAP.md
+++ b/k3s/BOOTSTRAP.md
@@ -2,7 +2,7 @@
 
 This guide covers bootstrapping a single-node K3s cluster using Ansible, then optionally scaling to a multi-node HA setup.
 
-> **Current state**: Single-node K3s server on the testbed (`192.168.1.128`) with SQLite datastore. HA cluster, Flux CD, and the CDK8s/Nx workflow are future work — see [Part 2](#part-2-scaling-to-ha-future-state) for the upgrade path.
+> **Current state**: Single-node K3s server on the testbed (`192.168.1.128`) with SQLite datastore. Flux CD is implemented and reconciles the cluster from `k3s/clusters/homelab/`. HA cluster scaling and the CDK8s/Nx promotion workflow are future work — see [Part 2](#part-2-scaling-to-ha-future-state) for the upgrade path.
 
 ---
 
@@ -14,6 +14,7 @@ The Ansible playbooks automate the entire K3s server installation:
 
 1. **`provision-nodes.yml`** — OS hardening, packages, UFW firewall, kernel modules, sysctl
 2. **`bootstrap-k3s.yml`** — K3s server install, configuration, kubeconfig fetch, token persistence
+3. **`bootstrap-flux.yml`** — Flux CD bootstrap, SOPS age key Secret, GitOps reconciliation
 
 Run them in order on a single testbed node. The result is a working single-node K3s cluster using SQLite (the default and recommended datastore for single-node deployments).
 
@@ -38,7 +39,7 @@ Your workstation (where you run Ansible) needs:
 
 ```bash
 # Install Ansible and required collections
-pip install ansible
+pip install ansible ansible-lint
 ansible-galaxy collection install -r k3s/bootstrap/ansible/requirements.yml
 
 # Install kubectl
@@ -103,6 +104,9 @@ Key settings in `inventory/group_vars/all.yml`:
 | `k3s_firewall_rules` | SSH, API, kubelet, Flannel | UFW ports to open |
 | `k3s_kernel_modules` | `br_netfilter`, `overlay` | Required kernel modules |
 | `k3s_sysctl_params` | bridge-nf, ip-forward, swappiness | Required sysctl settings |
+| `flux_github_owner` | `jander99` | GitHub owner for Flux bootstrap |
+| `flux_github_repo` | `homelab` | GitHub repo for Flux bootstrap |
+| `flux_git_branch` | `master` | Branch reconciled by Flux |
 
 Role-specific defaults are in `roles/k3s-server/defaults/main.yml` — override them in `group_vars/all.yml` or via `-e` flags.
 
@@ -178,9 +182,35 @@ k3s secrets-encrypt status
 You should see:
 - One `Ready` node (the testbed)
 - System pods running: `local-path-provisioner`, `coredns`, `metrics-server`, `kube-proxy`
-- No Flux pods yet (GitOps is future work)
 
-### Step 8: Use the Cluster
+### Step 8: Bootstrap Flux CD
+
+Flux bootstrap runs from the Ansible controller using the kubeconfig fetched by `bootstrap-k3s.yml`. It installs the pinned Flux and age CLIs if needed, creates `flux-system/sops-age` before reconciliation, then runs `flux bootstrap github` against the GitHub settings in `inventory/group_vars/all.yml`.
+
+Before running it:
+
+- Confirm `flux_github_owner`, `flux_github_repo`, and `flux_git_branch` match the target repository.
+- Export a GitHub token with repository write access.
+- Be ready to back up `~/.kube/k3s-homelab-age.agekey` after first run.
+
+```bash
+cd k3s/bootstrap/ansible
+export GITHUB_TOKEN=ghp_xxxx
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml
+```
+
+Verify Flux:
+
+```bash
+export KUBECONFIG=~/.kube/k3s-testbed.yaml
+flux check
+kubectl get kustomizations -A
+kubectl get helmreleases -A
+```
+
+You should see Flux controllers in `flux-system`, infrastructure controllers/configs reconciled, and applications from `k3s/applications/`.
+
+### Step 9: Use the Cluster
 
 ```bash
 export KUBECONFIG=~/.kube/k3s-testbed.yaml
@@ -199,6 +229,7 @@ kubectl delete deployment,svc nginx
 - **Kubeconfig on the node** is mode `0600` (root-only). On your control machine it is also `0600`.
 - **Node join token** is persisted at `~/.kube/k3s-testbed-token` (mode `0600`). You will need this token if you later add nodes for HA.
 - **Secrets at rest** are encrypted. Keep the encryption key safe — it lives at `/var/lib/rancher/k3s/server/encryption-config.json` on the node.
+- **SOPS age private key** is persisted at `~/.kube/k3s-homelab-age.agekey` and copied into the cluster as `flux-system/sops-age`. Back it up outside Git.
 - **UFW firewall** is configured with only the required ports open (SSH, API server, kubelet, Flannel).
 
 ### Troubleshooting
@@ -209,6 +240,8 @@ kubectl delete deployment,svc nginx
 | K3s install fails at download | `get.k3s.io` unreachable or wrong version string | Verify `k3s_version` in `group_vars/all.yml` matches a real K3s release |
 | Node stuck in `NotReady` | Flannel or kubelet not started | `sudo journalctl -u k3s -n 100` on the node |
 | `kubectl` cannot connect | Wrong IP in kubeconfig | Check `server:` line in `~/.kube/k3s-testbed.yaml` |
+| Flux bootstrap fails immediately | Missing `GITHUB_TOKEN` or repo settings | Export `GITHUB_TOKEN`; verify Flux vars in `inventory/group_vars/all.yml` |
+| Flux cannot decrypt SOPS secrets | Missing or wrong `sops-age` Secret | Recreate it from `~/.kube/k3s-homelab-age.agekey` |
 | Re-run playbook restarts K3s | Config file changed | Normal — Ansible detects config drift and restarts the service |
 
 ### Running the Full Entrypoint
@@ -217,10 +250,11 @@ The `site.yml` playbook runs all phases in sequence:
 
 ```bash
 cd k3s/bootstrap/ansible
+export GITHUB_TOKEN=ghp_xxxx
 ansible-playbook -i inventory/hosts.yml playbooks/site.yml
 ```
 
-> **Note:** `site.yml` currently runs Phase 1 (provision) and Phase 2 (K3s bootstrap). Phase 3 (Flux) is not yet implemented and will fail with a clear message.
+> **Note:** `site.yml` runs provisioning, K3s installation, and Flux bootstrap in order. The Flux phase requires `GITHUB_TOKEN` in the environment.
 
 ---
 
@@ -304,16 +338,16 @@ kubectl get pods -n kube-system -l component=etcd
 
 ### Future Phases
 
-These are not yet implemented and are listed here for planning purposes only. Storage-provider decisions are intentionally deferred until workloads actually need them.
+These are future planning items. Storage-provider decisions are intentionally deferred until workloads actually need them.
 
 | Phase | Component | Status |
 |-------|-----------|--------|
-| Flux CD | GitOps cluster root and reconciliation | Stub only (`bootstrap-flux.yml`) |
+| Flux CD | GitOps cluster root and reconciliation | Implemented (`bootstrap-flux.yml`) |
 | Nginx Ingress | HTTP load balancer | Not started (Traefik is the default K3s ingress) |
-| Cert Manager | TLS certificate automation | Not started |
-| SOPS + age | Secret encryption in Git | Not started |
-| Nx + CDK8s | TypeScript authoring and render pipeline | Not started |
-| Application manifests | Rendered output under `k3s/applications/` | Not started |
+| Cert Manager | TLS certificate automation | Deployed by Flux |
+| SOPS + age | Secret encryption in Git | Implemented for `*.sops.yaml` |
+| Nx + CDK8s | TypeScript authoring and render pipeline | Stub only; promotion workflow not designed |
+| Application manifests | Rendered output under `k3s/applications/` | Hand-authored apps deployed; CDK8s output not wired |
 | Velero | Backup/restore | Not started |
 
 Refer to `k3s/k3s.md` for the full target architecture and concrete repo blueprint.

--- a/k3s/bootstrap/ansible/AGENTS.md
+++ b/k3s/bootstrap/ansible/AGENTS.md
@@ -1,7 +1,7 @@
 # ANSIBLE DIRECTORY
 
 ## OVERVIEW
-Ansible workspace for provisioning OS nodes and installing a single-node K3s server. Two playbooks are runnable; `bootstrap-flux.yml` is a stub.
+Ansible workspace for provisioning OS nodes, installing a single-node K3s server, and bootstrapping Flux CD. `provision-nodes.yml`, `bootstrap-k3s.yml`, and `bootstrap-flux.yml` are runnable when prerequisites are met.
 
 ## STRUCTURE
 ```
@@ -13,13 +13,13 @@ ansible/
 ├── playbooks/
 │   ├── provision-nodes.yml            # ✓ Runnable — common + k3s-prereqs roles
 │   ├── bootstrap-k3s.yml              # ✓ Runnable — k3s-server role (single-node install)
-│   ├── bootstrap-flux.yml             # ✗ Stub — not yet runnable
+│   ├── bootstrap-flux.yml             # Flux CD bootstrap; requires GITHUB_TOKEN
 │   └── site.yml                       # Full entrypoint: runs all phases sequentially
 └── roles/
     ├── common/                        # apt upgrade, packages, timezone, UFW, passwordless sudo
     ├── k3s-prereqs/                   # swap disable, kernel modules (br_netfilter, overlay), sysctl
     ├── k3s-server/                    # K3s install, config, kubeconfig fetch, token persistence
-    └── flux-bootstrap/                # Stub role (empty)
+    └── flux-bootstrap/                # Flux CLI, age key, sops-age Secret, GitHub bootstrap
 ```
 
 ## WHERE TO LOOK
@@ -27,7 +27,7 @@ ansible/
 |------|----------|-------|
 | Add/remove cluster nodes | `inventory/hosts.yml` | Testbed: 192.168.1.128; target cluster: .40/.41/.42 |
 | Change k3s version | `inventory/group_vars/all.yml` | `k3s_version: v1.35.4+k3s1` |
-| Flux repo settings | `inventory/group_vars/all.yml` | `flux_owner: jander99`, `flux_repo: homelab`, `flux_branch: master` |
+| Flux repo settings | `inventory/group_vars/all.yml` | `flux_github_owner: jander99`, `flux_github_repo: homelab`, `flux_git_branch: master` |
 | K3s server config | `roles/k3s-server/` | Writes `/etc/rancher/k3s/config.yaml` on remote |
 | Add OS packages/UFW rules | `inventory/group_vars/all.yml` | Common role reads from here |
 
@@ -38,9 +38,8 @@ ansible/
 - **kubeconfig**: fetched to `~/.kube/k3s-<hostname>.yaml`; token to `~/.kube/k3s-<hostname>-token`.
 
 ## ANTI-PATTERNS
-- **Do not run playbooks without verifying target nodes are reachable** — `bootstrap-flux.yml` is a stub and will fail.
+- **Do not run playbooks without verifying target nodes are reachable** — `bootstrap-flux.yml` also requires a fetched kubeconfig and `GITHUB_TOKEN` in the environment.
 - **`secrets-encryption: true` in k3s-server config is a one-way door** — enabling it on a running cluster requires full reinstall to disable.
-- **Do not add roles to `bootstrap-flux.yml`** until the Flux bootstrap Ansible integration is designed.
 - **Do not change `flannel-backend`** from `vxlan` without understanding the network impact on existing cluster state.
 
 ## COMMANDS
@@ -48,6 +47,7 @@ ansible/
 # From this directory:
 ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml
 ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
+GITHUB_TOKEN=ghp_xxxx ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml
 
 # Verify connectivity first:
 ansible all -i inventory/hosts.yml -m ping

--- a/k3s/bootstrap/ansible/README.md
+++ b/k3s/bootstrap/ansible/README.md
@@ -1,6 +1,6 @@
 # K3s Ansible Bootstrap
 
-Ansible playbooks for provisioning and bootstrapping K3s cluster nodes. Both `provision-nodes.yml` and `bootstrap-k3s.yml` are runnable — Flux CD is a stub pending future work.
+Ansible playbooks for provisioning nodes, installing the single-node K3s server, and bootstrapping Flux CD against the GitOps manifests in this repository.
 
 ## Prerequisites
 
@@ -80,14 +80,29 @@ Installs K3s v1.35.4+k3s1 on all `k3s_servers` hosts. On success, kubeconfig is 
 KUBECONFIG=~/.kube/k3s-testbed.yaml kubectl get nodes
 ```
 
-### Full bootstrap (Flux CD not yet runnable)
+### Bootstrap Flux CD
+
+`bootstrap-flux.yml` runs on the Ansible controller using the kubeconfig fetched by `bootstrap-k3s.yml`. It installs the pinned Flux and age CLIs if needed, creates the `flux-system/sops-age` Secret before reconciliation, and runs `flux bootstrap github` against the repository settings in `inventory/group_vars/all.yml`.
+
+Before running it:
+
+- Verify `flux_github_owner`, `flux_github_repo`, and `flux_git_branch` in `inventory/group_vars/all.yml`.
+- Export a GitHub token with repository write access.
+- Back up the generated age private key at `~/.kube/k3s-homelab-age.agekey` after first run.
 
 ```bash
-# Phases 1 and 2 run successfully; Phase 3 (Flux CD) is a stub.
+export GITHUB_TOKEN=ghp_xxxx
+ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml -v
+```
+
+### Full bootstrap
+
+```bash
+export GITHUB_TOKEN=ghp_xxxx
 ansible-playbook -i inventory/hosts.yml playbooks/site.yml -v
 ```
 
-Flux CD (`bootstrap-flux.yml`) is a stub and will fail with a clear message until implemented.
+`site.yml` runs provisioning, K3s installation, and Flux bootstrap in order. Flux will reconcile `k3s/clusters/homelab/` from the configured Git branch.
 
 ---
 

--- a/k3s/bootstrap/ansible/playbooks/site.yml
+++ b/k3s/bootstrap/ansible/playbooks/site.yml
@@ -1,9 +1,8 @@
 ---
 # site.yml
 # Full cluster bootstrap — runs all phases in order.
-# NOTE: Phase 1 (provision-nodes) and Phase 2 (bootstrap-k3s) are runnable.
-#       Phase 3 (bootstrap-flux) is still a stub and will fail with a clear
-#       message until Flux configuration is implemented.
+# NOTE: Phase 3 (bootstrap-flux) requires GITHUB_TOKEN in the environment and
+#       Flux GitHub settings in inventory/group_vars/all.yml.
 #
 # Usage: ansible-playbook -i inventory/hosts.yml playbooks/site.yml -v
 

--- a/k3s/bootstrap/ansible/roles/common/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/common/tasks/main.yml
@@ -78,4 +78,3 @@
   community.general.ufw:
     state: enabled
   notify: Reload UFW
-

--- a/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
@@ -32,6 +32,24 @@
   delegate_to: localhost
   become: false
 
+- name: Assert Flux GitHub repository settings are set
+  ansible.builtin.assert:
+    that:
+      - flux_github_owner is defined
+      - flux_github_owner | length > 0
+      - flux_github_repo is defined
+      - flux_github_repo | length > 0
+      - flux_git_branch is defined
+      - flux_git_branch | length > 0
+    fail_msg: >-
+      Flux GitHub settings are incomplete. Set flux_github_owner,
+      flux_github_repo, and flux_git_branch in
+      inventory/group_vars/all.yml or host/group vars before running
+      bootstrap-flux.yml.
+    quiet: true
+  delegate_to: localhost
+  become: false
+
 - name: Check that kubeconfig exists on controller
   ansible.builtin.stat:
     path: "{{ flux_kubeconfig }}"
@@ -175,7 +193,7 @@
 
 # ─── flux-system namespace ────────────────────────────────────────────────────
 
-- name: Check if {{ sops_secret_namespace }} namespace exists
+- name: Check if SOPS secret namespace exists
   ansible.builtin.command: >
     kubectl --kubeconfig={{ flux_kubeconfig }} get namespace {{ sops_secret_namespace }}
   register: flux_ns_check
@@ -184,7 +202,7 @@
   delegate_to: localhost
   become: false
 
-- name: Create {{ sops_secret_namespace }} namespace (pre-created so sops-age Secret can be added before bootstrap)
+- name: Create SOPS secret namespace before bootstrap
   ansible.builtin.command: >
     kubectl --kubeconfig={{ flux_kubeconfig }} create namespace {{ sops_secret_namespace }}
   when: flux_ns_check.rc != 0
@@ -201,6 +219,15 @@
   register: sops_secret_check
   changed_when: false
   failed_when: false
+  delegate_to: localhost
+  become: false
+
+- name: Ensure age key parent directory exists
+  ansible.builtin.file:
+    path: "{{ age_key_file | dirname }}"
+    state: directory
+    mode: "0700"
+  when: sops_secret_check.rc != 0
   delegate_to: localhost
   become: false
 
@@ -244,7 +271,7 @@
       - "════════════════════════════════════════════════════════════════"
       - "Age key generated and stored as Secret {{ sops_secret_name }} in {{ sops_secret_namespace }}."
       - ""
-      - "Public key (add to k3s/.sops.yaml creation_rules):"
+      - "Public key (add to .sops.yaml creation_rules):"
       - "  {{ age_pubkey_line.stdout | regex_replace('# public key: ', '') }}"
       - ""
       - "Private key file: {{ age_key_file }}"
@@ -258,6 +285,17 @@
 
 # ─── Flux Bootstrap ───────────────────────────────────────────────────────────
 
+- name: Check if Flux controllers are already installed
+  ansible.builtin.command: >
+    kubectl --kubeconfig={{ flux_kubeconfig }}
+    get deployment source-controller kustomize-controller helm-controller notification-controller
+    -n flux-system
+  register: flux_controllers_check
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+  become: false
+
 - name: Bootstrap Flux CD via GitHub
   ansible.builtin.command: >
     {{ flux_install_dir }}/flux bootstrap github
@@ -270,7 +308,11 @@
     --token-auth
   environment:
     GITHUB_TOKEN: "{{ flux_github_token }}"
-  changed_when: true
+  changed_when: >
+    flux_controllers_check.rc != 0 or
+    'committed' in ((flux_bootstrap_result.stdout | default('')) ~ (flux_bootstrap_result.stderr | default(''))) or
+    'pushed' in ((flux_bootstrap_result.stdout | default('')) ~ (flux_bootstrap_result.stderr | default(''))) or
+    'installing components' in ((flux_bootstrap_result.stdout | default('')) ~ (flux_bootstrap_result.stderr | default('')))
   register: flux_bootstrap_result
   delegate_to: localhost
   become: false

--- a/k3s/bootstrap/ansible/roles/k3s-prereqs/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-prereqs/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: Disable swap immediately
   ansible.builtin.command: swapoff -a
+  changed_when: true
   when: k3s_active_swaps.stdout_lines | length > 1
 
 - name: Remove swap entries from /etc/fstab


### PR DESCRIPTION
## Summary
- add guardrails to the Flux bootstrap role for required GitHub settings and age key directory creation
- document Flux bootstrap as implemented instead of a stub across README, BOOTSTRAP, and AGENTS guidance
- add ansible-lint to bootstrap prerequisites and fix lint findings in Ansible roles

## Validation
- ansible-playbook --syntax-check -i inventory/hosts.yml playbooks/bootstrap-flux.yml
- ansible-playbook --syntax-check -i inventory/hosts.yml playbooks/site.yml
- ansible-lint playbooks/bootstrap-flux.yml
- ansible-lint playbooks/site.yml
- git diff --check