### PR TITLE
fix(storage): correct NFS export path to /volume1/data

### DIFF
--- a/k3s/infrastructure/configs/storage/nfs-media-pv-ro.yaml
+++ b/k3s/infrastructure/configs/storage/nfs-media-pv-ro.yaml
@@ -1,5 +1,5 @@
 ---
-# Read-only NFS PersistentVolume — Synology /data share
+# Read-only NFS PersistentVolume — Synology /volume1/data share
 # Mount this in pods that only need to read media (e.g. Plex, Jellyfin)
 # Pods must run with runAsUser: 1027, runAsGroup: 100, fsGroup: 100 to match NAS file ownership
 apiVersion: v1
@@ -13,7 +13,7 @@ spec:
     - ReadOnlyMany
   nfs:
     server: 192.168.1.20
-    path: /data
+    path: /volume1/data
     readOnly: true
   persistentVolumeReclaimPolicy: Retain
   # storageClassName must be "" on consuming PVCs; use volumeName: synology-media-ro for direct static binding

--- a/k3s/infrastructure/configs/storage/nfs-media-pv-rw.yaml
+++ b/k3s/infrastructure/configs/storage/nfs-media-pv-rw.yaml
@@ -1,5 +1,5 @@
 ---
-# Read-write NFS PersistentVolume — Synology /data share
+# Read-write NFS PersistentVolume — Synology /volume1/data share
 # Mount this in pods that need to write media (e.g. Sonarr, Radarr, NZBGet)
 # Pods must run with runAsUser: 1027, runAsGroup: 100, fsGroup: 100 to match NAS file ownership
 # NFS export on Synology: root_squash (default) is sufficient — only squashes UID 0; UID 1027 passes through
@@ -14,7 +14,7 @@ spec:
     - ReadWriteMany
   nfs:
     server: 192.168.1.20
-    path: /data
+    path: /volume1/data
   persistentVolumeReclaimPolicy: Retain
   # storageClassName must be "" on consuming PVCs; use volumeName: synology-media-rw for direct static binding
   storageClassName: ""


### PR DESCRIPTION
## Summary

- Fix `path: /data` → `path: /volume1/data` in both `nfs-media-pv-rw.yaml` and `nfs-media-pv-ro.yaml`

## Root Cause

Synology NFS exports use the full filesystem path (`/volume1/data`), not the logical share name (`/data`). The PV was configured with the wrong path, causing all NFS mounts to fail with "No such file or directory".

Confirmed via `showmount -e 192.168.1.20`:
```
Export list for 192.168.1.20:
/volume1/data 192.168.1.128
```

## Impact

Both PVs are affected — `synology-media-rw` and `synology-media-ro`. Any pod mounting either PV will fail until this is applied and the PV is recreated.