### PR TITLE
fix(authentik): add scope mappings to OIDC providers and inject all Headlamp OIDC env vars

### DIFF
--- a/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
+++ b/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
@@ -1,22 +1,25 @@
-apiVersion: ENC[AES256_GCM,data:vfs=,iv:n4bGkChHFOGQU/Sw8mK+Gx2tYRtTVre8uVo3FHjy0Ak=,tag:XfBOoPLwH7eQ7i0m67YHPw==,type:str]
-kind: ENC[AES256_GCM,data:lAtBp7kP,iv:QFhwXTVxleuxNSYfIR6sFoTNSbJqLn+fjR4QMFrkUfA=,tag:PXl+Dds9y6DFhJkTbC3c6Q==,type:str]
+apiVersion: ENC[AES256_GCM,data:VPs=,iv:hOINFxUPSHcVggYbYIW8Mgqm5EeACgt6shHCVFc55B4=,tag:iZwzvWFug2VHvkmz6EsjzA==,type:str]
+kind: ENC[AES256_GCM,data:J6AmzNj+,iv:kJufyKWN7V7FuqTZlNl/dLbrh77QogAmP7b3ql80Zzw=,tag:SSVZDeOVMfY+Web+7mK0RQ==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:qPvKutibT5sQuO03/9CqOT1dOb0=,iv:Raxo39Cw0d8SixXGPqHgBCBSVAEji4eFen3t46oGRNE=,tag:nUGsGTOCoz5sXuZakWTryA==,type:str]
-    namespace: ENC[AES256_GCM,data:NfQ+LMMoOBY=,iv:GBlw2DE9lJ9d3Yaf9L1TtP8o6jhboZCtIqqUIejlYt0=,tag:8+1IQwW1gA5pxT8dw01pxw==,type:str]
+    name: ENC[AES256_GCM,data:zpuHAWENdlpzTsY5cgqanEHVuPM=,iv:iRQvv/V/9B/u0rFlF4+kZKRFUtz47NkvfYmSvsCXNcs=,tag:CItsm3q7Ejf6g7UHuDRLEg==,type:str]
+    namespace: ENC[AES256_GCM,data:K4Iojxcufng=,iv:zEMhPprZpnnIiASTWfMB8Z3zk2+tZq45Rxjo8uuUDmg=,tag:VFglIs6LHGCOQze5cuKVXw==,type:str]
 stringData:
-    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:N77rXdfedu1vuFs30GOJZDJjCbdRPl0D+XqPgp83soI=,iv:X0QSb5wZApTPmt4NqxkLPCZpvag0tbKEheclqn6fiWk=,tag:pWpA3BzJPQTbJ2rY/SwqpA==,type:str]
+    OIDC_CLIENT_ID: ENC[AES256_GCM,data:KzI+9gMQxWw=,iv:ddmMw6cYFAP3I1Vt9WV6yWbC1yT9cq4tLg+gfftqWOs=,tag:JGytTm5xFIocB8MvRL6YvA==,type:str]
+    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:pj4YXARSIUcqnlreY4oWtMp7TnxszlPNmPfDiLtt5xg=,iv:Vb/TsaIjWoKBnzel+Dh+IiChyu5+cerk9m9li6GpMlU=,tag:52dLUh+o/AkCaLr0/sNoqA==,type:str]
+    OIDC_ISSUER_URL: ENC[AES256_GCM,data:sVi7YbRKLMNd3z0Mz3hBLgWxD4efsar6QELg0bXhGeE/Si7tSfr4dxr9KetCvKMpuHs02iRYkw==,iv:WxLGP4epf5OIdNGVWNBXruSk+0qj2w5WgxgY/gf3sj4=,tag:VHireAGpUsXvykceEU7bqw==,type:str]
+    OIDC_SCOPES: ENC[AES256_GCM,data:q33oLHjeD7TK78d75IOIxvcSh5E=,iv:7TG6bZImlWxF+xPr4BdqBwfVqwmjKlsJ5uVT1hh3lXg=,tag:pXSRxCeX3ppyn+jlLlc0uw==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGTlJ5dE5YWXFjME5BVVpi
-            WWkyNTRCMVFvUERUb3kyd2lZY3lHN0xxM3djCkJ3MVVvc2FXQnFXR1l3ampOVXBh
-            djA3YkZCZHdMYUlQL2JJSXp1R0k3cm8KLS0tIEsyRnNPL3FoY3RmTllRaXByMDFu
-            M0Z3UzdGUWI1Ri9pVGt4ajdsV1d3WFkKE2WgAn6QH+VNViYiF2TKhx7Qdnpui77y
-            ypogC8xj4doLbUZun9OlJezUoDchraNs59qvrFlQhIGFb+aqcGIcGg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxQ1hUTDZhdWQ2NzhpVTlM
+            dllqd0w0ZFdvcXU0T0tnbVNlRlBmYzQ0SEYwCk1uRmRKTitnYWxwa3BwZGV0aFpa
+            WjVRZTI4OVhDT2d3NlMyYkxwVG5NVG8KLS0tICtIeWhlRmFCM0c0NjBIYnVSZWla
+            TS9JOWx1VFhJWHptZHNjdVdqd1AyQncK8MSuitmQCPbqm+27a8Tc9vB5z9x4H09Z
+            A2WBWbistIQk7FwwucyNow9mLnPXhQQMMztnhXefu2z5Tkj7ACxFIA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-10T00:12:07Z"
-    mac: ENC[AES256_GCM,data:OKRnjOi7QsFvn0kChKvIC4GZ9HzvrQYLAwSJl5cYZwjF8n8IGTlR+HlUSQt5BAcx58/q2aP4t1n3KfhoSPTb6HS55bpm5+thWa5ptT6CUdcUUntNjPxRGmucGPxTmCO178etII3Jhwz7C8aRa2lkd0lswT2Q1WGHadKW9NLVUqw=,iv:VYBu8gmJaCdl+fQP0kf8ucg+KxldvyB7gIvdpsrM0vc=,tag:EV0qhEtr+TNm1kZoDR+H2g==,type:str]
+    lastmodified: "2026-05-10T01:08:54Z"
+    mac: ENC[AES256_GCM,data:ss+9If8swFUjSww/16Ws6wFP7n/r2e2k8yOGnXZ/kzQQv1P6do5JjsBc/NJsbP1MyBb3i39lnGR4feAEXMlaiiFrVaRnLQHJtJVbnstYfwda87FrEDg2fsssm+8o7tyoN9SrkPrdrJg1/r0GRktZp78SKRVSxs6CocoOsEsvMyQ=,iv:KmKKWr9tPf36gzHbELC9FE3/fzJOGisnh0vX99raHOA=,tag:KNZfNZwAD7//M6kUoUWnUQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -35,6 +35,10 @@ data:
             - matching_mode: strict
               url: "https://grafana.homelab.properties/login/generic_oauth"
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
       - model: authentik_core.application
         state: present
         identifiers:
@@ -63,6 +67,10 @@ data:
             - matching_mode: strict
               url: "https://headlamp.homelab.properties/oidc-callback"
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
       - model: authentik_core.application
         state: present
         identifiers:


### PR DESCRIPTION
## Problem

Two integration failures after blueprint deployment:

**Grafana InternalError**: `grafana-provider` and `headlamp-provider` had no `property_mappings` in the blueprint. Authentik returned empty claims in the userinfo response — no `email`, `name`, or `groups`. Grafana fell back to calling `/application/o/userinfo/emails` (GitHub-style endpoint, 404 in Authentik).

**Headlamp `$(OIDC_ISSUER_URL)` literal**: The Headlamp chart with `config.oidc.externalSecret` does `envFrom: - secretRef:` and expects ALL OIDC env vars in the external secret. Our secret only had `OIDC_CLIENT_SECRET`. The pod args `$(OIDC_CLIENT_ID)`, `$(OIDC_ISSUER_URL)`, `$(OIDC_SCOPES)` resolved to empty strings.

## Fix

**`blueprints-configmap.yaml`**: Add `property_mappings` to both `grafana-provider` and `headlamp-provider` entries:
```yaml
property_mappings:
  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
```

**`headlamp-oidc-secret.sops.yaml`**: Add `OIDC_CLIENT_ID`, `OIDC_ISSUER_URL`, `OIDC_SCOPES` alongside existing `OIDC_CLIENT_SECRET`.