### PR TITLE
feat: GPU time-slicing (replicas=2) + tdarr Recreate update strategy

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app: tdarr-node
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: tdarr-node

--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
@@ -36,3 +36,6 @@ spec:
           version: v1
           flags:
             migStrategy: none
+          sharing:
+            timeSlicing:
+              replicas: 2


### PR DESCRIPTION
## Summary

- **nvidia-device-plugin**: Enable GPU time-slicing with `replicas: 2` so the RTX 3070 appears as 2 virtual GPUs cluster-wide. This allows multiple pods to co-schedule the GPU (e.g. during rolling updates or future GPU workloads).
- **tdarr deployment**: Add `strategy: Recreate` to avoid VRAM contention between old and new tdarr-node pods during updates. Since tdarr is a single-instance transcode workload, Recreate is the correct update strategy — terminate old before starting new.

## Why both?

Time-slicing enables general GPU sharing cluster-wide, but for Tdarr specifically (heavy NVENC usage against an 8GB card), two tdarr instances sharing VRAM during an update could OOM. `Recreate` ensures tdarr itself always gets a clean exclusive GPU slot at update time, while time-slicing remains available for other workloads or lighter co-tenancy scenarios.

## Changes

| File | Change |
|------|--------|
| `k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml` | Added `sharing.timeSlicing.replicas: 2` |
| `k3s/applications/tdarr/deployment.yaml` | Added `strategy: type: Recreate` |