### PR TITLE
fix: Headlamp OIDC login loop — K3s API server flags, RBAC, and offline_access scope

### DIFF
--- a/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
+++ b/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
@@ -7,7 +7,7 @@ stringData:
     OIDC_CLIENT_ID: ENC[AES256_GCM,data:KzI+9gMQxWw=,iv:ddmMw6cYFAP3I1Vt9WV6yWbC1yT9cq4tLg+gfftqWOs=,tag:JGytTm5xFIocB8MvRL6YvA==,type:str]
     OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:pj4YXARSIUcqnlreY4oWtMp7TnxszlPNmPfDiLtt5xg=,iv:Vb/TsaIjWoKBnzel+Dh+IiChyu5+cerk9m9li6GpMlU=,tag:52dLUh+o/AkCaLr0/sNoqA==,type:str]
     OIDC_ISSUER_URL: ENC[AES256_GCM,data:sVi7YbRKLMNd3z0Mz3hBLgWxD4efsar6QELg0bXhGeE/Si7tSfr4dxr9KetCvKMpuHs02iRYkw==,iv:WxLGP4epf5OIdNGVWNBXruSk+0qj2w5WgxgY/gf3sj4=,tag:VHireAGpUsXvykceEU7bqw==,type:str]
-    OIDC_SCOPES: ENC[AES256_GCM,data:q33oLHjeD7TK78d75IOIxvcSh5E=,iv:7TG6bZImlWxF+xPr4BdqBwfVqwmjKlsJ5uVT1hh3lXg=,tag:pXSRxCeX3ppyn+jlLlc0uw==,type:str]
+    OIDC_SCOPES: ENC[AES256_GCM,data:ikzw22wXsepDdmRhyouX9Cb2XRIhUQYVHa9cE4c+pVUsCjg=,iv:iTeuLa+R3QHDLVoxY+1GwzKJ0iDvuLdzo8t2Hx5oFPY=,tag:O9DCU72UocuRxX1uNlMTlA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
@@ -19,7 +19,7 @@ sops:
             TS9JOWx1VFhJWHptZHNjdVdqd1AyQncK8MSuitmQCPbqm+27a8Tc9vB5z9x4H09Z
             A2WBWbistIQk7FwwucyNow9mLnPXhQQMMztnhXefu2z5Tkj7ACxFIA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-10T01:08:54Z"
-    mac: ENC[AES256_GCM,data:ss+9If8swFUjSww/16Ws6wFP7n/r2e2k8yOGnXZ/kzQQv1P6do5JjsBc/NJsbP1MyBb3i39lnGR4feAEXMlaiiFrVaRnLQHJtJVbnstYfwda87FrEDg2fsssm+8o7tyoN9SrkPrdrJg1/r0GRktZp78SKRVSxs6CocoOsEsvMyQ=,iv:KmKKWr9tPf36gzHbELC9FE3/fzJOGisnh0vX99raHOA=,tag:KNZfNZwAD7//M6kUoUWnUQ==,type:str]
+    lastmodified: "2026-05-10T21:44:14Z"
+    mac: ENC[AES256_GCM,data:Teb8ZxBbJsNysgXTC6LWKcMUGIG0odocPhkAA2czVLqHGdPeiqDhGKUIFDSRs0v0G3FlsT3wVjTZ7GlTOmewP6mDckjRBJm5XGKll8gu4TrgzbA6NsIOAgf/TWagAP/VXVGmvAUtxjx1kVcd3wKR5mX9F9rjyyIavvMEbR2G2jA=,iv:Xf1+uXF5R5Pe2rRDdVVsuNHk5K7PJMygVOdCQ6uXTHI=,tag:llod2hm9z4116hxd3Bg2Uw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -53,3 +53,11 @@ k3s_disable_components:
 flux_github_owner: "jander99"
 flux_github_repo: "homelab"
 flux_git_branch: "master"
+
+# ─── K3s OIDC settings ───────────────────────────────────────────────────────
+# Configures the K3s API server to validate OIDC tokens issued by Authentik.
+# These values enable Headlamp SSO via the headlamp application in Authentik.
+k3s_oidc_issuer_url: "https://auth.homelab.properties/application/o/headlamp/"
+k3s_oidc_client_id: "headlamp"
+k3s_oidc_username_claim: "preferred_username"
+k3s_oidc_groups_claim: "groups"

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -36,6 +36,18 @@
     group: root
     mode: "0755"
 
+- name: Validate OIDC vars are complete when OIDC is enabled
+  ansible.builtin.assert:
+    that:
+      - k3s_oidc_client_id | length > 0
+      - k3s_oidc_username_claim | length > 0
+      - k3s_oidc_groups_claim | length > 0
+    fail_msg: >-
+      k3s_oidc_issuer_url is set but one or more companion variables are empty.
+      Set k3s_oidc_client_id, k3s_oidc_username_claim, and k3s_oidc_groups_claim
+      in group_vars or host_vars.
+  when: k3s_oidc_issuer_url | length > 0
+
 - name: Write K3s server configuration
   ansible.builtin.copy:
     dest: "{{ k3s_config_file }}"

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -85,6 +85,16 @@
         - "{{ component }}"
       {% endfor %}
       {% endif %}
+      {% if k3s_oidc_issuer_url | length > 0 %}
+
+      # OIDC integration — allows K3s API server to validate tokens issued by an
+      # external OIDC provider (e.g. Authentik). Required for Headlamp SSO.
+      kube-apiserver-arg:
+        - "oidc-issuer-url={{ k3s_oidc_issuer_url }}"
+        - "oidc-client-id={{ k3s_oidc_client_id }}"
+        - "oidc-username-claim={{ k3s_oidc_username_claim }}"
+        - "oidc-groups-claim={{ k3s_oidc_groups_claim }}"
+      {% endif %}
     owner: root
     group: root
     mode: "0600"

--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -72,6 +72,7 @@ data:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, offline_access]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-groups"]]
       - model: authentik_core.application
         state: present
         identifiers:

--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -71,6 +71,7 @@ data:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, offline_access]]
       - model: authentik_core.application
         state: present
         identifiers:

--- a/k3s/infrastructure/configs/authentik/headlamp-oidc-rbac.yaml
+++ b/k3s/infrastructure/configs/authentik/headlamp-oidc-rbac.yaml
@@ -1,0 +1,19 @@
+---
+# ClusterRoleBinding granting Headlamp OIDC-authenticated users cluster-admin access.
+# The K3s API server validates tokens via --oidc-issuer-url and extracts the
+# groups claim. Members of the homelab-admins Authentik group are bound here.
+#
+# Adjust the subjects list or create a more restrictive ClusterRole if you
+# want finer-grained access control.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-oidc-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: homelab-admins

--- a/k3s/infrastructure/configs/authentik/kustomization.yaml
+++ b/k3s/infrastructure/configs/authentik/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - authentik-secret.sops.yaml
   - outpost-deployment.yaml
   - blueprints-configmap.yaml
+  - headlamp-oidc-rbac.yaml


### PR DESCRIPTION
## Summary

Fixes the Headlamp login loop caused by K3s not trusting Authentik-issued tokens, and fixes the session expiry every ~60 s caused by missing refresh tokens.

Closes #41

## Changes

### Ansible — K3s OIDC configuration
- `roles/k3s-server/defaults/main.yml` — added `k3s_oidc_*` role variables with empty defaults
- `roles/k3s-server/tasks/main.yml` — added conditional `kube-apiserver-arg` block that writes OIDC flags to `/etc/rancher/k3s/config.yaml` (only applied when `k3s_oidc_issuer_url` is non-empty); triggers `Restart k3s` handler
- `inventory/group_vars/all.yml` — set cluster-specific OIDC values (issuer URL, client ID, username/groups claims)

Running `bootstrap-k3s.yml` after merging will apply the flags to the live node and restart K3s.

### GitOps — RBAC and scope mapping
- `k3s/infrastructure/configs/authentik/headlamp-oidc-rbac.yaml` _(new)_ — `ClusterRoleBinding` granting `cluster-admin` to the `homelab-admins` Authentik group (the group claim K3s extracts from the token)
- `k3s/infrastructure/configs/authentik/kustomization.yaml` — added `headlamp-oidc-rbac.yaml` so Flux applies the binding
- `k3s/infrastructure/configs/authentik/blueprints-configmap.yaml` — added `offline_access` scope mapping to `headlamp-provider` so Authentik issues refresh tokens (prevents the 60 s session re-auth loop)
- `k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml` — `OIDC_SCOPES` updated to include `offline_access` (edited manually via `sops`)

## Testing

1. Merge PR → run `ansible-playbook bootstrap-k3s.yml` to apply K3s API server flags
2. Flux reconciles and applies the `ClusterRoleBinding`
3. Log in to Headlamp via Authentik — should reach the cluster dashboard without looping
4. Wait >60 s — session should remain active (refresh token keeps it alive)