### PR TITLE
fix(grafana): disable initChownData to prevent chown permission errors on existing PV

### DIFF
--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -117,6 +117,8 @@ spec:
 
     # Grafana: SOPS-backed secret, persistent storage
     grafana:
+      initChownData:
+        enabled: false
       envFromSecret: grafana-oidc-secret
       grafana.ini:
         auth.generic_oauth:


### PR DESCRIPTION
## Problem

After merging the Authentik OIDC configuration changes (PR #29), the kube-prometheus-stack Grafana upgrade fails because the `init-chown-data` init container gets `Permission denied` when trying to chown existing data directories:

```
chown: /var/lib/grafana/pdf: Permission denied
chown: /var/lib/grafana/csv: Permission denied
chown: /var/lib/grafana/png: Permission denied
```

## Root Cause

The directories `pdf`, `csv`, and `png` under `/var/lib/grafana` have permissions `drwx--S---` (700 + setgid, owned by `grafana:472`). The `init-chown-data` container (runAsUser: 0, CAP_CHOWN, RuntimeDefault seccomp) cannot chown them — the RuntimeDefault seccomp profile on K3s/containerd restricts the operation in this context.

## Fix

Disable the `initChownData` init container via:

```yaml
grafana:
  initChownData:
    enabled: false
```

This is safe because the existing Grafana PV data is already correctly owned by `grafana:472`. The init container's only purpose is to set ownership on first deploy; subsequent upgrades don't need it.