### PR TITLE
fix(authentik): move ingress to server.ingress (deprecated key in 2026.2.x chart)

### DIFF
--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -84,23 +84,19 @@ spec:
           size: 512Mi
           storageClass: local-path
 
-    ingress:
-      enabled: true
-      ingressClassName: traefik
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-prod
-        traefik.ingress.kubernetes.io/router.entrypoints: websecure
-      hosts:
-        - host: auth.homelab.properties
-          paths:
-            - path: /
-              pathType: Prefix
-      tls:
-        - secretName: authentik-tls
-          hosts:
-            - auth.homelab.properties
-
     server:
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - auth.homelab.properties
+        tls:
+          - secretName: authentik-tls
+            hosts:
+              - auth.homelab.properties
       extraVolumes:
         - name: custom-blueprints
           configMap:


### PR DESCRIPTION
## Summary

- Authentik HelmRelease was using the deprecated top-level `ingress:` key, causing Helm install to fail with: `ingress is deprecated. See the release notes for a list of changes.`
- Moved ingress configuration from `ingress:` to `server.ingress:` per the 2026.2.x chart migration
- Merged the ingress block into the existing `server:` block (alongside `extraVolumes`/`extraVolumeMounts` for blueprints)

## No functional changes
Same host (`auth.homelab.properties`), same TLS secret, same annotations, same ingressClassName — only the YAML key path changed.