### PR TITLE
feat(storage): add NFS PersistentVolumes for Synology media share

### DIFF
--- a/k3s/infrastructure/configs/storage/kustomization.yaml
+++ b/k3s/infrastructure/configs/storage/kustomization.yaml
@@ -2,8 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - metallb
-  - cert-manager
-  - monitoring
-  - authentik
-  - storage
+  - nfs-media-pv-ro.yaml
+  - nfs-media-pv-rw.yaml

--- a/k3s/infrastructure/configs/storage/nfs-media-pv-ro.yaml
+++ b/k3s/infrastructure/configs/storage/nfs-media-pv-ro.yaml
@@ -1,7 +1,7 @@
 ---
 # Read-only NFS PersistentVolume — Synology /data share
 # Mount this in pods that only need to read media (e.g. Plex, Jellyfin)
-# Pods must run with runAsUser: 1027, fsGroup: 100 to match NAS file ownership
+# Pods must run with runAsUser: 1027, runAsGroup: 100, fsGroup: 100 to match NAS file ownership
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -14,7 +14,9 @@ spec:
   nfs:
     server: 192.168.1.20
     path: /data
+    readOnly: true
   persistentVolumeReclaimPolicy: Retain
+  # storageClassName must be "" on consuming PVCs; use volumeName: synology-media-ro for direct static binding
   storageClassName: ""
   mountOptions:
     - nfsvers=4.1

--- a/k3s/infrastructure/configs/storage/nfs-media-pv-ro.yaml
+++ b/k3s/infrastructure/configs/storage/nfs-media-pv-ro.yaml
@@ -1,0 +1,22 @@
+---
+# Read-only NFS PersistentVolume — Synology /data share
+# Mount this in pods that only need to read media (e.g. Plex, Jellyfin)
+# Pods must run with runAsUser: 1027, fsGroup: 100 to match NAS file ownership
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: synology-media-ro
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadOnlyMany
+  nfs:
+    server: 192.168.1.20
+    path: /data
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime

--- a/k3s/infrastructure/configs/storage/nfs-media-pv-rw.yaml
+++ b/k3s/infrastructure/configs/storage/nfs-media-pv-rw.yaml
@@ -1,0 +1,23 @@
+---
+# Read-write NFS PersistentVolume — Synology /data share
+# Mount this in pods that need to write media (e.g. Sonarr, Radarr, NZBGet)
+# Pods must run with runAsUser: 1027, fsGroup: 100 to match NAS file ownership
+# NFS export on Synology must have squash: no_root_squash (or no squash)
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: synology-media-rw
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: 192.168.1.20
+    path: /data
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime

--- a/k3s/infrastructure/configs/storage/nfs-media-pv-rw.yaml
+++ b/k3s/infrastructure/configs/storage/nfs-media-pv-rw.yaml
@@ -1,8 +1,8 @@
 ---
 # Read-write NFS PersistentVolume — Synology /data share
 # Mount this in pods that need to write media (e.g. Sonarr, Radarr, NZBGet)
-# Pods must run with runAsUser: 1027, fsGroup: 100 to match NAS file ownership
-# NFS export on Synology must have squash: no_root_squash (or no squash)
+# Pods must run with runAsUser: 1027, runAsGroup: 100, fsGroup: 100 to match NAS file ownership
+# NFS export on Synology: root_squash (default) is sufficient — only squashes UID 0; UID 1027 passes through
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -16,6 +16,7 @@ spec:
     server: 192.168.1.20
     path: /data
   persistentVolumeReclaimPolicy: Retain
+  # storageClassName must be "" on consuming PVCs; use volumeName: synology-media-rw for direct static binding
   storageClassName: ""
   mountOptions:
     - nfsvers=4.1


### PR DESCRIPTION
## Summary

- Adds `k3s/infrastructure/configs/storage/` with two cluster-scoped NFS PersistentVolumes pointing to the Synology NAS at `192.168.1.20:/data`
- `synology-media-ro` — `ReadOnlyMany` for media players (Plex, Jellyfin, etc.)
- `synology-media-rw` — `ReadWriteMany` for arr apps and downloaders (Sonarr, Radarr, NZBGet)
- Wires the new `storage` kustomization into `infra-configs` reconciliation

## Auth model

NFS uses UID/GID passthrough (no credentials). Pods consuming these PVs must set:
```yaml
securityContext:
  runAsUser: 1027
  runAsGroup: 100
  fsGroup: 100
```
This matches the LinuxServer.io `PUID=1027 PGID=100` convention used by the Docker media stack on the NAS.

## Synology NFS setup required

Before Flux applies these, the NFS export must be configured in DSM:
- Control Panel → File Services → NFS → Enable NFSv4
- Shared Folder `/data` → NFS Permissions → add `192.168.1.0/24`, squash: **No squash**

## Not included

PersistentVolumeClaims are intentionally omitted — they are namespaced and will be added per-app when media workloads are onboarded to K3s.