### PR TITLE
feat(k3s): add csi-driver-smb for SMB/CIFS storage

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -15,6 +15,7 @@ common_packages:
   - unzip
   - jq
   - update-notifier-common
+  - cifs-utils
 
 # UFW rules — K3s required ports + SSH
 k3s_firewall_rules:

--- a/k3s/infrastructure/configs/kustomization.yaml
+++ b/k3s/infrastructure/configs/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cert-manager
   - monitoring
   - authentik
+  - smb-storage

--- a/k3s/infrastructure/configs/smb-storage/kustomization.yaml
+++ b/k3s/infrastructure/configs/smb-storage/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k3s/infrastructure/configs/smb-storage/kustomization.yaml
+++ b/k3s/infrastructure/configs/smb-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storageclass.yaml
+  - smb-credentials.sops.yaml

--- a/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml
+++ b/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml
@@ -1,0 +1,28 @@
+#ENC[AES256_GCM,data:OfbA41pz6AO1THdyDvyWAKQ63dW1jewug0Mwr77UtxbGZTyZqv3k3va173T0YWK3k4NIHavK,iv:wzIGOHMD/8Qk/KQ5NH1pGbL2iY07PBP4LJQwcyyOXO8=,tag:hWRdjU0QpK9xnSPeIVt0NQ==,type:comment]
+#ENC[AES256_GCM,data:SW5MJjrqhNV2CKvTKbAUVUGxOEoXRU3g2F4wm4eF+WoMctiPVZOruyfcrKrO,iv:wV++mdTtKagX1NQfJc+SIYFKfVnP73lRot5F2kZmvrg=,tag:Za40Eoe+gF7QJa9isphpBg==,type:comment]
+#ENC[AES256_GCM,data:L5zkOS3FyfkTGAEP0JZizMTo5pGTMVoAuBksChyBfmetEgXUrqIrQBohq3bX06M63h49XvHbZ3j/7jyookvZ3x+2R+AHIpvE1NTh1B2w,iv:N5WQcbcvAwUVdqY7Rt/f7/jJJJlv8592IRJlAzpkZTk=,tag:BfDPioS0WFnFp73oH67j5Q==,type:comment]
+#ENC[AES256_GCM,data:OMkrmQmwAYq2gqs5GdGCBDjoeVM3Ap2bZTjdKZ9xo+v0lPmUQ7du8YaCJFSw/cK/xSsE,iv:qbEf3JSIzYdJKcv+fCyItJyAcNWX37W7D51Uo0rqhN4=,tag:VzpafJ0S4GxWq1POj9pkGA==,type:comment]
+apiVersion: ENC[AES256_GCM,data:K+A=,iv:2GG4NcSARVrGOhC973+HAmORu/2VnIhlqCuVA//0zXU=,tag:ApR95+VBkw4AYhKaprQJTg==,type:str]
+kind: ENC[AES256_GCM,data:eRmk1VM4,iv:1IXPtU4auy1VptrD8wf1NCa+fgeWamMTIk41U2kdL94=,tag:nTugRA9g0HofOF0c8boLMQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:ivc3IDxIpfo=,iv:hJzI0cUMLuGM63GyEOEDr30bEQjCdV5Ny6QJQ6G9ybU=,tag:SBYzTE5MGGm5EWrCnlmNqQ==,type:str]
+    namespace: ENC[AES256_GCM,data:kwlH36DV/Zjrck0=,iv:GHE4GBQKPL4EB6hGyukp859Zk96HJpgKUMk8HO/Hnh4=,tag:5Rs7k4JqbdhLZXBUCU5Uaw==,type:str]
+type: ENC[AES256_GCM,data:rb0ZA5DR,iv:PXxzBnXKClD0VFB04d7sImn0Q73ZHaevl3KgH+sVUZ8=,tag:asAVCSz+qUUegMy8RWgr0A==,type:str]
+stringData:
+    username: ENC[AES256_GCM,data:PQiHoUTXeqxJ,iv:i0fmB5RdyYVHLsQEMIAPPLJobfeHz7SJCSeUZbesyVc=,tag:LjceIqnKOWSxJ+tVj2vwCw==,type:str]
+    password: ENC[AES256_GCM,data:VCzGCaJhoCpUrLPp,iv:cbnVMa0ePVBDv8x4i5LeGA1Cr54gjmuJQRlG+s0VpIA=,tag:4VXjrKlsBFzvdfezu4910w==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiQWVvdkkrb2dhNE1xbjFr
+            c3IvNGFlRW9CLy9obEpjT0NDWE9KYjRJdlFzCjdaN01mUm56VWJSTTZBUnZVNWRS
+            U3dwOUpJOCtxbDVIN3JjR1BuQXp2azAKLS0tIFoyQVBMaGNQNDRURGZrVGpnZFJC
+            dFFZeUlpSW8wMVNlYlp2empZV0tXak0KAoDOEuEbhCh4ve/t9r3/EaV37zg0Xeik
+            LTlGNEC1RH6VWexYuNZe5vTKp7mwNEpCBwjFV2430YrDUM7moKA2hg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-17T16:20:07Z"
+    mac: ENC[AES256_GCM,data:LgFzXXPw5qvAYP5IkGyOo7fyfz6Vmgf4NbnMUCFIZxOVaHWC6rqmclPv3SpMuAQ5QBbcSnH0+1LXmZ90ATt2TIKl6UOl4Pqs50eNeCM+oQSWaBXIcbheMgb48TiJywe1U88dtdopdzS2s0THtB8O3bgALCwtRdyTVmI8ZfM9l9k=,iv:hS1mBTHA1CDNb5miN0eOLByuHzWxjidZJwomLO5H4w8=,tag:+ZPxuh1UVjpifYXOnUJ4YA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml.example
+++ b/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml.example
@@ -1,0 +1,13 @@
+# TEMPLATE: Copy this file to smb-credentials.sops.yaml
+# Fill in username and password, then encrypt:
+#   sops --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     --encrypt --in-place smb-credentials.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: smbcreds
+  namespace: kube-system
+type: Opaque
+stringData:
+  username: k8s-media
+  password: REPLACE_WITH_ACTUAL_PASSWORD

--- a/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml.example
+++ b/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml.example
@@ -1,7 +1,7 @@
 # TEMPLATE: Copy this file to smb-credentials.sops.yaml
 # Fill in username and password, then encrypt:
-#   sops --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
-#     --encrypt --in-place smb-credentials.sops.yaml
+#   sops --encrypt --in-place smb-credentials.sops.yaml
+# (The .sops.yaml creation_rules supply the age recipient automatically.)
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k3s/infrastructure/configs/smb-storage/storageclass.yaml
+++ b/k3s/infrastructure/configs/smb-storage/storageclass.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/k3s/infrastructure/configs/smb-storage/storageclass.yaml
+++ b/k3s/infrastructure/configs/smb-storage/storageclass.yaml
@@ -1,0 +1,28 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: smb-media
+  annotations:
+    # NOT the cluster default — local-path remains default for config volumes
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: smb.csi.k8s.io
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+allowVolumeExpansion: false
+parameters:
+  # Replace <NAS_IP> and <SHARE_NAME> with your Synology NAS IP and share name
+  # Example: //192.168.1.10/media
+  source: //192.168.1.20/data
+  csi.storage.k8s.io/provisioner-secret-name: smbcreds
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: smbcreds
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+mountOptions:
+  - vers=3.0
+  - dir_mode=0777
+  - file_mode=0777
+  - uid=1027
+  - gid=100
+  - noperm
+  - cache=strict
+  - noserverino

--- a/k3s/infrastructure/controllers/csi-driver-smb/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/csi-driver-smb/helmrelease.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/k3s/infrastructure/controllers/csi-driver-smb/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/csi-driver-smb/helmrelease.yaml
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-driver-smb
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: csi-driver-smb
+      version: "1.20.1"
+      sourceRef:
+        kind: HelmRepository
+        name: csi-driver-smb
+        namespace: flux-system
+  targetNamespace: kube-system
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # runOnControlPlane: true is required for single-node K3s clusters where
+    # the control-plane node is also a worker. Remove this if adding worker nodes.
+    controller:
+      runOnControlPlane: true
+      replicas: 1
+    linux:
+      enabled: true
+      kubelet: /var/lib/kubelet
+      tolerations:
+        - operator: Exists
+    windows:
+      enabled: false

--- a/k3s/infrastructure/controllers/csi-driver-smb/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/csi-driver-smb/helmrepository.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/k3s/infrastructure/controllers/csi-driver-smb/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/csi-driver-smb/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: csi-driver-smb
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts

--- a/k3s/infrastructure/controllers/csi-driver-smb/kustomization.yaml
+++ b/k3s/infrastructure/controllers/csi-driver-smb/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k3s/infrastructure/controllers/csi-driver-smb/kustomization.yaml
+++ b/k3s/infrastructure/controllers/csi-driver-smb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cert-manager
   - nvidia-device-plugin
   - node-feature-discovery
+  - csi-driver-smb


### PR DESCRIPTION
## Summary

Adds SMB/CIFS persistent storage support to the K3s cluster via `csi-driver-smb`.

## Changes

### Infrastructure Controllers (`k3s/infrastructure/controllers/csi-driver-smb/`)
- **HelmRepository**: Adds `csi-driver-smb` Helm repository (csi-driver-smb.sigs.k8s.io)
- **HelmRelease**: Deploys `csi-driver-smb` chart v1.20.1 into `kube-system`; `controller.runOnControlPlane: true` for single-node K3s compatibility
- **kustomization.yaml**: Wires up the HelmRepository + HelmRelease resources
- `k3s/infrastructure/controllers/kustomization.yaml`: Added `- csi-driver-smb` path entry

### Infrastructure Configs (`k3s/infrastructure/configs/smb-storage/`)
- **StorageClass `smb-media`**: provisioner `smb.csi.k8s.io`, `reclaimPolicy: Retain`, source `//192.168.1.20/data` (Synology NAS), mountOptions: `vers=3.0`, `noserverino`, `uid=1027`, `gid=100`
- **SOPS-encrypted Secret `smbcreds`** (namespace `kube-system`): SMB username/password encrypted with age key; decrypted by Flux's SOPS provider at deploy time
- **smb-credentials.sops.yaml.example**: Plaintext example template for reference (no real credentials)
- `k3s/infrastructure/configs/kustomization.yaml`: Added `- smb-storage` path entry

## Security
- `smb-credentials.sops.yaml` contains only `ENC[AES256_GCM,...]` ciphertext — no plaintext passwords committed
- Encrypted with the project's `.sops.yaml` age key configuration

## Testing
- `kubectl kustomize k3s/infrastructure/controllers/` — passes
- `kubectl kustomize k3s/infrastructure/configs/` — passes
- Cluster verification (Flux reconcile + test PVC) is scheduled after merge (Part C)

## Notes
- Do NOT merge until Part C (cluster verification) is ready to proceed
- Single-node K3s on 192.168.1.128 (testbed node)