### PR TITLE
feat(k3s): deploy portainer-agent via Flux GitOps

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - headlamp/
   - pihole/
+  - portainer/
   # - tdarr/  # disabled: see PR infra/disable-tdarr
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.

--- a/k3s/applications/portainer/deployment.yaml
+++ b/k3s/applications/portainer/deployment.yaml
@@ -27,6 +27,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: AGENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: portainer-agent-secret
+              key: AGENT_SECRET
         ports:
         - containerPort: 9001
           protocol: TCP

--- a/k3s/applications/portainer/deployment.yaml
+++ b/k3s/applications/portainer/deployment.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portainer-agent
+  namespace: portainer
+spec:
+  selector:
+    matchLabels:
+      app: portainer-agent
+  template:
+    metadata:
+      labels:
+        app: portainer-agent
+    spec:
+      serviceAccountName: portainer-sa-clusteradmin
+      containers:
+      - name: portainer-agent
+        image: portainer/agent:2.39.2
+        imagePullPolicy: Always
+        env:
+        - name: LOG_LEVEL
+          value: INFO
+        - name: AGENT_CLUSTER_ADDR
+          value: "portainer-agent-headless"
+        - name: KUBERNETES_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        ports:
+        - containerPort: 9001
+          protocol: TCP

--- a/k3s/applications/portainer/kustomization.yaml
+++ b/k3s/applications/portainer/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - services.yaml
+  - deployment.yaml

--- a/k3s/applications/portainer/kustomization.yaml
+++ b/k3s/applications/portainer/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - serviceaccount.yaml
   - services.yaml
   - deployment.yaml
+  - portainer-agent-secret.sops.yaml

--- a/k3s/applications/portainer/portainer-agent-secret.sops.yaml
+++ b/k3s/applications/portainer/portainer-agent-secret.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:tLs=,iv:ZxCkEmf4QL8cRk4nWHhIQtRN/ExHXUkkzlCB/K0xEmI=,tag:SzKolEPpuClhZpYwWf3hMg==,type:str]
+kind: ENC[AES256_GCM,data:ZZYhFpTM,iv:9kCebTW6iPLyGi7a5EOoRM1sk+YZvTCn+IPgGnHdlYY=,tag:c+s1jCbOU3QByWLrpqVB2w==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:uUX/fvXT85hMCuSL6adNOg6meuJQvA==,iv:c2M6XSYxPQ74+3P00XmcYE5ZRaCW1uH9DCHpzOOFvMA=,tag:LGgeYh8uF2ePo4VAHuo9WQ==,type:str]
+    namespace: ENC[AES256_GCM,data:KRGsbA6oP7aH,iv:siMw2Qe27CUrpeLHmnJvim+JmnqxFEXNKgmR9eAuJ/c=,tag:8upaVuA2l29ko/xfU+bDZw==,type:str]
+stringData:
+    AGENT_SECRET: ENC[AES256_GCM,data:5jisnI8tx4MXk96Wth5KQd7aCcsUGN2kUG5q2dSdX9u+ZqJEDuORZ5cRCW+0S6ktDNRozBgp/duBxkOfRjiLTM2giApVrgzbxsaYpWUy3nPr/cns/7lz6St3N1zkj2v7YXYBq6VAUVpr+8H6t3PM6/8JAshjvtI=,iv:Td8E7FQt97Us5qc8oNF/LNH7t94JedHL/E6oXvfnq8M=,tag:GLx2Hn8v2nfrhS9QhVsS5Q==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtM29FN3ArTkluL1hmY0lm
+            bllRNXVXUDFtWUJuKzZnS08xOFkvNmZTdVJnCm1SVW5GM2NOQ0V2eEV5REphcFdO
+            d251dmNZRHA5QjhHZ3VQY0xLWEF0bzAKLS0tIHNScURNcnVTczcveDdLanN4UzF0
+            NXN1Z2I3bG91TEpSY0xwRUMxMVd0WFEKhMkz5bGsPP48YQstE7JFnwGYbal33zrL
+            2FhS/OOUTTvBV4AH0L40+UPwGoelUyWeLA+s25paalbs+SwgQ12V3w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-17T23:02:18Z"
+    mac: ENC[AES256_GCM,data:3ls6KWRA/HohWx+XnsMY1DXCn3fpDW3drV+mJDTSgU+rOT0rfe7d0J66mqW/JL4bXmg6bAX60W0gMObQxLiuuVDAZO/j3D3152jIUfnK7c9b8xJBs+0G/7UfLELr8mF+yoicPl1axKT41v7cV/BLIw05ufeidL1Vc3KoVY77loo=,iv:inTnl3iQfEcce+FdFSYuLOEfrspOPtQ9wK08vcRExM4=,tag:S61fCAKVZ/0LpSGT8/riXQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/portainer/serviceaccount.yaml
+++ b/k3s/applications/portainer/serviceaccount.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portainer-sa-clusteradmin
+  namespace: portainer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portainer-crb-clusteradmin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: portainer-sa-clusteradmin
+  namespace: portainer

--- a/k3s/applications/portainer/services.yaml
+++ b/k3s/applications/portainer/services.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: portainer-agent
+  namespace: portainer
+  annotations:
+    metallb.io/loadBalancerIPs: "192.168.1.202"
+spec:
+  type: LoadBalancer
+  selector:
+    app: portainer-agent
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: portainer-agent-headless
+  namespace: portainer
+spec:
+  clusterIP: None
+  selector:
+    app: portainer-agent

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - pihole.yaml
   - authentik.yaml
   - tdarr.yaml
+  - portainer.yaml

--- a/k3s/platform/namespaces/portainer.yaml
+++ b/k3s/platform/namespaces/portainer.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portainer


### PR DESCRIPTION
Deploys portainer/agent:2.39.2 as raw K8s manifests via Flux. Static metallb IP 192.168.1.202:9001. Namespace in platform layer. No HelmRelease — follows tdarr raw-manifest pattern.