### PR TITLE
feat: NVIDIA GPU support for K3s (toolkit + device plugin)

### DIFF
--- a/k3s/bootstrap/ansible/playbooks/provision-nodes.yml
+++ b/k3s/bootstrap/ansible/playbooks/provision-nodes.yml
@@ -1,6 +1,7 @@
 ---
 # provision-nodes.yml
-# Prepares Ubuntu nodes for K3s: OS hardening, package management, K3s prerequisites
+# Prepares Ubuntu nodes for K3s: OS hardening, package management, K3s prerequisites,
+# and NVIDIA GPU support (nvidia-container-toolkit + containerd runtime config).
 #
 # Usage: ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml -v
 
@@ -10,3 +11,4 @@
   roles:
     - common
     - k3s-prereqs
+    - nvidia-gpu

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/files/nvidia-config-v3.toml.tmpl
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/files/nvidia-config-v3.toml.tmpl
@@ -1,0 +1,15 @@
+{{ template "base" . }}
+
+# NVIDIA GPU runtime — managed by Ansible, do not edit manually.
+# Configures K3s containerd (2.x / config version 3) to use the NVIDIA
+# container runtime as the default, enabling GPU access for pods that
+# request nvidia.com/gpu resources via the nvidia-device-plugin.
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
+  default_runtime_name = "nvidia"
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.nvidia.options]
+  BinaryName = "/usr/bin/nvidia-container-runtime"

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/handlers/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# roles/nvidia-gpu/handlers/main.yml
+
+- name: Restart k3s
+  ansible.builtin.systemd:
+    name: k3s
+    state: restarted

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/handlers/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/handlers/main.yml
@@ -1,7 +1,10 @@
 ---
 # roles/nvidia-gpu/handlers/main.yml
 
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
 - name: Restart k3s
   ansible.builtin.systemd:
-    name: k3s
+    name: "{{ 'k3s' if 'k3s.service' in ansible_facts.services else 'k3s-agent' }}"
     state: restarted

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# roles/nvidia-gpu/tasks/main.yml
+# Installs nvidia-container-toolkit and configures K3s containerd to use the
+# NVIDIA GPU runtime. Assumes NVIDIA drivers are already installed on the node.
+#
+# Tested against: Ubuntu 26.04, K3s 1.35.x (containerd 2.x)
+
+# ── 1. nvidia-container-toolkit ───────────────────────────────────────────────
+
+- name: Download and dearmor NVIDIA container toolkit GPG key
+  ansible.builtin.shell:
+    cmd: >
+      curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey
+      | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    creates: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+
+- name: Add NVIDIA container toolkit apt repo
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    mode: "0644"
+    content: |
+      deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
+
+- name: Install nvidia-container-toolkit
+  ansible.builtin.apt:
+    name: nvidia-container-toolkit
+    state: present
+    update_cache: true
+
+# ── 2. Configure K3s containerd (v3 config for containerd 2.x) ────────────────
+# K3s auto-generates config.toml on each start. config-v3.toml.tmpl overrides
+# it permanently for containerd 2.x, adding the NVIDIA runtime as the default.
+# The {{ template "base" . }} directive preserves all K3s-generated defaults.
+
+- name: Create K3s containerd config directory
+  ansible.builtin.file:
+    path: /var/lib/rancher/k3s/agent/etc/containerd
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Write K3s containerd v3 template with NVIDIA runtime
+  ansible.builtin.copy:
+    src: nvidia-config-v3.toml.tmpl
+    dest: /var/lib/rancher/k3s/agent/etc/containerd/config-v3.toml.tmpl
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart k3s
+
+# ── 3. Verify ─────────────────────────────────────────────────────────────────
+
+- name: Verify nvidia-container-cli can see the GPU
+  ansible.builtin.command: nvidia-container-cli info
+  register: ctk_info
+  changed_when: false
+  failed_when: ctk_info.rc != 0

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
@@ -5,8 +5,17 @@
 #
 # Tested against: Ubuntu 26.04, K3s 1.35.x (containerd 2.x)
 
-# ── 1. nvidia-container-toolkit ───────────────────────────────────────────────
+# ── 1. Prerequisites ─────────────────────────────────────────────────────────
 
+- name: Install gnupg and curl for toolkit repo setup
+  ansible.builtin.apt:
+    name:
+      - curl
+      - gnupg
+    state: present
+    update_cache: false
+
+# ── 2. nvidia-container-toolkit ─────────────────────────────────────────────
 - name: Download and dearmor NVIDIA container toolkit GPG key
   ansible.builtin.shell:
     cmd: >

--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nvidia-device-plugin
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: nvidia-device-plugin
+      version: '>=0.17.0 <1.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: nvdp
+        namespace: flux-system
+  targetNamespace: kube-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # No time-slicing — GPUs are allocated exclusively (one pod per GPU).
+    # This is appropriate for transcoding workloads (Tdarr, Plex) where
+    # VRAM contention would cause failures.
+    config:
+      map:
+        default: |-
+          version: v1
+          flags:
+            migStrategy: none

--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
@@ -22,9 +22,10 @@ spec:
     remediation:
       retries: 3
   values:
-    # No time-slicing — GPUs are allocated exclusively (one pod per GPU).
-    # This is appropriate for transcoding workloads (Tdarr, Plex) where
-    # VRAM contention would cause failures.
+    # Exclusive GPU allocation: no sharing config means the device plugin assigns
+    # the full GPU to one pod at a time (the chart's default behavior).
+    # migStrategy: none disables MIG partitioning — the RTX 3070 does not support
+    # MIG, but being explicit avoids ambiguity.
     config:
       map:
         default: |-

--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvdp
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://nvidia.github.io/k8s-device-plugin

--- a/k3s/infrastructure/controllers/nvidia-device-plugin/kustomization.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - metallb
-  - cert-manager
-  - nvidia-device-plugin
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary

- **Ansible role `roles/nvidia-gpu`**: installs `nvidia-container-toolkit` from NVIDIA's distribution-agnostic repo, drops `config-v3.toml.tmpl` so K3s containerd 2.x registers the NVIDIA runtime as default, and verifies the GPU via `nvidia-container-cli`. Restarts k3s on config change.
- **Flux controller `nvidia-device-plugin`**: HelmRepository + HelmRelease deploying `nvidia-device-plugin` chart (`>=0.17.0`) into `kube-system`. Configured for **exclusive GPU allocation** (no time-slicing) to avoid VRAM contention between Tdarr/Plex transcoding workloads.
- `provision-nodes.yml` gains the `nvidia-gpu` role — toolkit is deployed as part of standard node provisioning.
- `controllers/kustomization.yaml` adds `nvidia-device-plugin` to the Flux reconciliation tree.

## What this enables

After running `provision-nodes.yml` and letting Flux reconcile, pods can request GPU resources:

```yaml
resources:
  limits:
    nvidia.com/gpu: 1
```

## Notes

- Assumes NVIDIA drivers are already installed on the node (confirmed: v595.58.03, CUDA 13.2).
- `config-v3.toml.tmpl` is deployed as a static file (not an Ansible template) to avoid Jinja2/Go-template conflicts with the `{{ template "base" . }}` directive.
- Uses `io.containerd.cri.v1.runtime` plugin path (containerd 2.x, K3s 1.35+).