### PR TITLE
fix(headlamp): add offline_access scope to OIDC config

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
       oidc:
         clientID: headlamp
         issuerURL: https://auth.homelab.properties/application/o/headlamp/
-        scopes: openid email profile
+        scopes: openid email profile offline_access
         externalSecret:
           enabled: true
           name: headlamp-oidc-secret


### PR DESCRIPTION
## Problem

Headlamp signs users out after ~1 hour. The session cookie TTL is 24h, so the cause is not the cookie — it's the OIDC token.

Without `offline_access` in the requested scopes, Authentik does not issue a refresh token. It only issues an access token, which expires after 1 hour (Authentik default `access_token_validity = hours=1`). Headlamp's `OIDCTokenRefreshMiddleware` / `GetNewToken` logic can refresh sessions using a cached refresh token, but there is nothing to refresh if Authentik never issued one.

## Fix

Add `offline_access` to `config.oidc.scopes` in the Headlamp HelmRelease.

```diff
-        scopes: openid email profile
+        scopes: openid email profile offline_access
```

With this scope present, Authentik will issue both an access token and a refresh token (valid 30 days by default). Headlamp will silently refresh the session in the background, and users will stay logged in until the refresh token itself expires or is revoked.

## Files Changed

- `k3s/applications/headlamp/helmrelease.yaml` — one-line scope addition