### PR TITLE
feat: add Node Feature Discovery as Flux infra controller

### DIFF
--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - metallb
   - cert-manager
   - nvidia-device-plugin
+  - node-feature-discovery

--- a/k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
       config:
         sources:
           pci:
-            # Label by PCI vendor ID only (e.g. feature.node.kubernetes.io/pci-10de.present=true
+            # Label by PCI vendor ID only (e.g. feature.node.kubernetes.io/pci-10de.present=true)
             # for NVIDIA). The chart default also includes class+device, producing more granular
             # labels like pci-0302_10de.present. Vendor-only labels match what nvidia-device-plugin
             # uses for its default node affinity.

--- a/k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: node-feature-discovery
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: node-feature-discovery
+      version: '>=0.18.0 <1.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: nfd
+        namespace: flux-system
+  targetNamespace: node-feature-discovery
+  install:
+    crds: CreateReplace
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    worker:
+      config:
+        sources:
+          pci:
+            # Label by PCI vendor ID only (e.g. feature.node.kubernetes.io/pci-10de.present=true
+            # for NVIDIA). The chart default also includes class+device, producing more granular
+            # labels like pci-0302_10de.present. Vendor-only labels match what nvidia-device-plugin
+            # uses for its default node affinity.
+            deviceLabelFields:
+              - vendor

--- a/k3s/infrastructure/controllers/node-feature-discovery/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/node-feature-discovery/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nfd
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/node-feature-discovery/charts

--- a/k3s/infrastructure/controllers/node-feature-discovery/kustomization.yaml
+++ b/k3s/infrastructure/controllers/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary

- Deploys [Node Feature Discovery](https://kubernetes-sigs.github.io/node-feature-discovery/) v0.18.x as a Flux-managed infra controller
- NFD auto-labels nodes with detected hardware features (CPU ISA extensions, PCI devices, storage, memory, kernel, etc.)
- Configures PCI vendor-only labels (`deviceLabelFields: [vendor]`) so `feature.node.kubernetes.io/pci-10de.present=true` is produced for the NVIDIA RTX 3070

## Why

The `nvidia-device-plugin` DaemonSet (deployed in #46) uses node affinity requiring `feature.node.kubernetes.io/pci-10de.present=true`. Without NFD, that label never appears and the device plugin DaemonSet has 0 desired pods — the GPU is never advertised to the scheduler.

## Changes

- `k3s/infrastructure/controllers/node-feature-discovery/helmrepository.yaml` — HelmRepository pointing to `https://kubernetes-sigs.github.io/node-feature-discovery/charts`
- `k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml` — HelmRelease with vendor-only PCI label config
- `k3s/infrastructure/controllers/node-feature-discovery/kustomization.yaml` — Kustomization for the above
- `k3s/infrastructure/controllers/kustomization.yaml` — adds `node-feature-discovery` resource

## Verification

After merge + Flux reconciliation, verify:
```bash
kubectl get pods -n node-feature-discovery
kubectl get node <node> --show-labels | grep pci-10de
kubectl get pods -n kube-system | grep nvidia
kubectl get node <node> -o jsonpath='{.status.capacity.nvidia\.com/gpu}'
```