### PR TITLE
docs: add Optiplex mini cluster hardware specs

### DIFF
--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -52,7 +52,7 @@ k3s/
 - `BOOTSTRAP.md` is the authoritative guide for standing up the cluster when ready.
 - `k3s.md` contains the concrete repo blueprint, Flux kustomization graph, and Nx/CDK8s workflow.
 - Current Docker services on Synology NAS are the live production environment — K3s migration is future work.
-- **Testbed node** (i7-4770k) at 192.168.1.128 is the current active single-node cluster. Target architecture is 3x Dell Optiplex (192.168.1.40-42) with embedded etcd — not yet provisioned.
+- **Testbed node** (i7-4770k) at 192.168.1.128 is the current active single-node cluster. Target architecture is 3x Dell Optiplex (k3s-mini-01/02/03, 192.168.1.40-42) with embedded etcd — hardware acquired, not yet provisioned. See `k3s/k3s.md` § "Node Hardware" for full per-node specs.
 - `provision-nodes.yml` is runnable — runs `common` + `k3s-prereqs` roles.
 - `bootstrap-k3s.yml` is runnable — runs `k3s-server` role to install and configure a single K3s server node.
 - `bootstrap-flux.yml` is implemented and uses the `flux-bootstrap` role. It requires `GITHUB_TOKEN`, the kubeconfig fetched by `bootstrap-k3s.yml`, and Flux GitHub settings in `inventory/group_vars/all.yml`.

--- a/k3s/k3s.md
+++ b/k3s/k3s.md
@@ -20,12 +20,24 @@ These are the choices worth being opinionated about up front:
 
 ## Target Cluster
 
-- **Nodes**: 3x Dell Optiplex at `192.168.1.40`, `192.168.1.41`, `192.168.1.42`
+- **Nodes**: 3x Dell Optiplex at `192.168.1.40` (k3s-mini-01), `192.168.1.41` (k3s-mini-02), `192.168.1.42` (k3s-mini-03)
 - **Datastore**: embedded etcd once the cluster moves from single-node SQLite to HA
 - **GitOps root**: `k3s/clusters/homelab/`
 - **Ingress/TLS**: Nginx Ingress + cert-manager
 - **Secrets**: SOPS + age
 - **Storage posture**: do not hardcode a future storage vendor into the blueprint; only set `storageClassName` when a workload truly needs it
+
+### Node Hardware
+
+> **Status**: Hardware is acquired and spec'd; cluster is not yet provisioned.
+
+| Spec | k3s-mini-01 | k3s-mini-02 | k3s-mini-03 |
+|------|-------------|-------------|-------------|
+| **Chassis** | Dell Optiplex 5060 | Dell Optiplex 5060 | Dell Optiplex 7060 |
+| **CPU** | Intel Core i5-8600T @ 2.30 GHz | Intel Core i5-8500T @ 2.10 GHz | Intel Core i5-8500T @ 2.10 GHz |
+| **RAM** | 32 GB (F4-3200C22-16GRS) | 32 GB (HMA82GS6CJR8N-VK) | 32 GB (F4-2666C18-16GRS) |
+| **SATA SSD** | Unknown (512 GB) | Crucial MX500 CT250MX500SSD1 (250 GB) | Crucial MX500 CT250MX500SSD1 (250 GB) |
+| **M.2 NVMe** | Crucial P3 CT1000P3SSD8 (1 TB) | WD Black SN770 (500 GB) | Crucial P3 Plus CT500P3PSSD8 (500 GB) |
 
 ## Repository Blueprint
 


### PR DESCRIPTION
## Summary

- Adds a **Node Hardware** table to `k3s/k3s.md` under the existing "Target Cluster" section, documenting the per-node specs for the planned 3-node Dell Optiplex cluster
- Updates `k3s/AGENTS.md` to note that hardware is acquired (not just planned) and references the new table

## Hardware documented

| Node | Chassis | CPU | RAM | SATA SSD | M.2 NVMe |
|------|---------|-----|-----|----------|----------|
| k3s-mini-01 | Optiplex 5060 | i5-8600T @ 2.30 GHz | 32 GB (F4-3200C22-16GRS) | Unknown (512 GB) | Crucial P3 CT1000P3SSD8 (1 TB) |
| k3s-mini-02 | Optiplex 5060 | i5-8500T @ 2.10 GHz | 32 GB (HMA82GS6CJR8N-VK) | Crucial MX500 CT250MX500SSD1 (250 GB) | WD Black SN770 (500 GB) |
| k3s-mini-03 | Optiplex 7060 | i5-8500T @ 2.10 GHz | 32 GB (F4-2666C18-16GRS) | Crucial MX500 CT250MX500SSD1 (250 GB) | Crucial P3 Plus CT500P3PSSD8 (500 GB) |

> Cluster is not yet provisioned — hardware only.