### PR TITLE
chore: disable tdarr in Flux applications kustomization

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - headlamp/
   - pihole/
-  - tdarr/
+  # - tdarr/  # disabled: see PR infra/disable-tdarr
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.


### PR DESCRIPTION
## Summary

Temporarily disables tdarr by commenting it out of the Flux applications kustomization.

With `prune: true` on the `apps` Kustomization, Flux will reconcile away any existing tdarr resources in the cluster.

The tdarr manifests (`k3s/applications/tdarr/`) are preserved so the app can be re-enabled later by uncommenting the line.

## Changes

- `k3s/applications/kustomization.yaml`: commented out `- tdarr/` resource entry