### PR TITLE
fix(tdarr): remove runAsUser/runAsGroup from pod securityContext

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -18,8 +18,6 @@ spec:
     spec:
       runtimeClassName: nvidia
       securityContext:
-        runAsUser: 1027
-        runAsGroup: 100
         fsGroup: 100
       containers:
         - name: tdarr-node


### PR DESCRIPTION
## Summary

- Removes `runAsUser: 1027` and `runAsGroup: 100` from the tdarr-node pod `securityContext`
- Keeps `fsGroup: 100` for correct NFS mount write permissions

## Why

LinuxServer.io containers (like `haveagitgat/tdarr_node`) require root at startup to run the s6-overlay init system, which internally drops privileges using the `PUID`/`PGID` environment variables. Setting `runAsUser` in the Kubernetes pod spec prevents s6 from calling `setgroups()`, causing `s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted` in a continuous boot loop.

The correct pattern for LSIO containers in Kubernetes is to omit `runAsUser`/`runAsGroup` and control user mapping exclusively through the `PUID` and `PGID` env vars already present in the deployment.