### PR TITLE
fix(authentik): use correct AUTHENTIK_ENV__ prefix for !Env blueprint tags

### DIFF
--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -28,7 +28,7 @@ data:
           name: grafana-provider
           client_type: confidential
           client_id: grafana
-          client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET
+          client_secret: !Env AUTHENTIK_ENV__GRAFANA_OIDC_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           redirect_uris:
@@ -56,7 +56,7 @@ data:
           name: headlamp-provider
           client_type: confidential
           client_id: headlamp
-          client_secret: !Env HEADLAMP_OIDC_CLIENT_SECRET
+          client_secret: !Env AUTHENTIK_ENV__HEADLAMP_OIDC_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           redirect_uris:


### PR DESCRIPTION
## Summary
- Fix `!Env` references in grafana-provider and headlamp-provider blueprints
- The Authentik Helm chart injects env vars with `AUTHENTIK_ENV__` prefix via `authentik.env.*` values
- Blueprints were calling `!Env GRAFANA_OIDC_CLIENT_SECRET` but pod has `AUTHENTIK_ENV__GRAFANA_OIDC_CLIENT_SECRET`
- Caused `client_secret: null` → blueprint validation failure