### PR TITLE
fix: set runtimeClassName=nvidia on device plugin DaemonSet

### DIFF
--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
@@ -22,6 +22,10 @@ spec:
     remediation:
       retries: 3
   values:
+    # Run the device plugin pod with the nvidia container runtime so NVML
+    # libraries are mounted into the container. Without this the plugin crashes
+    # with ERROR_LIBRARY_NOT_FOUND when using the default runc runtime.
+    runtimeClassName: nvidia
     # Exclusive GPU allocation: no sharing config means the device plugin assigns
     # the full GPU to one pod at a time (the chart's default behavior).
     # migStrategy: none disables MIG partitioning — the RTX 3070 does not support


### PR DESCRIPTION
## Problem

`nvidia-device-plugin` crashes on startup with:
```
E Failed to initialize NVML: ERROR_LIBRARY_NOT_FOUND
```

The DaemonSet pod runs with the default `runc` runtime, which does not mount NVIDIA host libraries (`libnvidia-ml.so`) into the container. NVML is therefore unavailable and the plugin exits immediately.

## Fix

Add `runtimeClassName: nvidia` to the chart values. This causes containerd to use the `nvidia` container runtime for the device plugin pod, making NVML accessible. The `nvidia` RuntimeClass already exists in the cluster (created by the same chart).

## Change

`k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml` — adds `runtimeClassName: nvidia` to values

## Verification

After merge + Flux reconciliation:
```bash
kubectl get pods -n kube-system | grep nvidia     # should show Running
kubectl get node <node> -o jsonpath='{.status.capacity.nvidia\.com/gpu}'  # should return 1
```