### PR TITLE
fix(nvidia): add resources list to time-slicing config

### DIFF
--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
@@ -26,10 +26,9 @@ spec:
     # libraries are mounted into the container. Without this the plugin crashes
     # with ERROR_LIBRARY_NOT_FOUND when using the default runc runtime.
     runtimeClassName: nvidia
-    # Exclusive GPU allocation: no sharing config means the device plugin assigns
-    # the full GPU to one pod at a time (the chart's default behavior).
-    # migStrategy: none disables MIG partitioning — the RTX 3070 does not support
-    # MIG, but being explicit avoids ambiguity.
+    # GPU time-slicing: advertise 2 virtual GPU slots from the single RTX 3070.
+    # The resources list is required by the v1 config schema; omitting it causes
+    # the plugin to fail with 'no resources specified'.
     config:
       map:
         default: |-
@@ -38,4 +37,6 @@ spec:
             migStrategy: none
           sharing:
             timeSlicing:
-              replicas: 2
+              resources:
+                - name: nvidia.com/gpu
+                  replicas: 2


### PR DESCRIPTION
## Summary

- Fixes nvidia-device-plugin crashing with \`unable to parse config file: no resources specified\`
- The v1 config schema requires \`sharing.timeSlicing.resources[]\` with \`name\` + \`replicas\` fields
- Previous config had \`replicas: 2\` at the wrong level (directly under \`timeSlicing\` instead of under \`resources[0]\`)

## Validation

After Flux reconciles, the nvidia-device-plugin pod should start cleanly and \`kubectl describe node homelab | grep nvidia.com/gpu\` should show capacity of **2** instead of 1.