### PR TITLE
fix(headlamp): use config.oidc.externalSecret for OIDC client secret injection

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -49,12 +49,9 @@ spec:
         clientID: headlamp
         issuerURL: https://auth.homelab.properties/application/o/headlamp/
         scopes: openid email profile
-    env:
-      - name: OIDC_CLIENT_SECRET
-        valueFrom:
-          secretKeyRef:
-            name: headlamp-oidc-secret
-            key: OIDC_CLIENT_SECRET
+        externalSecret:
+          enabled: true
+          name: headlamp-oidc-secret
     clusterRoleBinding:
       clusterRoleName: cluster-admin
     initContainers:


### PR DESCRIPTION
## Problem

Headlamp chart 0.41.x schema for `env` only allows `name` + `value` (string literals). `additionalProperties: false` blocks `valueFrom.secretKeyRef`, causing repeated upgrade failures:

```
- env.0: value is required
- env.0: Additional property valueFrom is not allowed
```

## Fix

Use the chart-native `config.oidc.externalSecret` mechanism:

```yaml
config:
  oidc:
    clientID: headlamp
    issuerURL: https://auth.homelab.properties/application/o/headlamp/
    scopes: openid email profile
    externalSecret:
      enabled: true
      name: headlamp-oidc-secret
```

This instructs the chart to do `envFrom: - secretRef: name: headlamp-oidc-secret` on the pod, injecting `OIDC_CLIENT_SECRET` (and any other keys) from the SOPS-decrypted secret. No schema violation.