### PR TITLE
fix(authentik): fix portainer LDAP blueprint for 2026.2.2 API changes

### DIFF
--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -157,8 +157,8 @@ data:
         attrs:
           name: Portainer LDAP
           base_dn: dc=ldap,dc=goauthentik,dc=io
-          bind_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
-          search_group: null
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
           bind_mode: cached
           search_mode: cached
       - model: authentik_core.application


### PR DESCRIPTION
## Problem

The Authentik LDAP blueprint for Portainer was failing with:
```
Entry invalid: Serializer errors {
  'authorization_flow': [ErrorDetail('This field is required.')],
  'invalidation_flow': [ErrorDetail('This field is required.')]
}
```

This caused the `portainer-ldap` BlueprintInstance to stay in `error` state, meaning no LDAP provider/token/outpost was created in Authentik — and the LDAP outpost pod kept getting `403 Token invalid/expired`.

## Root Cause

The Authentik 2026.2.2 `LDAPProvider` serializer changed two field names and added a new required field:

| Old (what we had) | New (2026.2.2) |
|---|---|
| `bind_flow` | `authorization_flow` |
| `search_group: null` | field removed from serializer |
| _(missing)_ | `invalidation_flow` (now required) |

## Fix

- Replace `bind_flow` with `authorization_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]`
- Replace `search_group: null` with `invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]`

Both flows (`default-authentication-flow` and `default-invalidation-flow`) are verified to exist in the cluster.