### PR TITLE
fix(pihole): pin image and exporter sidecar versions

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -24,8 +24,12 @@ spec:
         namespace: flux-system
       interval: 12h
   values:
-    # Pi-hole v6 (appVersion: 2025.11.1) — chart version 2.35.0
+    # Pi-hole v6 (appVersion: 2026.05.0) — chart version 2.35.0
     replicaCount: 1
+
+    # -- Pi-hole container image: pin to specific version for Dependabot tracking
+    image:
+      tag: "2026.05.0"
 
     # -- Upstream DNS: plain DNS to Cloudflare
     DNS1: "1.1.1.1"
@@ -110,6 +114,9 @@ spec:
         enabled: true
       sidecar:
         enabled: true
+        image:
+          # ekofr/pihole-exporter: v1.2.0 required for Pi-hole v6 API
+          tag: "v1.2.0"
 
     # -- Pod DNS config: ensure pihole pod uses external DNS, not itself
     podDnsConfig:


### PR DESCRIPTION
## Summary

Pins two previously unpinned image versions in the Pi-hole HelmRelease so Dependabot can track them and so the cluster actually works correctly.

### Changes

**`k3s/applications/pihole/helmrelease.yaml`**

| Field | Before | After | Reason |
|---|---|---|---|
| `image.tag` | *(unset — used chart appVersion `2025.11.1`)* | `2026.05.0` | Matches Synology instance; enables Dependabot tracking |
| `monitoring.sidecar.image.tag` | *(unset — chart defaulted to `v1.0.0`)* | `v1.2.0` | **v1.0.0 targets the Pi-hole v5 API** (`/admin/api.php`). Pi-hole v6 replaced that with a new REST API, so the sidecar was exporting **no metrics at all**. v1.2.0 adds v6 API support. |

### Background

The `mojo2600/pihole-kubernetes` chart bundles `ekofr/pihole-exporter` as its monitoring sidecar. The same `ekofr/pihole-exporter:v1.2.0` is already running on the Synology Docker Pi-hole — this aligns the K3s instance to match.