### PR TITLE
feat(authentik): Deploy Authentik SSO with K3s Flux GitOps

### DIFF
--- a/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
+++ b/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:aYg=,iv:ZPJDWiLWWexAHtT4oJrN9Ys8zFb6V95Qz8oB6EK3GLg=,tag:EvQQMruJciNN4J0jgSJbZg==,type:str]
+kind: ENC[AES256_GCM,data:kEWPy2p0,iv:31XFm86VSHlLkixBrTe7KN8pdF4RqP+YwKgy+yX+7CQ=,tag:UBnQLXV+QQ1vgGK767L7Zw==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:ohA89kVcZt+a5aMV9BxOD55Jn1o=,iv:vzZoaitOVmIMqFUfFPwTCUPPL6UxvLM/MtHCSSVzI0Y=,tag:5lFXR8K07/Tzmkg+RHn0fQ==,type:str]
+    namespace: ENC[AES256_GCM,data:7F96Ii1D2qY=,iv:gVATdgMjg/PQfbWTH/5sid1m2Zs4NCpRGnyRCvPXVeQ=,tag:hQQuX3Ow4eRq7bvqk/a4sQ==,type:str]
+stringData:
+    HEADLAMP_CONFIG_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:XfxjIpaTK4gn/3n8NWhJXp09wR7j8YH2/LuG1pNuUgE=,iv:wd4nz9gz+LUhKLC7nhDe4fp7VtiqgCaf5PSjh+Zy3AM=,tag:V+VaCHY43yOPO5XxckCGaw==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlS1hSaUV0MjFlV1hPb0lD
+            cmxidmM2VklzM2RPZGlvdnZjNzFjMmZCZGgwCmQzTUIzLzlmd1hUNGdvVGdvNXdO
+            SFlONSs1S2QzOVNWRGZ1bW0zTDlhLzQKLS0tIFNsUGZXcE5ncWxRY0Z4dWtXVXZD
+            VGtncEtuYXA3YTRRNU1hL2NnWVZjR2MKV2dTqu69K3BkIfq0yNSA5uJN+B/IjQl+
+            YiRQSdR4RWZCni18ICfO97fbhizsjIqzX3e2s5rIl55zDAmdx30Fmg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-09T19:37:09Z"
+    mac: ENC[AES256_GCM,data:WmGVdsfzj5nd4/RXLc1olNPxBFRFoJg5lNxCytS//mTzYbHxcNUUS4H7A7MiAuojGhsVaDF2rgaA8uv6vsQsLEKQ0XHmK4nxhGDJftBAvY5yLBorsweUqgTaJwLWVxPaq3B6bpoiD2ysZBYFgcXD3daM1btB9k1bHxUo7migP3g=,iv:GtFxTy26XB00ORKK/YcOAKY7MiSPYraTU6EOsgui5lE=,tag:6LIDHrV2anD9lv/8X8vtWw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -49,10 +49,6 @@ spec:
         clientID: headlamp
         issuerURL: https://auth.homelab.properties/application/o/headlamp/
         scopes: openid email profile
-    env:
-      HEADLAMP_CONFIG_OIDC_CLIENT_ID: headlamp
-      HEADLAMP_CONFIG_OIDC_ISSUER_URL: https://auth.homelab.properties/application/o/headlamp/
-      HEADLAMP_CONFIG_OIDC_SCOPES: openid email profile
     envFrom:
       - secretRef:
           name: headlamp-oidc-secret

--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
       clusterRoleName: cluster-admin
     initContainers:
       - name: headlamp-plugins
-        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.6.0
         imagePullPolicy: Always
         command:
           - /bin/sh
@@ -75,7 +75,7 @@ spec:
           - mountPath: /build/plugins
             name: headlamp-plugins
       - name: headlamp-plugins-cert-manager
-        image: ghcr.io/headlamp-k8s/headlamp-plugin-cert-manager:latest
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-cert-manager:v0.1.0
         imagePullPolicy: Always
         command:
           - /bin/sh

--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -45,6 +45,17 @@ spec:
     config:
       inCluster: true
       pluginsDir: /build/plugins
+      oidc:
+        clientID: headlamp
+        issuerURL: https://auth.homelab.properties/application/o/headlamp/
+        scopes: openid email profile
+    env:
+      HEADLAMP_CONFIG_OIDC_CLIENT_ID: headlamp
+      HEADLAMP_CONFIG_OIDC_ISSUER_URL: https://auth.homelab.properties/application/o/headlamp/
+      HEADLAMP_CONFIG_OIDC_SCOPES: openid email profile
+    envFrom:
+      - secretRef:
+          name: headlamp-oidc-secret
     clusterRoleBinding:
       clusterRoleName: cluster-admin
     initContainers:

--- a/k3s/applications/headlamp/kustomization.yaml
+++ b/k3s/applications/headlamp/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - servicemonitor.yaml
+  - headlamp-oidc-secret.sops.yaml

--- a/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
+++ b/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
@@ -1,0 +1,29 @@
+apiVersion: ENC[AES256_GCM,data:04k=,iv:dsda42iHnzuRNNfErbyAf93k5hoD7dm/BNgbeW/uPM4=,tag:0743OlJac8gu2BwzSCkCEg==,type:str]
+kind: ENC[AES256_GCM,data:IkD8paqO,iv:JjhVEtEZGt6Ijae8UVfqtDN4NDWArqvIIuy0H8UUEgw=,tag:WgwVC29FpVyGUcYGaebWZQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:B+/+WZ/ddLx04AtHkxZEQQ==,iv:pEu4AM7MJ/X8e4PHdf+4ZIGWNpWG2AjIhJHSciOPEC0=,tag:cjDzUPBaJpGZW3N0gQfogg==,type:str]
+    namespace: ENC[AES256_GCM,data:WfW39iK/yKe8,iv:YxU39w1SZcnqfd15bIi5fS9ANQNkvqxq9/B+CjtI/uA=,tag:Mcfhyh++B3AWJh9mDewjpA==,type:str]
+stringData:
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:dGqibun2KEyaBCai7Xpm5tHuMi2TwBjO/U8baUsYN1cnK+K2iVxe4rSWaoSzIeBWhkY=,iv:wz+I4s6UxdbSmqa2zAlMizLv0UWK/5qUrCzcs1+ga9A=,tag:CWg5cClZSzUAYo5NrJUhWg==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:b//FwhM49n1jA6OYbUqq+D6ETRUBwj3d,iv:QAjluTRx8ESmC0NeMQ3eyNTcENKgPVUgqzkx/F/XaHo=,tag:7jKOF6HZQKfTSEdnMK2BWg==,type:str]
+    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:F3WRrOY5grSIweYqNHCjGvmFauwzRAlC+6M0pH5teqg2PERDi9jfJg==,iv:JJq0N8HkU1Vef1IB9XSWlzMzboy28t7fOmVf7gaEfhY=,tag:U0y+MYplYMIDSA11jUXxww==,type:str]
+    postgresql-password: ENC[AES256_GCM,data:36daa5SThqqR9/oQv/8RInIubZlG6bLlsROosG8YA9s=,iv:ivZaNvmlcC0qSxVei70p/qN3dXN2TVG0pbd14iBu38M=,tag:J57ZxGEr+5EbniyoVlw6iQ==,type:str]
+    redis-password: ENC[AES256_GCM,data:AqYpLtlt49idecW+mkES02Jp+U76kE9KJpolhbMTXPM=,iv:QNB7qq9eNO7jaWL0CdhxF0BDmRAlgrkdO+bPC0/5DHQ=,tag:ZLIFFtzpiuz/ZXi8kYFXlg==,type:str]
+    grafana-oidc-client-secret: ENC[AES256_GCM,data:PCFMGlwPqWsTE2aHkL7mgdZVDSyRUc5Hnq9rW69pxm0=,iv:+ASCWnqRv455q3eXH/TNo6eJM1jnREcfCWbr/G7c0xQ=,tag:/GPFoxUa29Hd6/fxRs4oUg==,type:str]
+    headlamp-oidc-client-secret: ENC[AES256_GCM,data:TSu5wOQLWZT9pjDwkjKpiuM+CfN93vYNDsNV0kff++E=,iv:3hshuJuu2SVPbqZvhEscwKUp7Vju1tuOLATmYjOSw3E=,tag:PfLyr6BnNVAxaogX6vZ4Ig==,type:str]
+    outpost-token: ENC[AES256_GCM,data:mHuEzJBrrWn8O1D0VMHaDbFIbaj1HbCN+pu4zIEWHml27JrJ7ul+EQ==,iv:Vv7x+1JG1PAmnhtkFeEfylOJbqzBJ22PxM/oIg2lx8Q=,tag:pWqLeXjFx9/3UOzEVA9tXA==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRN2tjT3NPUHVkNTRnTDZP
+            NFllczVYU0dXQ3llYWpkRlJWQ0YwNnVmem5ZCm4zeVJCM0dNcnVMMFNnMDJZN0lt
+            LzhQdlQ4TlRhVFBqTTFnaUxEWVl6TFEKLS0tIDUzbXJKMWVrUlhjUUxqemllTkJS
+            WERVdk1rMkdEa1dsWHFVa3d2eWNDZzgKwCd9g72JY5/22KzAaB3JBCd2OW0Rcp+7
+            D7JJnuTBmI0dde9ZVa83AH1JqZQD6+2pRX0e0lnY08uU7QFULBKojQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-09T19:26:55Z"
+    mac: ENC[AES256_GCM,data:Hatf4xYRGyKiVakfwL442ISitr79P4qMpbwSo7UtPNZkslioN/Tdg+YKt4OSwUSDAHD9jcthRlU7zXxzkFkrYDY3VNqIMZmztaFbsdLbr+0dC5Di0mDIa5KLZebBx2jAgc5F8ahB5cK50sZDKGeKiLa7snr9S23V8Ml7K+XzQsg=,iv:GzVGJVqCwi0TbC6XFIX+FEMJ0hDUAFGpFOEOQRAEqwY=,tag:As1fY4bH7EG+X2xnmgZrag==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprints
+  namespace: authentik
+data:
+  groups.yaml: |
+    version: 1
+    metadata:
+      name: "Homelab Groups"
+    entries:
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: homelab-admins
+        attrs:
+          name: homelab-admins
+  grafana-provider.yaml: |
+    version: 1
+    metadata:
+      name: "Grafana OIDC Provider"
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        state: present
+        identifiers:
+          name: grafana-provider
+        attrs:
+          name: grafana-provider
+          client_type: confidential
+          client_id: grafana
+          client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          redirect_uris: "https://grafana.homelab.properties/login/generic_oauth"
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: grafana
+        attrs:
+          name: Grafana
+          slug: grafana
+          provider: !Find [authentik_providers_oauth2.oauth2provider, [name, grafana-provider]]
+  headlamp-provider.yaml: |
+    version: 1
+    metadata:
+      name: "Headlamp OIDC Provider"
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        state: present
+        identifiers:
+          name: headlamp-provider
+        attrs:
+          name: headlamp-provider
+          client_type: confidential
+          client_id: headlamp
+          client_secret: !Env HEADLAMP_OIDC_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          redirect_uris: "https://headlamp.homelab.properties/oidc-callback"
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: headlamp
+        attrs:
+          name: Headlamp
+          slug: headlamp
+          provider: !Find [authentik_providers_oauth2.oauth2provider, [name, headlamp-provider]]
+  proxy-providers.yaml: |
+    version: 1
+    metadata:
+      name: "Proxy Providers"
+    entries:
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: prometheus-provider
+        attrs:
+          name: prometheus-provider
+          mode: forward_single
+          external_host: https://prometheus.homelab.properties
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: prometheus
+        attrs:
+          name: Prometheus
+          slug: prometheus
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-provider]]
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: alertmanager-provider
+        attrs:
+          name: alertmanager-provider
+          mode: forward_single
+          external_host: https://alertmanager.homelab.properties
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: alertmanager
+        attrs:
+          name: Alertmanager
+          slug: alertmanager
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-provider]]
+  outpost.yaml: |
+    version: 1
+    metadata:
+      name: "Proxy Outpost"
+    entries:
+      - model: authentik_core.token
+        state: present
+        identifiers:
+          identifier: outpost-token
+        attrs:
+          identifier: outpost-token
+          key: !Env OUTPOST_TOKEN
+          intent: api
+          user: !Find [authentik_core.user, [username, akadmin]]
+      - model: authentik_outposts.outpost
+        state: present
+        identifiers:
+          name: homelab-proxy-outpost
+        attrs:
+          name: homelab-proxy-outpost
+          type: proxy
+          token: !Find [authentik_core.token, [identifier, outpost-token]]
+          providers:
+            - !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-provider]]
+          config:
+            authentik_host: https://auth.homelab.properties
+            authentik_host_insecure: false

--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik
+  namespace: authentik
+spec:
+  interval: 1h
+  timeout: 15m
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: authentik
+      version: "2026.2.2"
+      sourceRef:
+        kind: HelmRepository
+        name: authentik
+        namespace: authentik
+      interval: 12h
+  valuesFrom:
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: AUTHENTIK_SECRET_KEY
+      targetPath: authentik.secret_key
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: AUTHENTIK_BOOTSTRAP_PASSWORD
+      targetPath: authentik.bootstrap.password
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: AUTHENTIK_BOOTSTRAP_TOKEN
+      targetPath: authentik.bootstrap.token
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: postgresql-password
+      targetPath: postgresql.auth.password
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: redis-password
+      targetPath: redis.auth.password
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: grafana-oidc-client-secret
+      targetPath: authentik.env.GRAFANA_OIDC_CLIENT_SECRET
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: headlamp-oidc-client-secret
+      targetPath: authentik.env.HEADLAMP_OIDC_CLIENT_SECRET
+    - kind: Secret
+      name: authentik-secret
+      valuesKey: outpost-token
+      targetPath: authentik.env.OUTPOST_TOKEN
+  values:
+    authentik:
+      postgresql:
+        host: "authentik-postgresql"
+        name: authentik
+        user: authentik
+      redis:
+        host: "authentik-redis-master"
+
+    postgresql:
+      enabled: true
+      auth:
+        username: authentik
+        database: authentik
+      primary:
+        persistence:
+          size: 2Gi
+          storageClass: local-path
+
+    redis:
+      enabled: true
+      auth:
+        enabled: true
+      master:
+        persistence:
+          size: 512Mi
+          storageClass: local-path
+
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+      hosts:
+        - host: auth.homelab.properties
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: authentik-tls
+          hosts:
+            - auth.homelab.properties
+
+    server:
+      extraVolumes:
+        - name: custom-blueprints
+          configMap:
+            name: authentik-blueprints
+      extraVolumeMounts:
+        - name: custom-blueprints
+          mountPath: /blueprints/custom
+
+    worker:
+      extraVolumes:
+        - name: custom-blueprints
+          configMap:
+            name: authentik-blueprints
+      extraVolumeMounts:
+        - name: custom-blueprints
+          mountPath: /blueprints/custom

--- a/k3s/infrastructure/configs/authentik/helmrepository.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: authentik
+  namespace: authentik
+spec:
+  interval: 24h
+  url: https://charts.goauthentik.io

--- a/k3s/infrastructure/configs/authentik/kustomization.yaml
+++ b/k3s/infrastructure/configs/authentik/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - grafana-secret.sops.yaml
-  - grafana-oidc-secret.sops.yaml
   - helmrepository.yaml
   - helmrelease.yaml
-  - authentik-middleware.yaml
+  - authentik-secret.sops.yaml
+  - outpost-deployment.yaml
+  - blueprints-configmap.yaml

--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-outpost
+  namespace: authentik
+  labels:
+    app: authentik-outpost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authentik-outpost
+  template:
+    metadata:
+      labels:
+        app: authentik-outpost
+    spec:
+      containers:
+        - name: proxy
+          image: ghcr.io/goauthentik/proxy:2026.2.2
+          env:
+            - name: AUTHENTIK_HOST
+              value: "https://auth.homelab.properties"
+            - name: AUTHENTIK_INSECURE
+              value: "false"
+            - name: AUTHENTIK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: authentik-secret
+                  key: outpost-token
+          ports:
+            - containerPort: 9000
+              name: http
+            - containerPort: 9443
+              name: https
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-outpost
+  namespace: authentik
+spec:
+  selector:
+    app: authentik-outpost
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+    - name: https
+      port: 9443
+      targetPort: 9443

--- a/k3s/infrastructure/configs/kustomization.yaml
+++ b/k3s/infrastructure/configs/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - metallb
   - cert-manager
   - monitoring
+  - authentik

--- a/k3s/infrastructure/configs/monitoring/authentik-middleware.yaml
+++ b/k3s/infrastructure/configs/monitoring/authentik-middleware.yaml
@@ -1,0 +1,21 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-forwardauth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://authentik-outpost.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/traefik
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-authentik-username
+      - X-authentik-groups
+      - X-authentik-email
+      - X-authentik-name
+      - X-authentik-uid
+      - X-authentik-jwt
+      - X-authentik-meta-jwks
+      - X-authentik-meta-outpost
+      - X-authentik-meta-provider
+      - X-authentik-meta-app
+      - X-authentik-meta-version

--- a/k3s/infrastructure/configs/monitoring/grafana-oidc-secret.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafana-oidc-secret.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:YEU=,iv:MBNwU17q49ycuBRPNHNQXliJb2eYNkmB0APtQMew3V4=,tag:O1WSi4p0V1OCHH1OElbxUQ==,type:str]
+kind: ENC[AES256_GCM,data:XW7liDP+,iv:morEyC12sidpHGqU9YR1yCoz7OA/Z5KiKA+oZDmwl8k=,tag:rJzFsBzNqTn+fIy7dY0iWA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:fTzpFGJ4TX+YOqhFHb13pWmCSA==,iv:8F36pAMduM0Z7b1kQbUWsTSYabxEuiFd1ObkA2KTxjI=,tag:uovjsew2K55ki5a9m7OaYg==,type:str]
+    namespace: ENC[AES256_GCM,data:3nYYpcCMgOuiBQ==,iv:sI/T07gUuhhDxxNAyiBT5pqRl5DfKtSNZgeNZBGfNns=,tag:1HHqSM5aD+oyo3eVZZ1cOg==,type:str]
+stringData:
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:yi36QuVmIoPW8Qgdw1AR1r2HLmQkjud4BmTdF1oWX70=,iv:JWhUhWISQfy0wb1rNuA4SGmDgwPlohG2i+ItWRv/cDk=,tag:dVgw6thgPxfrIx4Ui84yqQ==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzeDZKK09SWFBTbjNZcWpG
+            Um5kaHk2UitWUGNZNVVYZzZFQXB0alNNc1RjCkxuV0syVEIwZ09aRTg1Wm5LaWs0
+            RWNUbnEvK25zaXVzd043SnhVYkVsd2MKLS0tIElEWWNrcmRtSjVmT0NGTTdMekht
+            Sm5CUFBRMkpCTUJHT3F3cklDWDBHaWcKhH/JmuXEbDvfBKV0J3p2uD9ETrj2BVln
+            XWhmn1WTqAHMTCSdmAaBlDuSzrEVPsSvw0jK0jXGfsj8W0jSx9FC2g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-09T19:37:32Z"
+    mac: ENC[AES256_GCM,data:v8+JbvDI7mCcJHX/JWVFuOPu4xiZM8betVov2v9NMFrRQgu1tebmGKvuWpAYp0hbOYFdyQKv4njnljVV/jd2Vmrdk21PN8RxeipapaGDgFjAxjSTHY2bmzfQmgA6V613Lc/NdkkIG5huhn3VrNW6eu6n8drCaCQO9dUqfISIbYo=,iv:UlJm58EB9a/zA2sk8G3YpmE54TeVAZM/0KGVUhj8/8I=,tag:onKPWAF6zHXcwAF+TCoFsQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -77,6 +77,7 @@ spec:
         ingressClassName: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-prod
+          traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
         hosts:
           - prometheus.homelab.properties
         tls:
@@ -106,6 +107,7 @@ spec:
         ingressClassName: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-prod
+          traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
         hosts:
           - alertmanager.homelab.properties
         tls:
@@ -115,6 +117,19 @@ spec:
 
     # Grafana: SOPS-backed secret, persistent storage
     grafana:
+      envFromSecret: grafana-oidc-secret
+      grafana.ini:
+        auth.generic_oauth:
+          enabled: true
+          name: Authentik
+          allow_sign_up: true
+          client_id: grafana
+          client_secret: $__env{GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}
+          scopes: openid email profile
+          auth_url: https://auth.homelab.properties/application/o/authorize/
+          token_url: https://auth.homelab.properties/application/o/token/
+          api_url: https://auth.homelab.properties/application/o/userinfo/
+          role_attribute_path: "contains(groups[*], 'homelab-admins') && 'Admin' || 'Viewer'"
       admin:
         existingSecret: grafana-admin-secret
         userKey: admin-user

--- a/k3s/platform/namespaces/authentik.yaml
+++ b/k3s/platform/namespaces/authentik.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authentik

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cert-manager.yaml
   - monitoring.yaml
   - pihole.yaml
+  - authentik.yaml


### PR DESCRIPTION
## Summary

This PR deploys Authentik as the SSO provider for the homelab K3s cluster using Flux GitOps.

### Changes

- **Authentik deployment** (`k3s/infrastructure/configs/authentik/`): HelmRelease, SOPS-encrypted secrets, blueprints for OIDC providers
- **Platform namespace** (`k3s/platform/namespaces/authentik.yaml`): Authentik namespace definition
- **Monitoring integration**: Authentik middleware for Grafana OIDC authentication
- **Headlamp OIDC** (`k3s/applications/headlamp/`): SOPS-encrypted OIDC client secret + HelmRelease OIDC config pointing to `auth.homelab.properties`

### OIDC Configuration (Headlamp)

- Issuer URL: `https://auth.homelab.properties/application/o/headlamp/`
- Client ID: `headlamp`
- Secret: stored in `headlamp-oidc-secret.sops.yaml` (SOPS/age encrypted)
- Env vars injected via `envFrom` referencing the Kubernetes secret

### Verification

```bash
kubectl kustomize k3s/applications/headlamp/ | grep -i oidc
grep "ENC[AES256_GCM" k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
```