### PR TITLE
fix(ansible): use NFSv3 for OS-level NFS mount

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -70,4 +70,4 @@ k3s_oidc_groups_claim: "groups"
 nfs_mounts:
   - src: 192.168.1.20:/volume1/data
     path: /mnt/synology/media
-    opts: vers=3,soft,timeo=30,retrans=3,_netdev,noresvport,noatime
+    opts: vers=3,soft,timeo=30,retrans=3,_netdev,noatime

--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -70,4 +70,4 @@ k3s_oidc_groups_claim: "groups"
 nfs_mounts:
   - src: 192.168.1.20:/volume1/data
     path: /mnt/synology/media
-    opts: vers=4.1,rsize=32768,wsize=32768,soft,timeo=30,retrans=3,_netdev,noresvport,noatime
+    opts: vers=3,soft,timeo=30,retrans=3,_netdev,noresvport,noatime

--- a/k3s/bootstrap/ansible/roles/nfs-mounts/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/nfs-mounts/tasks/main.yml
@@ -24,7 +24,7 @@
   ansible.posix.mount:
     src: "{{ item.src }}"
     path: "{{ item.path }}"
-    fstype: nfs4
+    fstype: nfs
     opts: "{{ item.opts }}"
     state: mounted
     dump: "0"


### PR DESCRIPTION
NFSv4.1 mount hangs indefinitely on Synology during initial session establishment. NFSv3 mounts immediately and cleanly. Dropped explicit rsize/wsize — NFSv3 auto-negotiates 131072 (better than our previous 32768). Removed vers= from the soft/timeo opts accordingly.