### PR TITLE
fix(auth): fix outpost DNS, Grafana root_url, and Headlamp client secret key

### DIFF
--- a/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
+++ b/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:aYg=,iv:ZPJDWiLWWexAHtT4oJrN9Ys8zFb6V95Qz8oB6EK3GLg=,tag:EvQQMruJciNN4J0jgSJbZg==,type:str]
-kind: ENC[AES256_GCM,data:kEWPy2p0,iv:31XFm86VSHlLkixBrTe7KN8pdF4RqP+YwKgy+yX+7CQ=,tag:UBnQLXV+QQ1vgGK767L7Zw==,type:str]
+apiVersion: ENC[AES256_GCM,data:vfs=,iv:n4bGkChHFOGQU/Sw8mK+Gx2tYRtTVre8uVo3FHjy0Ak=,tag:XfBOoPLwH7eQ7i0m67YHPw==,type:str]
+kind: ENC[AES256_GCM,data:lAtBp7kP,iv:QFhwXTVxleuxNSYfIR6sFoTNSbJqLn+fjR4QMFrkUfA=,tag:PXl+Dds9y6DFhJkTbC3c6Q==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:ohA89kVcZt+a5aMV9BxOD55Jn1o=,iv:vzZoaitOVmIMqFUfFPwTCUPPL6UxvLM/MtHCSSVzI0Y=,tag:5lFXR8K07/Tzmkg+RHn0fQ==,type:str]
-    namespace: ENC[AES256_GCM,data:7F96Ii1D2qY=,iv:gVATdgMjg/PQfbWTH/5sid1m2Zs4NCpRGnyRCvPXVeQ=,tag:hQQuX3Ow4eRq7bvqk/a4sQ==,type:str]
+    name: ENC[AES256_GCM,data:qPvKutibT5sQuO03/9CqOT1dOb0=,iv:Raxo39Cw0d8SixXGPqHgBCBSVAEji4eFen3t46oGRNE=,tag:nUGsGTOCoz5sXuZakWTryA==,type:str]
+    namespace: ENC[AES256_GCM,data:NfQ+LMMoOBY=,iv:GBlw2DE9lJ9d3Yaf9L1TtP8o6jhboZCtIqqUIejlYt0=,tag:8+1IQwW1gA5pxT8dw01pxw==,type:str]
 stringData:
-    HEADLAMP_CONFIG_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:XfxjIpaTK4gn/3n8NWhJXp09wR7j8YH2/LuG1pNuUgE=,iv:wd4nz9gz+LUhKLC7nhDe4fp7VtiqgCaf5PSjh+Zy3AM=,tag:V+VaCHY43yOPO5XxckCGaw==,type:str]
+    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:N77rXdfedu1vuFs30GOJZDJjCbdRPl0D+XqPgp83soI=,iv:X0QSb5wZApTPmt4NqxkLPCZpvag0tbKEheclqn6fiWk=,tag:pWpA3BzJPQTbJ2rY/SwqpA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlS1hSaUV0MjFlV1hPb0lD
-            cmxidmM2VklzM2RPZGlvdnZjNzFjMmZCZGgwCmQzTUIzLzlmd1hUNGdvVGdvNXdO
-            SFlONSs1S2QzOVNWRGZ1bW0zTDlhLzQKLS0tIFNsUGZXcE5ncWxRY0Z4dWtXVXZD
-            VGtncEtuYXA3YTRRNU1hL2NnWVZjR2MKV2dTqu69K3BkIfq0yNSA5uJN+B/IjQl+
-            YiRQSdR4RWZCni18ICfO97fbhizsjIqzX3e2s5rIl55zDAmdx30Fmg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGTlJ5dE5YWXFjME5BVVpi
+            WWkyNTRCMVFvUERUb3kyd2lZY3lHN0xxM3djCkJ3MVVvc2FXQnFXR1l3ampOVXBh
+            djA3YkZCZHdMYUlQL2JJSXp1R0k3cm8KLS0tIEsyRnNPL3FoY3RmTllRaXByMDFu
+            M0Z3UzdGUWI1Ri9pVGt4ajdsV1d3WFkKE2WgAn6QH+VNViYiF2TKhx7Qdnpui77y
+            ypogC8xj4doLbUZun9OlJezUoDchraNs59qvrFlQhIGFb+aqcGIcGg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-09T19:37:09Z"
-    mac: ENC[AES256_GCM,data:WmGVdsfzj5nd4/RXLc1olNPxBFRFoJg5lNxCytS//mTzYbHxcNUUS4H7A7MiAuojGhsVaDF2rgaA8uv6vsQsLEKQ0XHmK4nxhGDJftBAvY5yLBorsweUqgTaJwLWVxPaq3B6bpoiD2ysZBYFgcXD3daM1btB9k1bHxUo7migP3g=,iv:GtFxTy26XB00ORKK/YcOAKY7MiSPYraTU6EOsgui5lE=,tag:6LIDHrV2anD9lv/8X8vtWw==,type:str]
+    lastmodified: "2026-05-10T00:12:07Z"
+    mac: ENC[AES256_GCM,data:OKRnjOi7QsFvn0kChKvIC4GZ9HzvrQYLAwSJl5cYZwjF8n8IGTlR+HlUSQt5BAcx58/q2aP4t1n3KfhoSPTb6HS55bpm5+thWa5ptT6CUdcUUntNjPxRGmucGPxTmCO178etII3Jhwz7C8aRa2lkd0lswT2Q1WGHadKW9NLVUqw=,iv:VYBu8gmJaCdl+fQP0kf8ucg+KxldvyB7gIvdpsrM0vc=,tag:EV0qhEtr+TNm1kZoDR+H2g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -21,9 +21,11 @@ spec:
           image: ghcr.io/goauthentik/proxy:2026.2.2
           env:
             - name: AUTHENTIK_HOST
+              value: "http://authentik-server.authentik.svc.cluster.local"
+            - name: AUTHENTIK_HOST_BROWSER
               value: "https://auth.homelab.properties"
             - name: AUTHENTIK_INSECURE
-              value: "false"
+              value: "true"
             - name: AUTHENTIK_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -121,6 +121,8 @@ spec:
         enabled: false
       envFromSecret: grafana-oidc-secret
       grafana.ini:
+        server:
+          root_url: https://grafana.homelab.properties
         auth.generic_oauth:
           enabled: true
           name: Authentik


### PR DESCRIPTION
## Problem

Three auth integration failures after Authentik deployment:

### 1. Prometheus/Alertmanager: "no app for hostname"
Outpost pod cannot resolve `auth.homelab.properties` from inside the cluster (no in-cluster DNS for external domain). Outpost never fetches provider config from Authentik API → serves no apps.

**Fix:** `AUTHENTIK_HOST` → internal K8s service URL (`http://authentik-server.authentik.svc.cluster.local`); add `AUTHENTIK_HOST_BROWSER=https://auth.homelab.properties` for browser redirects; `AUTHENTIK_INSECURE=true` (HTTP endpoint).

### 2. Grafana: Redirect URI Error
No `root_url` in grafana.ini `[server]` section → Grafana constructs redirect_uri as `http://grafana.homelab.properties:3000/login/generic_oauth`. Authentik has strict-match on `https://grafana.homelab.properties/login/generic_oauth` → mismatch.

**Fix:** Add `server.root_url: https://grafana.homelab.properties` to grafana.ini in kube-prometheus-stack HelmRelease.

### 3. Headlamp: "invalid_client"
Secret key was `HEADLAMP_CONFIG_OIDC_CLIENT_SECRET` but Headlamp reads `OIDC_CLIENT_SECRET`. Client secret never injected → Authentik rejects auth.

**Fix:** Rename key in `headlamp-oidc-secret.sops.yaml` to `OIDC_CLIENT_SECRET`.

## Changes
- `k3s/infrastructure/configs/authentik/outpost-deployment.yaml` — outpost env vars
- `k3s/infrastructure/configs/monitoring/helmrelease.yaml` — add grafana.ini server.root_url
- `k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml` — correct secret key name