### PR TITLE
fix: add CPU/memory resource limits to tdarr-node

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -52,11 +52,13 @@ spec:
             - name: healthcheckgpuWorkers
               value: "0"
           resources:
-            limits:
-              nvidia.com/gpu: "1"
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+              nvidia.com/gpu: "1"
           volumeMounts:
             - name: media
               mountPath: /media


### PR DESCRIPTION
## Problem

The tdarr-node health check worker was consuming most of the available CPU on the i7-4770k (4c/8t) testbed host, making the machine sluggish.

## Fix

Replaced the partial `resources` block in `k3s/applications/tdarr/deployment.yaml` with a proper Burstable QoS spec:

```yaml
resources:
  requests:
    cpu: 500m      # scheduler baseline when idle
    memory: 1Gi
  limits:
    cpu: 2000m     # ~25% of 8 logical threads
    memory: 4Gi    # ~12.5% of 32GB; prevents OOMKill on large files
    nvidia.com/gpu: "1"
```

**QoS class**: Burstable — appropriate for a background transcoding workload. Higher priority than BestEffort but won't starve other pods during memory pressure.

## Notes

- CPU limit of 2000m caps the health check ffmpeg decode at 2 threads, leaving 6 threads free for the OS and other workloads
- Memory limit of 4Gi is generous enough to handle large media files without risking OOMKill
- `nvidia.com/gpu: "1"` preserved in limits (required for GPU scheduling)
