### PR TITLE
fix(authentik): add PostgreSQL session env vars to proxy outpost

### DIFF
--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -31,6 +31,22 @@ spec:
                 secretKeyRef:
                   name: authentik-secret
                   key: outpost-token
+            - name: AUTHENTIK_POSTGRESQL__HOST
+              value: "authentik-postgresql.authentik.svc.cluster.local"
+            - name: AUTHENTIK_POSTGRESQL__USER
+              value: "authentik"
+            - name: AUTHENTIK_POSTGRESQL__NAME
+              value: "authentik"
+            - name: AUTHENTIK_POSTGRESQL__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authentik-postgresql
+                  key: password
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authentik-postgresql
+                  key: password
           ports:
             - containerPort: 9000
               name: http


### PR DESCRIPTION
## Problem

After PR #35 fixed the DNS issue (outpost websocket now connects), the proxy outpost fails to set up the Prometheus and Alertmanager providers:

```
{"env_var":"POSTGRES_PASSWORD","event":"Environment variable not found, using fallback","fallback":""}
"using PostgreSQL session backend"
"failed to connect to user=authentik database=authentik: 127.0.0.1:5432: connection refused"
"failed to setup application"
```

The outpost (Go binary) requires PostgreSQL for session storage. With no `AUTHENTIK_POSTGRESQL__HOST` configured it defaults to `localhost:5432`, which doesn't exist in the pod.

## Root Cause

Authentik 2026.2.x dropped Redis in favor of `django_dramatiq_postgres`. The proxy outpost (separate Go binary) still needs PostgreSQL env vars explicitly — they are not inherited from the main server/worker pod configuration.

## Fix

Added 5 env vars to the outpost Deployment sourced from the chart-generated `authentik-postgresql` secret:

- `AUTHENTIK_POSTGRESQL__HOST` — cluster-internal hostname
- `AUTHENTIK_POSTGRESQL__USER` — `authentik`
- `AUTHENTIK_POSTGRESQL__NAME` — `authentik`  
- `AUTHENTIK_POSTGRESQL__PASSWORD` — from `authentik-postgresql` secret, key `password`
- `POSTGRES_PASSWORD` — same (outpost checks this fallback name)

## Validation

`kubectl apply --dry-run=client` passes for both Deployment and Service.