### PR TITLE
fix(tdarr): disable internal node on Synology

### DIFF
--- a/docker/media/tdarr-compose.yml
+++ b/docker/media/tdarr-compose.yml
@@ -14,11 +14,11 @@ services:
       - serverIP=0.0.0.0
       - serverPort=8266
       - webUIPort=8265
-      - internalNode=true
+      - internalNode=false
       - nodeName=synology-healthcheck
       - transcodecpuWorkers=0
       - transcodegpuWorkers=0
-      - healthcheckcpuWorkers=2
+      - healthcheckcpuWorkers=0
       - healthcheckgpuWorkers=0
     volumes:
       - /volume1/data:/media


### PR DESCRIPTION
## Summary

- Set `internalNode=false` — removes the built-in CPU worker node spawned by the server container
- Set `healthcheckcpuWorkers=0` — ensures no workers start even if internalNode is re-enabled

## Motivation

The Synology's Atom CPU was being overwhelmed during the initial library scan. All transcoding and health check work should be delegated to the K3s GPU node (RTX 3070).

## Apply

After merging, restart the container on the NAS:
```bash
docker-compose -f tdarr-compose.yml up -d
```