### PR TITLE
fix(authentik): remove LDAP leftovers via blueprint state:absent

### DIFF
--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -188,3 +188,24 @@ data:
           group: !Find [authentik_core.group, [name, homelab-admins]]
           order: 0
           enabled: true
+  portainer-ldap-cleanup.yaml: |
+    version: 1
+    metadata:
+      name: "Portainer LDAP Cleanup"
+    entries:
+      - model: authentik_outposts.outpost
+        state: absent
+        identifiers:
+          name: homelab-ldap-outpost
+      - model: authentik_providers_ldap.ldapprovider
+        state: absent
+        identifiers:
+          name: Portainer LDAP
+      - model: authentik_flows.flow
+        state: absent
+        identifiers:
+          slug: ldap-authentication-flow
+      - model: authentik_core.user
+        state: absent
+        identifiers:
+          username: portainer-ldap-reader


### PR DESCRIPTION
Removes Authentik objects created during the LDAP debugging phase that are no longer needed after switching to OAuth.

## What this does

Adds a `portainer-ldap-cleanup.yaml` blueprint key to `authentik-blueprints` ConfigMap with `state: absent` entries for:

- `homelab-ldap-outpost` (LDAP outpost)
- `Portainer LDAP` (LDAP provider)
- `ldap-authentication-flow` (custom flow created manually during debug)
- `portainer-ldap-reader` (internal user created manually during debug)

Authentik will apply the blueprint on next sync and delete all four objects.

## Post-merge

After these objects are deleted, a follow-up PR can remove this cleanup blueprint key to keep the ConfigMap tidy.