### PR TITLE
fix(authentik): use correct chart keys for blueprint ConfigMap volume mount

### DIFF
--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -105,19 +105,12 @@ spec:
           - secretName: authentik-tls
             hosts:
               - auth.homelab.properties
-      extraVolumes:
-        - name: custom-blueprints
-          configMap:
-            name: authentik-blueprints
-      extraVolumeMounts:
-        - name: custom-blueprints
-          mountPath: /blueprints/custom
 
     worker:
-      extraVolumes:
+      volumes:
         - name: custom-blueprints
           configMap:
             name: authentik-blueprints
-      extraVolumeMounts:
+      volumeMounts:
         - name: custom-blueprints
           mountPath: /blueprints/custom


### PR DESCRIPTION
## Problem

Custom blueprints (homelab-admins group, OIDC providers, outpost) were never applied because the blueprint ConfigMap was never mounted into the worker pod.

Root cause: the Authentik Helm chart uses `worker.volumes`/`worker.volumeMounts`, **not** `worker.extraVolumes`/`worker.extraVolumeMounts`. The initial manifests used the wrong keys so the ConfigMap volume was silently ignored.

## Fix

- `server.extraVolumes`/`server.extraVolumeMounts` → removed (server doesn't process blueprints)
- `worker.extraVolumes` → `worker.volumes`
- `worker.extraVolumeMounts` → `worker.volumeMounts`

## Expected result after merge

After Flux reconciles (triggering a Helm upgrade), the worker pod will have `/blueprints/custom` mounted with all 5 blueprint files. Authentik will apply them on the next blueprint scan cycle, creating:
- `homelab-admins` group
- Grafana OIDC provider
- Headlamp OIDC provider  
- Proxy providers for Prometheus + Alertmanager
- Outpost token record