### PR TITLE
feat(monitoring): scrape Synology node-exporter from K3s Prometheus

### DIFF
--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -63,6 +63,7 @@ spec:
         retention: 30d
         podMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/k3s/infrastructure/configs/monitoring/kustomization.yaml
+++ b/k3s/infrastructure/configs/monitoring/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - authentik-middleware.yaml
+  - scrapeconfig-synology.yaml

--- a/k3s/infrastructure/configs/monitoring/scrapeconfig-synology.yaml
+++ b/k3s/infrastructure/configs/monitoring/scrapeconfig-synology.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: synology-node-exporter
+  namespace: monitoring
+spec:
+  staticConfigs:
+    - targets:
+        - 192.168.1.20:9100
+      labels:
+        job: synology-node-exporter
+  scrapeInterval: 60s
+  metricsPath: /metrics

--- a/k3s/infrastructure/configs/monitoring/scrapeconfig-synology.yaml
+++ b/k3s/infrastructure/configs/monitoring/scrapeconfig-synology.yaml
@@ -5,10 +5,9 @@ metadata:
   name: synology-node-exporter
   namespace: monitoring
 spec:
+  jobName: synology-node-exporter
   staticConfigs:
     - targets:
         - 192.168.1.20:9100
-      labels:
-        job: synology-node-exporter
   scrapeInterval: 60s
   metricsPath: /metrics


### PR DESCRIPTION
## Summary

- Add `ScrapeConfig` CR (`scrapeconfig-synology.yaml`) targeting the Synology NAS node-exporter at `192.168.1.20:9100`
- Set `scrapeConfigSelectorNilUsesHelmValues: false` in the kube-prometheus-stack HelmRelease so Prometheus picks up all `ScrapeConfig` resources cluster-wide (mirrors existing `serviceMonitorSelectorNilUsesHelmValues` and `podMonitorSelectorNilUsesHelmValues` settings)

## What changes

| File | Change |
|------|--------|
| `helmrelease.yaml` | +1 line: `scrapeConfigSelectorNilUsesHelmValues: false` under `prometheusSpec` |
| `scrapeconfig-synology.yaml` | New file — `ScrapeConfig` CR for static target at `192.168.1.20:9100` |
| `kustomization.yaml` | +1 resource reference |

## How to verify

After Flux reconciles, check Prometheus targets UI at `https://prometheus.homelab.properties/targets` — a `synology-node-exporter` job should appear with the `192.168.1.20:9100` endpoint in UP state.