### PR TITLE
fix(tdarr): fix initContainer grep for NFSv3 mount type

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -28,11 +28,11 @@ spec:
             - sh
             - -c
             - |
-              if ! grep -q ' /mnt/synology/media nfs4 ' /host-proc/mounts; then
-                echo 'ERROR: /mnt/synology/media is not mounted as nfs4 — refusing to start'
+              if ! grep -q ' /mnt/synology/media nfs ' /host-proc/mounts; then
+                echo 'ERROR: /mnt/synology/media is not mounted as nfs — refusing to start'
                 exit 1
               fi
-              echo 'NFS4 mountpoint verified'
+              echo 'NFS mountpoint verified'
           volumeMounts:
             - name: host-proc-mounts
               mountPath: /host-proc/mounts


### PR DESCRIPTION
## Problem

The `verify-nfs-mount` initContainer was grep-ing for `nfs4` in `/proc/mounts`, but after fixing to NFSv3 in PR #65, the mount type is `nfs` — not `nfs4`. The initContainer would always exit 1, causing the pod to crash-loop indefinitely.

## Fix

Changed the grep pattern from `' /mnt/synology/media nfs4 '` to `' /mnt/synology/media nfs '` in `k3s/applications/tdarr/deployment.yaml`. Also updated the echo messages to drop the "4" suffix for consistency.

## Testing

Mount confirmed on testbed:
```
192.168.1.20:/volume1/data on /mnt/synology/media type nfs (rw,noatime,vers=3,...)
```
The pattern `' /mnt/synology/media nfs '` will match this line. The `nfs4` pattern would not.