### PR TITLE
fix(nvidia-gpu): gather service_facts in tasks, not as a handler

### DIFF
--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/handlers/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
 # roles/nvidia-gpu/handlers/main.yml
 
-- name: Gather service facts
-  ansible.builtin.service_facts:
-
 - name: Restart k3s
   ansible.builtin.systemd:
     name: "{{ 'k3s' if 'k3s.service' in ansible_facts.services else 'k3s-agent' }}"

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
@@ -41,6 +41,9 @@
 # it permanently for containerd 2.x, adding the NVIDIA runtime as the default.
 # The {{ template "base" . }} directive preserves all K3s-generated defaults.
 
+- name: Gather service facts (needed by restart handler)
+  ansible.builtin.service_facts:
+
 - name: Create K3s containerd config directory
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/agent/etc/containerd


### PR DESCRIPTION
## Problem

The `Restart k3s` handler checks `ansible_facts.services` to determine whether to restart `k3s` or `k3s-agent`, but `ansible_facts.services` was never populated — the `Gather service facts` handler was never notified by any task, so it never ran.

```
fatal: 'dict object' has no attribute 'services'
```

## Fix

Move `ansible.builtin.service_facts` from a handler into a regular task (before the containerd config copy). Tasks run before handlers flush, so `ansible_facts.services` is guaranteed to be available when `Restart k3s` evaluates the conditional.

Removed the now-unused `Gather service facts` handler.

## Changes
- `roles/nvidia-gpu/tasks/main.yml` — added `service_facts` task before the config copy
- `roles/nvidia-gpu/handlers/main.yml` — removed defunct `Gather service facts` handler