### PR TITLE
fix: mount tdarr transcode cache emptyDir at /tmp

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: media
               mountPath: /media
             - name: transcode-cache
-              mountPath: /temp
+              mountPath: /tmp
             - name: config
               mountPath: /app/configs
       volumes:


### PR DESCRIPTION
## Summary

- Mount the 200Gi `transcode-cache` emptyDir at `/tmp` instead of `/temp`

## Why

Both the Movies and TV Tdarr libraries have their transcode cache configured at `/tmp`. Previously the node mounted the emptyDir at `/temp`, requiring either a path translator in node options or manual UI configuration to redirect `/tmp` → `/temp`.

Mounting directly at `/tmp` means library paths match node paths exactly — no path translator needed, no UI-side workaround required.

## Risk

Low. `/tmp` in a container is conventionally an empty writable directory. The emptyDir is mounted before the container starts (s6-overlay init has a writable `/tmp` from the start). The 200Gi sizeLimit ensures the node's SSD is used for transcode scratch space rather than the overlay filesystem.