### PR TITLE
feat(nfs): upgrade OS-level NFS mount to v4.1

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -70,4 +70,4 @@ k3s_oidc_groups_claim: "groups"
 nfs_mounts:
   - src: 192.168.1.20:/volume1/data
     path: /mnt/synology/media
-    opts: vers=3,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime
+    opts: vers=4.1,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime


### PR DESCRIPTION
## Context

Previous NFSv4.1 attempts via K8s static PVs failed due to:
- Kubelet managing the mount lifecycle (stale mounts blocked pod termination)
- `noresvport` on the PV breaking NFSv4.1 session recovery (client reconnects on a new port, server can't associate with old session)
- In-tree K8s NFS driver limitations with NFSv4.1 sessions

Those PVs were removed in #68. The OS-level fstab mount (introduced in #65, tuned in #69) bypasses all of this — the kernel NFS client manages the v4.1 session directly, independently of kubelet.

## Change

```diff
-    opts: vers=3,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime
+    opts: vers=4.1,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime
```

## Expected improvement

With NFSv3 the Synology server negotiated down to 128KB rsize/wsize. NFSv4.1 removes that cap — the full 1MB block size should be negotiated, potentially pushing throughput from ~15 MB/s toward CIFS territory (50+ MB/s).

## Apply

After merge:
```bash
cd k3s/bootstrap/ansible
ansible-playbook playbooks/provision-nodes.yml
```

If the mount hangs during the playbook, unmount first:
```bash
sudo umount -f /mnt/synology/media
# then re-run playbook
```

Verify:
```bash
grep synology /proc/mounts
# expect: vers=4.1,rsize=1048576,wsize=1048576,proto=tcp
```

## Rollback

If NFSv4.1 is unstable, revert `vers=4.1` → `vers=3` in `group_vars/all.yml` and re-run the playbook.