### PR TITLE
chore(authentik): remove portainer LDAP cleanup blueprint

### DIFF
--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -188,24 +188,3 @@ data:
           group: !Find [authentik_core.group, [name, homelab-admins]]
           order: 0
           enabled: true
-  portainer-ldap-cleanup.yaml: |
-    version: 1
-    metadata:
-      name: "Portainer LDAP Cleanup"
-    entries:
-      - model: authentik_outposts.outpost
-        state: absent
-        identifiers:
-          name: homelab-ldap-outpost
-      - model: authentik_providers_ldap.ldapprovider
-        state: absent
-        identifiers:
-          name: Portainer LDAP
-      - model: authentik_flows.flow
-        state: absent
-        identifiers:
-          slug: ldap-authentication-flow
-      - model: authentik_core.user
-        state: absent
-        identifiers:
-          username: portainer-ldap-reader


### PR DESCRIPTION
LDAP objects have been deleted by the `state: absent` blueprint in PR #86. Removing the cleanup blueprint key now that it has served its purpose.