### PR TITLE
fix(headlamp): use valueFrom.secretKeyRef for OIDC_CLIENT_SECRET env var

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -50,8 +50,11 @@ spec:
         issuerURL: https://auth.homelab.properties/application/o/headlamp/
         scopes: openid email profile
     env:
-      - secretRef:
-          name: headlamp-oidc-secret
+      - name: OIDC_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: headlamp-oidc-secret
+            key: OIDC_CLIENT_SECRET
     clusterRoleBinding:
       clusterRoleName: cluster-admin
     initContainers:


### PR DESCRIPTION
## Problem

Headlamp HelmRelease upgrade failed with schema validation error:

```
- env.0: name is required
- env.0: value is required
- env.0: Additional property secretRef is not allowed
```

The `env` field in the Headlamp chart uses `[]corev1.EnvVar` schema — it expects `name`/`value`/`valueFrom`, not an `envFrom`-style `secretRef`.

## Fix

Change the `env` entry from:
```yaml
env:
  - secretRef:
      name: headlamp-oidc-secret
```

To:
```yaml
env:
  - name: OIDC_CLIENT_SECRET
    valueFrom:
      secretKeyRef:
        name: headlamp-oidc-secret
        key: OIDC_CLIENT_SECRET
```

This injects the client secret as a proper environment variable, allowing Headlamp's OIDC to authenticate with Authentik.