### PR TITLE
fix(portainer): use Synology volumes path for agent bind mount

### DIFF
--- a/docker/portainer/portainer-compose.yml
+++ b/docker/portainer/portainer-compose.yml
@@ -8,7 +8,7 @@ services:
       - TZ=America/New_York
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /var/lib/docker/volumes:/var/lib/docker/volumes
+      - /volume1/docker/volumes:/var/lib/docker/volumes
     ports:
       - 9001:9001
     network_mode: homelab_bridge_network


### PR DESCRIPTION
Synology Docker stores volumes at `/volume1/docker/volumes`, not the standard `/var/lib/docker/volumes`. Fixes the bind mount error when starting the Portainer agent on the NAS.