### PR TITLE
fix(authentik): fix Headlamp envFrom key and Grafana OAuth2 api_url

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
         clientID: headlamp
         issuerURL: https://auth.homelab.properties/application/o/headlamp/
         scopes: openid email profile
-    envFrom:
+    env:
       - secretRef:
           name: headlamp-oidc-secret
     clusterRoleBinding:

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -132,7 +132,10 @@ spec:
           scopes: openid email profile
           auth_url: https://auth.homelab.properties/application/o/authorize/
           token_url: https://auth.homelab.properties/application/o/token/
-          api_url: https://auth.homelab.properties/application/o/userinfo/
+          api_url: https://auth.homelab.properties/application/o/userinfo
+          email_attribute_path: email
+          login_attribute_path: preferred_username
+          name_attribute_path: name
           role_attribute_path: "contains(groups[*], 'homelab-admins') && 'Admin' || 'Viewer'"
       admin:
         existingSecret: grafana-admin-secret


### PR DESCRIPTION
## Problem

Two auth integration issues remain after the blueprint fixes:

### 1. Headlamp — `invalid_client` on OIDC callback

The Headlamp Helm chart uses `.Values.env` (mapped to `envFrom:` in the pod template), **not** `.Values.envFrom`. The HelmRelease had `envFrom:` as the top-level key, which the chart ignores — meaning `OIDC_CLIENT_SECRET` was never injected into the pod.

**Fix**: Rename `envFrom:` → `env:` in the Headlamp HelmRelease values.

### 2. Grafana — `InternalError` after OAuth login

Grafana successfully exchanges the OAuth code for a token, but then fails when fetching the user's email:
```
Error getting email address url=https://auth.homelab.properties/application/o/userinfo//emails error="404"
```

Two issues:
1. `api_url` had a trailing slash → Grafana appended `emails` creating a double-slash `userinfo//emails`
2. No `email_attribute_path` set → Grafana tried to call a `/emails` sub-endpoint instead of reading the `email` field from the userinfo JSON

**Fix**: Remove trailing slash from `api_url` + add `email_attribute_path`, `login_attribute_path`, and `name_attribute_path` pointing at the correct OIDC claim fields.

## Changes

- `k3s/applications/headlamp/helmrelease.yaml`: `envFrom:` → `env:`
- `k3s/infrastructure/configs/monitoring/helmrelease.yaml`: fixed `api_url` (no trailing slash) + added attribute path fields