### PR TITLE
feat(tdarr): connect media volume via SMB CSI instead of hostPath

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - headlamp/
   - pihole/
   - portainer/
-  # - tdarr/  # disabled: see PR infra/disable-tdarr
+  - tdarr/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -68,9 +68,8 @@ spec:
               mountPath: /app/configs
       volumes:
         - name: media
-          hostPath:
-            path: /mnt/synology/media
-            type: Directory
+          persistentVolumeClaim:
+            claimName: tdarr-media
         - name: transcode-cache
           emptyDir:
             sizeLimit: 200Gi

--- a/k3s/applications/tdarr/pvc.yaml
+++ b/k3s/applications/tdarr/pvc.yaml
@@ -14,3 +14,51 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+# Static PV for tdarr media — mounts //192.168.1.20/data (Synology NAS) via SMB CSI.
+# Uses smb-media StorageClass provisioner (smb.csi.k8s.io); credentials in kube-system/smbcreds.
+# ReadWriteMany allows multiple pods to mount the same share if needed.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tdarr-media
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: tdarr-media-volume
+    volumeAttributes:
+      source: "//192.168.1.20/data"
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+# PVC for tdarr media — binds to the static tdarr-media PV above.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tdarr-media
+  namespace: tdarr
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: tdarr-media
+  resources:
+    requests:
+      storage: 10Ti


### PR DESCRIPTION
## Problem

The tdarr-node deployment mounted `/media` via `hostPath: /mnt/synology/media`, which assumed the Synology CIFS share was pre-mounted on the K3s host. It isn't — so the pod would fail to start with a volume mount error.

## Solution

Replace the `hostPath` volume with a static PV/PVC pair that uses the existing `smb-media` StorageClass (`smb.csi.k8s.io`) to mount `//192.168.1.20/data` directly from the Synology NAS via SMB CSI driver (already deployed as `csi-driver-smb` v1.20.1 in kube-system).

## Changes

### `k3s/applications/tdarr/pvc.yaml`
- Added static `PersistentVolume` (`tdarr-media`, 10Ti, Retain, ReadWriteMany)
  - Driver: `smb.csi.k8s.io`
  - Source: `//192.168.1.20/data` (same share the Docker tdarr server uses)
  - Credentials: `kube-system/smbcreds` (existing SOPS secret)
  - MountOptions: matches `smb-media` StorageClass (`vers=3.0, uid=1027, gid=100, noperm, cache=strict, noserverino`)
- Added `PersistentVolumeClaim` (`tdarr-media`) bound to the above PV via `volumeName`

### `k3s/applications/tdarr/deployment.yaml`
- Replaced `hostPath` volume block for `media` with a `persistentVolumeClaim` reference to `tdarr-media`

### `k3s/applications/kustomization.yaml`
- Re-enabled `- tdarr/` (was commented out since PR `infra/disable-tdarr`)

## Testing

After merge and Flux reconciliation:
1. PV `tdarr-media` should bind to PVC `tdarr-media` in namespace `tdarr`
2. tdarr-node pod should mount `/media` from the Synology NAS share
3. Tdarr node should register with the server at `http://192.168.1.20:8266`