### PR TITLE
revert(nfs): downgrade back to NFSv3 — Synology does not support NFSv4.1

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -70,4 +70,4 @@ k3s_oidc_groups_claim: "groups"
 nfs_mounts:
   - src: 192.168.1.20:/volume1/data
     path: /mnt/synology/media
-    opts: vers=4.1,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime
+    opts: vers=3,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime


### PR DESCRIPTION
## Reason

NFSv4.1 testing revealed the Synology DSM does not support NFSv4.1 or NFSv4.2. Attempting to mount with `vers=4.1` hung indefinitely — the kernel tried 4.2 first (Protocol not supported), then fell back to 4.1 which never completed the handshake.

NFSv4.0 does work, but the Synology enforces a 128KB rsize/wsize cap server-side for all NFS versions (same as NFSv3). There is zero performance benefit to NFSv4.0 over NFSv3 on this hardware, and NFSv4 adds `nfs-idmapd` dependency complexity.

## NFS version matrix on this Synology

| Version | Works | rsize/wsize cap |
|---------|-------|-----------------|
| NFSv3 | ✓ | 128KB (server) |
| NFSv4.0 | ✓ | 128KB (server) |
| NFSv4.1 | ✗ | Hangs — not supported |
| NFSv4.2 | ✗ | Protocol not supported |

## Change

```diff
-    opts: vers=4.1,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime
+    opts: vers=3,proto=tcp,rsize=1048576,wsize=1048576,soft,timeo=30,retrans=3,_netdev,noatime
```

`proto=tcp` and `rsize/wsize=1048576` are kept — they're still correct (kernel negotiates down to 128KB but no harm in requesting 1MB).