### PR TITLE
fix(authentik): update blueprints for 2026.2.x API changes

### DIFF
--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -30,7 +30,10 @@ data:
           client_id: grafana
           client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          redirect_uris: "https://grafana.homelab.properties/login/generic_oauth"
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          redirect_uris:
+            - matching_mode: strict
+              url: "https://grafana.homelab.properties/login/generic_oauth"
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
       - model: authentik_core.application
         state: present
@@ -55,7 +58,10 @@ data:
           client_id: headlamp
           client_secret: !Env HEADLAMP_OIDC_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          redirect_uris: "https://headlamp.homelab.properties/oidc-callback"
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          redirect_uris:
+            - matching_mode: strict
+              url: "https://headlamp.homelab.properties/oidc-callback"
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
       - model: authentik_core.application
         state: present
@@ -68,7 +74,7 @@ data:
   proxy-providers.yaml: |
     version: 1
     metadata:
-      name: "Proxy Providers"
+      name: "Proxy Providers and Outpost"
     entries:
       - model: authentik_providers_proxy.proxyprovider
         state: present
@@ -79,6 +85,7 @@ data:
           mode: forward_single
           external_host: https://prometheus.homelab.properties
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
       - model: authentik_core.application
         state: present
         identifiers:
@@ -96,6 +103,7 @@ data:
           mode: forward_single
           external_host: https://alertmanager.homelab.properties
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
       - model: authentik_core.application
         state: present
         identifiers:
@@ -104,11 +112,6 @@ data:
           name: Alertmanager
           slug: alertmanager
           provider: !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-provider]]
-  outpost.yaml: |
-    version: 1
-    metadata:
-      name: "Proxy Outpost"
-    entries:
       - model: authentik_core.token
         state: present
         identifiers:


### PR DESCRIPTION
## Summary

- **`invalidation_flow` required**: Authentik 2026.2.x added `invalidation_flow` as a required field on OAuth2 providers (`oauth2provider`) and proxy providers (`proxyprovider`). All 4 provider blueprints updated.
- **`redirect_uris` format changed**: The field now expects a list of `{matching_mode, url}` objects instead of a plain string. Fixed for `grafana-provider` and `headlamp-provider`.
- **Outpost ordering fix**: Blueprint files are applied alphabetically. `outpost.yaml` (`o`) was applied before `proxy-providers.yaml` (`p`), causing `Invalid pk "None"` because providers didn't exist yet. Merged outpost content into `proxy-providers.yaml` so all providers and the outpost are created in a single atomic blueprint.

## Changes

- `k3s/infrastructure/configs/authentik/blueprints-configmap.yaml`
  - Added `invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]` to all providers
  - Changed `redirect_uris` from string to list format in grafana/headlamp providers
  - Merged `outpost.yaml` content into end of `proxy-providers.yaml` (now named "Proxy Providers and Outpost")
  - Removed separate `outpost.yaml` data key