### PR TITLE
chore: upgrade k3s to v1.36.0+k3s1

### DIFF
--- a/k3s/bootstrap/ansible/AGENTS.md
+++ b/k3s/bootstrap/ansible/AGENTS.md
@@ -26,7 +26,7 @@ ansible/
 | Task | Location | Notes |
 |------|----------|-------|
 | Add/remove cluster nodes | `inventory/hosts.yml` | Testbed: 192.168.1.128; target cluster: .40/.41/.42 |
-| Change k3s version | `inventory/group_vars/all.yml` | `k3s_version: v1.35.4+k3s1` |
+| Change k3s version | `inventory/group_vars/all.yml` | `k3s_version: v1.36.0+k3s1` |
 | Flux repo settings | `inventory/group_vars/all.yml` | `flux_github_owner: jander99`, `flux_github_repo: homelab`, `flux_git_branch: master` |
 | K3s server config | `roles/k3s-server/` | Writes `/etc/rancher/k3s/config.yaml` on remote |
 | Add OS packages/UFW rules | `inventory/group_vars/all.yml` | Common role reads from here |

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -39,7 +39,7 @@ k3s_sysctl_params:
 
 # K3s version installed on all nodes — pin to a specific release.
 # Find the latest: https://github.com/k3s-io/k3s/releases
-k3s_version: "v1.35.4+k3s1"
+k3s_version: "v1.36.0+k3s1"
 
 # K3s built-in components to disable — these are replaced by external controllers.
 # servicelb (klipper-lb) must be disabled when MetalLB is installed to prevent

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -142,6 +142,7 @@
     (k3s_installed_version.stdout is defined and
      k3s_version not in k3s_installed_version.stdout)
   changed_when: true
+  notify: Restart k3s
 
 - name: Enable and start K3s service
   ansible.builtin.systemd:

--- a/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-server/tasks/main.yml
@@ -151,6 +151,9 @@
     enabled: true
     daemon_reload: true
 
+- name: Flush handlers so K3s restarts before readiness checks
+  ansible.builtin.meta: flush_handlers
+
 - name: Wait for K3s API server port to open
   ansible.builtin.wait_for:
     host: 127.0.0.1


### PR DESCRIPTION
## Summary

- Bumps `k3s_version` from `v1.35.4+k3s1` → `v1.36.0+k3s1` in `inventory/group_vars/all.yml`
- Fixes an upgrade gap: the `Install K3s` task uses `INSTALL_K3S_SKIP_START: "true"` (installs binary, skips start), but previously had no `notify: Restart k3s` — meaning a running cluster would get the new binary installed without the service ever restarting. Added the handler notification so upgrades fully take effect.

## How to apply

```bash
cd k3s/bootstrap/ansible
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml -v
```