### PR TITLE
feat(tdarr): increase CPU limit from 2000m to 4000m

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               cpu: 500m
               memory: 1Gi
             limits:
-              cpu: 2000m
+              cpu: 4000m
               memory: 4Gi
               nvidia.com/gpu: "1"
           volumeMounts:


### PR DESCRIPTION
Tdarr node is consistently hitting the 2000m CPU limit. Raising to 4000m to give it headroom.

## Changes
- `k3s/applications/tdarr/deployment.yaml`: `resources.limits.cpu` 2000m → 4000m

## Notes
This will restart the pod on merge (Recreate strategy). Merge after current transcode tasks drain.