### PR TITLE
fix: install libnvidia-encode in nvidia-gpu Ansible role for NVENC support

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -43,6 +43,14 @@ spec:
               value: all
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
+            - name: transcodecpuWorkers
+              value: "0"
+            - name: transcodegpuWorkers
+              value: "1"
+            - name: healthcheckcpuWorkers
+              value: "1"
+            - name: healthcheckgpuWorkers
+              value: "0"
           resources:
             limits:
               nvidia.com/gpu: "1"

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# roles/nvidia-gpu/defaults/main.yml
+# Override nvidia_encode_package in group_vars or host_vars when the driver
+# series changes (e.g. upgrade from 595-server to 600-series requires updating
+# this value to libnvidia-encode-600-server).
+nvidia_encode_package: libnvidia-encode-595-server

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
@@ -39,7 +39,7 @@
   ansible.builtin.apt:
     name:
       - nvidia-container-toolkit
-      - libnvidia-encode-595-server
+      - "{{ nvidia_encode_package }}"
     state: present
     update_cache: true
   notify: Restart k3s

--- a/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nvidia-gpu/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 # roles/nvidia-gpu/tasks/main.yml
-# Installs nvidia-container-toolkit. K3s 1.35+ auto-detects the NVIDIA
-# container runtime at startup and adds it to containerd config automatically.
-# Assumes NVIDIA drivers are already installed on the node.
+# Installs nvidia-container-toolkit and libnvidia-encode (required for NVENC GPU
+# transcoding). K3s 1.35+ auto-detects the NVIDIA container runtime at startup
+# and adds it to containerd config automatically.
+# Assumes base NVIDIA drivers are already installed on the node (e.g. via
+# nvidia-headless-no-dkms-*-server-open). libnvidia-encode is a separate package
+# not included in the headless variant; without it NVENC encoding fails inside
+# containers even when the GPU is visible.
 #
 # Tested against: Ubuntu 26.04, K3s 1.35.x (containerd 2.x)
 
@@ -31,9 +35,11 @@
     content: |
       deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
 
-- name: Install nvidia-container-toolkit
+- name: Install nvidia-container-toolkit and NVENC encode library
   ansible.builtin.apt:
-    name: nvidia-container-toolkit
+    name:
+      - nvidia-container-toolkit
+      - libnvidia-encode-595-server
     state: present
     update_cache: true
   notify: Restart k3s


### PR DESCRIPTION
## Problem

The testbed K3s node runs `nvidia-headless-no-dkms-595-server-open`, the headless server variant which **excludes** `libnvidia-encode.so`. The NVIDIA container runtime can only inject libraries that exist on the host, so even though the GPU was fully visible inside containers (nvidia-smi worked, devices mounted), the NVENC hardware encoder failed at runtime:

\`\`\`
[h264_nvenc @ ...] Cannot load libnvidia-encode.so.1
[h264_nvenc @ ...] The minimum required Nvidia driver for nvenc is 520.56.06 or newer
\`\`\`

Tdarr-node reported `h264_nvenc-true-**false**` and `hevc_nvenc-true-**false**` in its encoder probe.

## Fix

Add `libnvidia-encode-595-server` to the `nvidia-gpu` Ansible role alongside `nvidia-container-toolkit`. The `-server` suffix matches the `-server-open` driver series installed on the node.

After installing on the host and restarting the tdarr-node pod, encoder status changed to:
- `h264_nvenc-true-**true**` ✅
- `hevc_nvenc-true-**true**` ✅

(`av1_nvenc-true-false` is expected — RTX 3070 has no AV1 NVENC hardware.)

## Note

`libnvidia-encode-595-server` is version-pinned. If the driver series is upgraded, update this package name accordingly.