### PR TITLE
fix(tdarr): pin tdarr server and node to 2.75.01 (latest)

### DIFF
--- a/docker/media/tdarr-compose.yml
+++ b/docker/media/tdarr-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   tdarr:
-    image: haveagitgat/tdarr:2.73.01
+    image: haveagitgat/tdarr:2.75.01
     container_name: tdarr
     environment:
       - PUID=1027

--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 100
       containers:
         - name: tdarr-node
-          image: haveagitgat/tdarr_node:latest
+          image: haveagitgat/tdarr_node:2.75.01
           env:
             - name: TZ
               value: America/New_York


### PR DESCRIPTION
## Summary

Pins both tdarr containers to the same version to ensure server/node compatibility.

## Changes

- `docker/media/tdarr-compose.yml`: `haveagitgat/tdarr:2.73.01` → `2.75.01`
- `k3s/applications/tdarr/deployment.yaml`: `haveagitgat/tdarr_node:latest` → `2.75.01`

`2.75.01` is the current latest tag on Docker Hub (published 2026-05-22).