### PR TITLE
feat: mount Synology NFS at OS level via Ansible

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -21,6 +21,22 @@ spec:
       runtimeClassName: nvidia
       securityContext:
         fsGroup: 100
+      initContainers:
+        - name: verify-nfs-mount
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - |
+              if ! grep -q ' /mnt/synology/media nfs4 ' /host-proc/mounts; then
+                echo 'ERROR: /mnt/synology/media is not mounted as nfs4 — refusing to start'
+                exit 1
+              fi
+              echo 'NFS4 mountpoint verified'
+          volumeMounts:
+            - name: host-proc-mounts
+              mountPath: /host-proc/mounts
+              readOnly: true
       containers:
         - name: tdarr-node
           image: haveagitgat/tdarr_node:latest
@@ -77,3 +93,7 @@ spec:
         - name: config
           persistentVolumeClaim:
             claimName: tdarr-node-config
+        - name: host-proc-mounts
+          hostPath:
+            path: /proc/mounts
+            type: File

--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -68,8 +68,9 @@ spec:
               mountPath: /app/configs
       volumes:
         - name: media
-          persistentVolumeClaim:
-            claimName: tdarr-media
+          hostPath:
+            path: /mnt/synology/media
+            type: Directory
         - name: transcode-cache
           emptyDir:
             sizeLimit: 200Gi

--- a/k3s/applications/tdarr/pvc.yaml
+++ b/k3s/applications/tdarr/pvc.yaml
@@ -1,19 +1,4 @@
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: tdarr-media
-  namespace: tdarr
-spec:
-  accessModes:
-    - ReadWriteMany
-  storageClassName: ""
-  volumeName: synology-media-rw
-  resources:
-    requests:
-      storage: 28Ti
-
----
 # Local PVC for tdarr node config — persists node identity (nodeName, worker config)
 # Uses K3s local-path provisioner; directory auto-created on first bind,
 # pinned to whichever node the pod schedules to (homelab testbed).

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -15,6 +15,7 @@ common_packages:
   - unzip
   - jq
   - update-notifier-common
+  - nfs-common
 
 # UFW rules — K3s required ports + SSH
 k3s_firewall_rules:
@@ -61,3 +62,13 @@ k3s_oidc_issuer_url: "https://auth.homelab.properties/application/o/headlamp/"
 k3s_oidc_client_id: "headlamp"
 k3s_oidc_username_claim: "preferred_username"
 k3s_oidc_groups_claim: "groups"
+
+# ─── NFS mounts ──────────────────────────────────────────────────────────────
+# OS-level NFS mounts configured via /etc/fstab by the nfs-mounts role.
+# Mounting at OS level avoids kubelet lifecycle entanglement (stale mounts
+# no longer block pod termination or require k3s restarts to recover).
+# soft + timeo=30 + retrans=3: fail cleanly after ~9s instead of blocking forever.
+nfs_mounts:
+  - src: 192.168.1.20:/volume1/data
+    path: /mnt/synology/media
+    opts: vers=4.1,rsize=32768,wsize=32768,soft,timeo=30,retrans=3,_netdev,noresvport,noatime

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -15,7 +15,6 @@ common_packages:
   - unzip
   - jq
   - update-notifier-common
-  - nfs-common
 
 # UFW rules — K3s required ports + SSH
 k3s_firewall_rules:

--- a/k3s/bootstrap/ansible/playbooks/provision-nodes.yml
+++ b/k3s/bootstrap/ansible/playbooks/provision-nodes.yml
@@ -1,7 +1,8 @@
 ---
 # provision-nodes.yml
 # Prepares Ubuntu nodes for K3s: OS hardening, package management, K3s prerequisites,
-# and NVIDIA GPU support (nvidia-container-toolkit + containerd runtime config).
+# NVIDIA GPU support (nvidia-container-toolkit + containerd runtime config),
+# and OS-level NFS mounts (more stable than K8s PV/PVC for single-node workloads).
 #
 # Usage: ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml -v
 
@@ -12,3 +13,4 @@
     - common
     - k3s-prereqs
     - nvidia-gpu
+    - nfs-mounts

--- a/k3s/bootstrap/ansible/roles/nfs-mounts/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/nfs-mounts/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# roles/nfs-mounts/defaults/main.yml
+# Override nfs_mounts in group_vars/all.yml or host_vars/<host>.yml
+
+# List of NFS mounts to configure on this node.
+# Each entry is passed directly to ansible.posix.mount (state: mounted).
+#
+# Example:
+#   nfs_mounts:
+#     - src: 192.168.1.20:/volume1/data
+#       path: /mnt/synology/media
+#       opts: vers=4.1,rsize=32768,wsize=32768,soft,timeo=30,retrans=3,_netdev,noresvport,noatime
+nfs_mounts: []

--- a/k3s/bootstrap/ansible/roles/nfs-mounts/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nfs-mounts/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# roles/nfs-mounts/tasks/main.yml
+# Configures OS-level NFS mounts via /etc/fstab + systemd (_netdev).
+# Mounting at the OS level (rather than via K8s PV/PVC) avoids kubelet
+# lifecycle entanglement: stale mounts no longer block pod termination
+# or require k3s restarts to recover.
+
+- name: Ensure nfs-common is installed
+  ansible.builtin.apt:
+    name: nfs-common
+    state: present
+    update_cache: false
+
+- name: Create NFS mount point directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+  loop: "{{ nfs_mounts }}"
+
+- name: Configure NFS mounts in /etc/fstab and mount immediately
+  ansible.posix.mount:
+    src: "{{ item.src }}"
+    path: "{{ item.path }}"
+    fstype: nfs4
+    opts: "{{ item.opts }}"
+    state: mounted
+    dump: "0"
+    passno: "0"
+  loop: "{{ nfs_mounts }}"


### PR DESCRIPTION
## Summary
- New Ansible role `nfs-mounts` provisions OS-level NFS mounts via `/etc/fstab`
- tdarr switches from K8s PVC to `hostPath` pointing at the Ansible-managed mount

## Problem
K8s-managed NFS (PV/PVC) is entangled with the kubelet pod lifecycle. When NFS goes stale (e.g. transient NAS blip), kubelet blocks trying to `umount` on pod termination. The new pod then gets stuck in `ContainerCreating`. Recovery requires:
```
sudo umount -f -l /var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~nfs/synology-media-rw
sudo systemctl restart k3s
kubectl delete pod -n tdarr ... --force
```
This happened twice in 48 hours.

## Solution
OS-level NFS mount via systemd (`_netdev`). Mount lifecycle is independent of pods — a stale mount recovers with `sudo mount -a`, no k3s restart needed. The `soft` option ensures NFS operations fail with ESTALE after ~9s (30 deciseconds × 3 retries) instead of blocking forever.

## Mount Options
```
vers=4.1,rsize=32768,wsize=32768,soft,timeo=30,retrans=3,_netdev,noresvport,noatime
```
- `rsize/wsize=32768`: aligned to Synology 32KB NFS packet size setting
- `soft,timeo=30,retrans=3`: fail cleanly after ~9s (vs. `hard` which blocks forever)
- `_netdev`: systemd waits for network before mounting at boot
- `noresvport`: allows kernel to reuse ports after NFS blip
- `noatime`: avoids write amplification from access time updates

## Changes
- `roles/nfs-mounts/defaults/main.yml`: role defaults (`nfs_mounts: []`)
- `roles/nfs-mounts/tasks/main.yml`: install nfs-common, create dirs, configure fstab + mount
- `group_vars/all.yml`: `nfs_mounts` var for Synology media share; `nfs-common` in `common_packages`
- `playbooks/provision-nodes.yml`: adds `nfs-mounts` role
- `k3s/applications/tdarr/deployment.yaml`: media volume → `hostPath: /mnt/synology/media`
- `k3s/applications/tdarr/pvc.yaml`: removes `tdarr-media` PVC

## Post-merge Steps
1. Run Ansible: `ansible-playbook -i inventory/hosts.yml playbooks/provision-nodes.yml -v`
   - This mounts `/mnt/synology/media` on the testbed node
2. Delete old stale K8s NFS mount (if still present):
   `sudo umount -f -l /var/lib/kubelet/pods/<old-uid>/volumes/kubernetes.io~nfs/synology-media-rw`
3. Delete old `synology-media-rw` PV (Released, no longer needed):
   `kubectl delete pv synology-media-rw`
4. Let Flux reconcile tdarr deployment — pod restarts with hostPath volume

## Notes
- `synology-media-rw` PV is left as-is (Released, Retain policy) — not removed to avoid Flux deletion race. Manual cleanup: `kubectl delete pv synology-media-rw` after merge.
- `tdarr-node-config` PVC (local-path, from PR #63) is unaffected.