### PR TITLE
docker/pihole: remove cloudflared sidecar, switch to plain DNS

### DIFF
--- a/docker/pihole/pihole-compose.yml
+++ b/docker/pihole/pihole-compose.yml
@@ -1,22 +1,6 @@
 version: "3.8"
 
 services:
-
-  cloudflared:
-    container_name: cloudflared
-    image: cloudflare/cloudflared:2026.5.0
-    environment:
-      - TZ='America/New_York'
-      - TUNNEL_DNS_UPSTREAM=https://1.1.1.1/dns-query,https://1.0.0.1/dns-query,https://9.9.9.9/dns-query,https://149.112.112.9/dns-query
-      - TUNNEL_DNS_PORT=5053
-      - TUNNEL_DNS_ADDRESS=0.0.0.0
-      - TUNNEL_METRICS=0.0.0.0:33301
-    command: proxy-dns
-    networks:
-      br:
-        ipv4_address: 172.20.1.1
-    restart: unless-stopped
-
   pihole:
     container_name: pihole
     image: pihole/pihole:2026.05.0
@@ -24,8 +8,8 @@ services:
       - TZ='America/New_York'
       - WEBPASSWORD=admin
       - ServerIP=192.168.1.2
-      - DNS1=172.20.1.1#5053
-      - DNS2=no
+      - DNS1=1.1.1.1
+      - DNS2=1.0.0.1
     volumes:
       - '/volume1/docker/config/pihole/:/etc/pihole/'
       - '/volume1/docker/config/pihole/dnsmasq.d/:/etc/dnsmasq.d/'
@@ -35,8 +19,6 @@ services:
       br:
         ipv4_address: 172.20.1.2
     restart: unless-stopped
-    depends_on:
-      - cloudflared
 
   pihole-exporter:
     container_name: pihole-exporter
@@ -50,9 +32,6 @@ services:
     restart: unless-stopped
     depends_on:
       - pihole
-
-        
-
 networks:
   br:
     external: 


### PR DESCRIPTION
## Summary

Removes the cloudflared `proxy-dns` sidecar from the Docker Pi-hole stack. The cloudflared `proxy-dns` command was deprecated in November 2025, breaking the DoH upstream DNS chain.

## Changes

- **Removed** `cloudflared` service (image, env, networks, command)
- **Updated** Pi-hole upstream DNS from `172.20.1.1#5053` (cloudflared DoH) → `1.1.1.1` / `1.0.0.1` (plain Cloudflare DNS), matching the K3s configuration
- **Removed** `depends_on: cloudflared` from the pihole service

## Why

The K3s Pi-hole config already uses plain DNS to Cloudflare for the same reason — the cloudflared proxy-dns feature was deprecated. This aligns the Docker stack with that decision.