### PR TITLE
feat(tdarr): replace hostPath config with local-path PVC

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -74,6 +74,5 @@ spec:
           emptyDir:
             sizeLimit: 200Gi
         - name: config
-          hostPath:
-            path: /var/lib/tdarr-node/configs
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: tdarr-node-config

--- a/k3s/applications/tdarr/pvc.yaml
+++ b/k3s/applications/tdarr/pvc.yaml
@@ -12,3 +12,20 @@ spec:
   resources:
     requests:
       storage: 28Ti
+
+---
+# Local PVC for tdarr node config — persists node identity (nodeName, worker config)
+# Uses K3s local-path provisioner; directory auto-created on first bind,
+# pinned to whichever node the pod schedules to (homelab testbed).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tdarr-node-config
+  namespace: tdarr
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary
- Adds `tdarr-node-config` PVC using K3s `local-path` StorageClass
- Replaces `hostPath` volume in `deployment.yaml` with the new PVC

## Why
The previous `hostPath` at `/var/lib/tdarr-node/configs` is fragile: it requires the directory to exist on the node before the pod starts, and isn't tracked by Kubernetes. If the node is re-provisioned, the tdarr node identity is lost and it re-registers as a ghost.

## Changes
- `k3s/applications/tdarr/pvc.yaml`: Added `tdarr-node-config` PVC (`local-path`, `ReadWriteOnce`, 1Gi)
- `k3s/applications/tdarr/deployment.yaml`: Replaced `hostPath` config volume with PVC reference

## Notes
- `local-path` provisioner (K3s default) auto-creates the directory on first bind
- Storage pins to the scheduling node automatically via `WaitForFirstConsumer`
- No manual PV or nodeAffinity required
- Existing hostPath data at `/var/lib/tdarr-node/configs` on the node may need to be copied into the new PVC path after first pod start