### PR TITLE
feat(media): add sonarr, radarr, and recyclarr on k3s

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - pihole/
   - portainer/
   - tdarr/
+  - sonarr/
+  - radarr/
+  - recyclarr/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/radarr/deployment.yaml
+++ b/k3s/applications/radarr/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: radarr
+  template:
+    metadata:
+      labels:
+        app: radarr
+        app.kubernetes.io/name: radarr
+    spec:
+      securityContext:
+        fsGroup: 100
+      containers:
+        - name: radarr
+          image: lscr.io/linuxserver/radarr:latest
+          ports:
+            - name: http
+              containerPort: 7878
+              protocol: TCP
+          env:
+            - name: PUID
+              value: "1027"
+            - name: PGID
+              value: "100"
+            - name: TZ
+              value: America/New_York
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: media
+              mountPath: /data/media
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 7878
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 7878
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.3.0
+          args:
+            - radarr
+          ports:
+            - name: metrics
+              containerPort: 9707
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "9707"
+            - name: URL
+              value: http://localhost:7878
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: radarr-apikey
+                  key: api-key
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: radarr-config
+        - name: media
+          persistentVolumeClaim:
+            claimName: radarr-media

--- a/k3s/applications/radarr/deployment.yaml
+++ b/k3s/applications/radarr/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         fsGroup: 100
       containers:
         - name: radarr
-          image: lscr.io/linuxserver/radarr:latest
+          image: lscr.io/linuxserver/radarr:6.1.1
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 7878

--- a/k3s/applications/radarr/ingress.yaml
+++ b/k3s/applications/radarr/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: radarr
+  namespace: media
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: radarr.homelab.properties
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: radarr
+                port:
+                  number: 7878
+  tls:
+    - hosts:
+        - radarr.homelab.properties
+      secretName: radarr-tls

--- a/k3s/applications/radarr/kustomization.yaml
+++ b/k3s/applications/radarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - servicemonitor.yaml
+  - radarr-apikey.sops.yaml

--- a/k3s/applications/radarr/pvc.yaml
+++ b/k3s/applications/radarr/pvc.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radarr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: radarr-media
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: radarr-media-volume
+    volumeAttributes:
+      source: //192.168.1.20/data
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radarr-media
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: radarr-media
+  resources:
+    requests:
+      storage: 10Ti

--- a/k3s/applications/radarr/radarr-apikey.sops.yaml
+++ b/k3s/applications/radarr/radarr-apikey.sops.yaml
@@ -1,0 +1,14 @@
+# SOPS-encrypted Secret — DO NOT commit plaintext in production.
+# After first deploy, extract the API key from the Radarr UI:
+#   Settings -> General -> API Key
+# Then encrypt this file:
+#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     k3s/applications/radarr/radarr-apikey.sops.yaml > /tmp/radarr-apikey.sops.yaml
+#   mv /tmp/radarr-apikey.sops.yaml k3s/applications/radarr/radarr-apikey.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: radarr-apikey
+  namespace: media
+stringData:
+  api-key: REPLACE_ME_AFTER_FIRST_DEPLOY

--- a/k3s/applications/radarr/radarr-apikey.sops.yaml
+++ b/k3s/applications/radarr/radarr-apikey.sops.yaml
@@ -1,14 +1,29 @@
-# SOPS-encrypted Secret — DO NOT commit plaintext in production.
-# After first deploy, extract the API key from the Radarr UI:
-#   Settings -> General -> API Key
-# Then encrypt this file:
-#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
-#     k3s/applications/radarr/radarr-apikey.sops.yaml > /tmp/radarr-apikey.sops.yaml
-#   mv /tmp/radarr-apikey.sops.yaml k3s/applications/radarr/radarr-apikey.sops.yaml
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:4szCRYSrlQG6qDWrf5vpwFoxfTzJllHY+HF4il0h9V8ikvNcGOsRP5jqgCzHih6NvsXPzxG9UtERLXwVRKDCpOw=,iv:paesKv0L3AL8+11ER1fO+QyeQ/xW+EDjKhr/R5fZnwU=,tag:DfT4nfK9S4ZhnFK2plcBkg==,type:comment]
+#ENC[AES256_GCM,data:5LZRu6UuCSmOkb2iZt+u3sY4sRVsx08cpfKkaVZWn9c5qFrW/iGPzakslQTnsOH/ECLfENVfdCfml6Y4,iv:XEM0guoGzbN11kUyC246wKPBzPqTXX2RutKwGdgUzLE=,tag:AKcuuf6kf7KOPxtz1e5p8A==,type:comment]
+#ENC[AES256_GCM,data:DeOQXIL5nxh6i9Ywhpxs/DEjJRCoMRebZBwrvskaOFUJ,iv:OgXVxFfDYJI0sG/KmvfA1f/2D8j+aJYWUj7zuramRtg=,tag:QJ5VBR/HQSEfjE7HnVd95A==,type:comment]
+#ENC[AES256_GCM,data:cNBjhAfagGI7B6wNgbLgHPWlDayttFHx,iv:EYRxD7vnaKKd8zl8qiHm5zxb4SVSLkRb8OytHN89rZg=,tag:qVj6xBN2cZzL3HIIvi0+SA==,type:comment]
+#ENC[AES256_GCM,data:M28I8PlfxbugTmBMlpPS9cVDQ2Dx+88KwE/jaAiwu2RXHIqZ92zVIlaXO30zZ7KWjoqe/10H53WO1oGfOwegL2bze4s2HJbq96VeOGruTUVgTsi4Hefjgg==,iv:lH+JTek/nX1x9MzqDza2bndXrEdec9BNnjkB4Q4uHOU=,tag:upw6Fm7FXEotClUOALOGFg==,type:comment]
+#ENC[AES256_GCM,data:vK+ttMTcjfy7xn6xa8US4aTZAGrBsXx5n+t3kGm23pQC97ZB+MCikvH56T1xsqbsQcAR7XvUlD/nB4VesH6aDd0x4/CL2ljO0/LpAGw/k3rX0I8=,iv:cJy/3jNpYdD8TprBbzRMvk2HbqWI/vxxrt1ZZE+WSVk=,tag:EKPKjeRd99PNw536KP2+OQ==,type:comment]
+#ENC[AES256_GCM,data:p/P3Xxa/kULfA3jMFB2oQilDCm2cArTGN0nwSPIS06SmlE6gsQ0UqLesye3M1wk3/zSOa9WmIsc6ra/O7Q8cQp5qCWH0RKC/DgylpMUCeqBMLA==,iv:IiQkaFzrPEbkMin+9ASxrKl4u5VrTxkN74+3pKAHMBs=,tag:LQ2R1vO//nIlagBxFGoUqg==,type:comment]
+apiVersion: ENC[AES256_GCM,data:XYw=,iv:qRFdM7kSnRszKBt5kccqM/XqchK43Rao/Tt+GbXyCfQ=,tag:IueBlNka0skvBqKTVyroWA==,type:str]
+kind: ENC[AES256_GCM,data:xK/6Zz3u,iv:rEKIaVpkEKF9nr0fqgiZeOh5fYs5UxORej+WddVQTj4=,tag:tLdln77y13tP3zddYrwZlA==,type:str]
 metadata:
-  name: radarr-apikey
-  namespace: media
+    name: ENC[AES256_GCM,data:NzgVk8d81ZamRa85cw==,iv:x3do41bsEfBT8W+74XuBZ4IP+elJfgFdK3JVLwB1SRw=,tag:WEeIvrY0S/Wdaa/cAp9LiA==,type:str]
+    namespace: ENC[AES256_GCM,data:2ir/zzo=,iv:u1/TYqhTXEt+TSdqlLleFFDPCfjDs/2zqMnBiGZS99A=,tag:BMevQYmHpas6tVZCl0wRmQ==,type:str]
 stringData:
-  api-key: REPLACE_ME_AFTER_FIRST_DEPLOY
+    api-key: ENC[AES256_GCM,data:M8NlstKAZMoZLTuf+9OYzNUh9FDklNRAXIqnpOc=,iv:iIhOgCPSaFjVEN6Cz8SefvLKeGrimwEFlezOHFC5N1c=,tag:RQPIqLH5fyFHuIPVjJAhwQ==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIT2FOVk9yNDhFTzlLRE9D
+            NmdEQVgwZGJCbkY0KzFQZXozR01MbGM1dEVnCnBxT2psOFJkNFFESVFZQVZIcVJy
+            RERhaXlkUU5mdmxzUTRIaDYyZkpoaUEKLS0tIFVVUi9HdWxoYU9hY3luMUk1L1Jp
+            akZrbmp1Uno0Z3RMZll6SnByZVUrU2cKhCK/26YiQ+EBLEUCyJrPfhY8LpfTk3Cq
+            wBAfbXzafPLLT66MeUfivVyaUKQTtqtKorP8knqh7UAoaGO9RlSUrw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T18:08:36Z"
+    mac: ENC[AES256_GCM,data:mC6XQ/dLUPl0BF/dY6Xg/+y5TRVF+2nLPwy5Il7iMXHWYD90OaGZhVZSlDuJNiFSO1wo5DpZA16Af9KBPxjmVbn8T40mvfCHosnUX0czGDFyR+PB8N+g7xE8ZHgMwuOMb2ckn+VA+0L58a8qy3DT8V2cS1WWKLSzNygKTMdVDwA=,iv:LeW0qQRfP18EC7WSwuEEkGL0lDFPqf1Ij0bkmmSBK+g=,tag:ECrhU/AU261ZfxuqkbPIZA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/radarr/service.yaml
+++ b/k3s/applications/radarr/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: radarr
+  namespace: media
+  labels:
+    app.kubernetes.io/name: radarr
+spec:
+  type: ClusterIP
+  selector:
+    app: radarr
+  ports:
+    - name: http
+      port: 7878
+      targetPort: 7878
+      protocol: TCP
+    - name: metrics
+      port: 9707
+      targetPort: 9707
+      protocol: TCP

--- a/k3s/applications/radarr/servicemonitor.yaml
+++ b/k3s/applications/radarr/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: radarr
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 4m
+      scrapeTimeout: 90s

--- a/k3s/applications/recyclarr/configmap.yaml
+++ b/k3s/applications/recyclarr/configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: recyclarr-config
+  namespace: media
+data:
+  recyclarr.yml: |
+    sonarr:
+      tv:
+        base_url: !env_var SONARR_BASE_URL
+        api_key: !env_var SONARR_API_KEY
+        delete_old_custom_formats: true
+        replace_existing_custom_formats: true
+        quality_definition:
+          type: series
+        quality_profiles:
+          - name: WEB-1080p
+            reset_unmatched_scores:
+              enabled: true
+            upgrade:
+              allowed: true
+              until_quality: WEB 1080p
+              until_score: 10000
+            score_set: default
+        custom_formats:
+          - trash_ids:
+              - 72dae194fc92bf828f32cde7744e51a1
+            quality_profiles:
+              - name: WEB-1080p
+        include:
+          - template: sonarr-quality-definition-series
+          - template: sonarr-v4-quality-profile-web-1080p
+          - template: sonarr-v4-custom-formats-web-1080p
+
+    radarr:
+      movies:
+        base_url: !env_var RADARR_BASE_URL
+        api_key: !env_var RADARR_API_KEY
+        delete_old_custom_formats: true
+        replace_existing_custom_formats: true
+        quality_definition:
+          type: movie
+        quality_profiles:
+          - name: HD Bluray + WEB
+            reset_unmatched_scores:
+              enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Bluray-1080p
+              until_score: 10000
+            score_set: default
+        custom_formats:
+          - trash_ids:
+              - d1d67249d3890e49bc12e275d989a7e9
+            quality_profiles:
+              - name: HD Bluray + WEB
+        include:
+          - template: radarr-quality-definition-movie
+          - template: radarr-quality-profile-hd-bluray-web
+          - template: radarr-custom-formats-hd-bluray-web

--- a/k3s/applications/recyclarr/cronjob.yaml
+++ b/k3s/applications/recyclarr/cronjob.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: recyclarr
+  namespace: media
+spec:
+  schedule: "30 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          restartPolicy: OnFailure
+          containers:
+            - name: recyclarr
+              image: ghcr.io/recyclarr/recyclarr:8.6.0
+              command:
+                - recyclarr
+                - sync
+              env:
+                - name: TZ
+                  value: America/New_York
+                - name: RECYCLARR_CONFIG_DIR
+                  value: /config
+              envFrom:
+                - secretRef:
+                    name: recyclarr-secrets
+              volumeMounts:
+                - name: config
+                  mountPath: /config/recyclarr.yml
+                  subPath: recyclarr.yml
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          volumes:
+            - name: config
+              configMap:
+                name: recyclarr-config
+            - name: tmp
+              emptyDir: {}

--- a/k3s/applications/recyclarr/cronjob.yaml
+++ b/k3s/applications/recyclarr/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: media
 spec:
   schedule: "30 2 * * *"
+  timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1

--- a/k3s/applications/recyclarr/kustomization.yaml
+++ b/k3s/applications/recyclarr/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+  - configmap.yaml
+  - recyclarr-secrets.sops.yaml

--- a/k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
+++ b/k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
@@ -1,0 +1,18 @@
+# SOPS-encrypted Secret — DO NOT commit plaintext in production.
+# After first deploy, extract API keys from Sonarr and Radarr UIs:
+#   Sonarr: Settings -> General -> API Key
+#   Radarr:  Settings -> General -> API Key
+# Then encrypt this file:
+#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     k3s/applications/recyclarr/recyclarr-secrets.sops.yaml > /tmp/recyclarr-secrets.sops.yaml
+#   mv /tmp/recyclarr-secrets.sops.yaml k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recyclarr-secrets
+  namespace: media
+stringData:
+  SONARR_API_KEY: REPLACE_ME_AFTER_FIRST_DEPLOY
+  RADARR_API_KEY: REPLACE_ME_AFTER_FIRST_DEPLOY
+  SONARR_BASE_URL: http://sonarr.media.svc.cluster.local:8989
+  RADARR_BASE_URL: http://radarr.media.svc.cluster.local:7878

--- a/k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
+++ b/k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
@@ -1,18 +1,33 @@
-# SOPS-encrypted Secret — DO NOT commit plaintext in production.
-# After first deploy, extract API keys from Sonarr and Radarr UIs:
-#   Sonarr: Settings -> General -> API Key
-#   Radarr:  Settings -> General -> API Key
-# Then encrypt this file:
-#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
-#     k3s/applications/recyclarr/recyclarr-secrets.sops.yaml > /tmp/recyclarr-secrets.sops.yaml
-#   mv /tmp/recyclarr-secrets.sops.yaml k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:Qj6g8MVzMTl9L7ZfP+9zuQysLoCiTkO1dbQIfZDPL3vloKNOkArDAUT6JsmgQRHFv0DwYSCyD0YGHrf7eVqiTQo=,iv:xrCP5Vd1bmAvVRIr0JWq6Zh4zFMHTHJsV7rWNRhDFVs=,tag:WFsIOkXDlfDs2kZRaRwy8w==,type:comment]
+#ENC[AES256_GCM,data:Kczr7EuFwxOn4KAtFZ5Ms1EnSEVAqWG9b4macGwhZ1oTrjHUPn9Lx/jsCA+B9OVu0FOeaq2XB4712G5YaJBdr4k=,iv:wRB21qxM++u3qXaP6TXVvBQ3gHhlYq4wsvdxWmwMego=,tag:6BdjCLSuJQ9D/hOqo2y1LQ==,type:comment]
+#ENC[AES256_GCM,data:GdWalx3oEVLrn+pHC/m2hhMpi7fKaZ/YsuTQI1E42NUDqQmjJH3wDYY=,iv:zfAwDnbp+GuJcvX46YTt55J2savXtoUPWDeK7bwxZSM=,tag:IimoMxneTishA/tXRM8Thg==,type:comment]
+#ENC[AES256_GCM,data:xvTyG1AqiyzZO5cW+b2FduOB6HxjfVFvKJCZOC0/q2AmDmFKP42q8qnL,iv:XSNGvuqkU5H8Oo8xlwuO/UKFisU0qCvwzb2UhOwL6nU=,tag:2MW0lAJc2ml9YByTh8oViw==,type:comment]
+#ENC[AES256_GCM,data:V+CTfKm2gjD9DRl1JxYiYoFr0wWYDxEM,iv:LFo/99HyD40BKPuLIgoRwEtCHS4fbo8KmYmG1poDSZw=,tag:ugyjsNUzhDcJrzB5DNO2Kg==,type:comment]
+#ENC[AES256_GCM,data:Lc12HqW4AIplMSbeZGLoV6z1aGPUe1KODFgCaWDpGCgUr6OJIkM6tbVkMb+kOPJGLIjgj/xDC8+CezPCbxm9k7Jic8ZWJh2HSvmHSrZyrMgKbm4KHCYrtg==,iv:EUGw5DVUB/k1OZ2ys4fxF9O8t6Qvj81MoJIovRoaCmo=,tag:MmuivBRuMm8l5Fj/035JQQ==,type:comment]
+#ENC[AES256_GCM,data:c8lI7wDRqp1kPuZjtsp/FwCNahxFrnk7v4c8w5IApi1O7eMrSJtlHShLSlRZE1x8KnkuwXNf1XzKkOFQw5RofttCQDRzklBW5FWooVTPR4dKj7u/mzdNz+JRymn9eg==,iv:NGAdLPgl/GXCN8hF0diY4hNkK13ut9TmgFUht5JJG38=,tag:GHrbdMZqg/ObRriaDj16nA==,type:comment]
+#ENC[AES256_GCM,data:567TKWjcP5O9lgYDwEY3nOhUT25nuEKI8n+DA7duz+LCAmPuDnPrmDQZ0eKy4MxfMynxoVbHM47mAACKHojlkI4Vbdo83EUHLcjffmJ5xi/sxXIXnxwg0LbOPTft,iv:XSTW534QS/vxewIdhx4/+hHdEqo4Pu7n8xGDVOExN2E=,tag:1ibsn76KBlssC0NAQ7hGtg==,type:comment]
+apiVersion: ENC[AES256_GCM,data:AQk=,iv:WY/nuA/3XYM6hYAW0PWVg/OMkPq5jkuR8nZXgzcQPjo=,tag:6mMe+c3O02Wc/0VGGPpl3w==,type:str]
+kind: ENC[AES256_GCM,data:7ozRxe02,iv:ZXat06oiaNbvQq73JOkPSF5LzfBlvuFkWCwCniUdY9A=,tag:78A9apdPN5bIG69qIgminA==,type:str]
 metadata:
-  name: recyclarr-secrets
-  namespace: media
+    name: ENC[AES256_GCM,data:JbcFWFyagGS2lnDbGwAPFts=,iv:wBhkMbMBr8sqbZfzHIswy3mIZuUFtb91ZZMIxIdtGuI=,tag:yYRbyKUxKsY+pf7Mdz263w==,type:str]
+    namespace: ENC[AES256_GCM,data:7sUFIsc=,iv:umi4/VS+Y93N6y9nvuGNnWK4fbxs9cki8op6k91eY4w=,tag:9Udv5sUrY3vrpNBog3e75g==,type:str]
 stringData:
-  SONARR_API_KEY: REPLACE_ME_AFTER_FIRST_DEPLOY
-  RADARR_API_KEY: REPLACE_ME_AFTER_FIRST_DEPLOY
-  SONARR_BASE_URL: http://sonarr.media.svc.cluster.local:8989
-  RADARR_BASE_URL: http://radarr.media.svc.cluster.local:7878
+    SONARR_API_KEY: ENC[AES256_GCM,data:svfrOsV6VVFa4G/SiJuqg8XR8QeM5tgY3DpDsok=,iv:lJUyJ09wFGwvfgEXyajcWvK579CzxSvQ6nnL1gxQ7fg=,tag:KtKHHm7wb7e9j7q6IShT7Q==,type:str]
+    RADARR_API_KEY: ENC[AES256_GCM,data:YaHkvKjqHjF/5ldrhHwMR35yjaR5E8VlnEeBlkI=,iv:KctMu3tvey8efaAt5RU5etLt6A9aT6du310bXzzY5CU=,tag:Cw3qKUJbJ7SjBqEBGVyjTg==,type:str]
+    SONARR_BASE_URL: ENC[AES256_GCM,data:2KdkSKAaoyzb80wcEnjkUQHXVseqfWY3pZ5A3j1z3TWF5JJ80WYYtSb/,iv:sNEBTTiopAMLct8qL7NDENKUPq0F2XqKO0DJ7GrdAzo=,tag:TGrhkfdRPrhscABZIFL8qQ==,type:str]
+    RADARR_BASE_URL: ENC[AES256_GCM,data:IW2Ghp9zUBwmSYOywOtGfpI2VZvH23Au8IKYz6Sri1GFbrmEq3YaaiNZ,iv:WDuZPDnTCzysqmQOEOsfrsRWTLn7++qNwot2vO6Nj0o=,tag:j0xpuueY0kC9gMPbTTYY1Q==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5a0Z2UzJnUHQwMGNaNjB4
+            ditWdkpNc2JqandjelJYelZ2OTNnenVVWHlBCmVneFdpdE04KzdHR1J3Z2VVdDV0
+            MVFLVFRmVXQ1Wm5VT1M1YmlkVXIzU2cKLS0tIFpSSWIwOTFrZVpMNlM4Snc5R1Nt
+            eE1oaFJVTnFZVHRIelc3ZUoxY1lYQ00K22qOYQuz8Ax1SPXX3uYeCjt1fYxWuIUb
+            Q+pTQq5IKA6wp0NDesByIJyRrhB78wdFz/i6eK3RPgm3+9Us78kD/w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T18:08:36Z"
+    mac: ENC[AES256_GCM,data:rDnlegYBZDd49hEbg0R9icJw8fDF552xRmJ6w/U5OAcsbnuVC7Htwrifk6YAEV35leENNOXIBIb3+6fvPM1GlOmoENGOulQzvMQXMusMoUVqYBX2eiJC2DCD+bNfghVnGDbonZqJ3job2gMKWyHZJfl9b7hduyDQblkIyLZQi90=,iv:/NePeaSFDFRLG2mwa4BGm45KmYs7eXgCb6bPcnn+muI=,tag:hmvOj+S4J+qqwokklOMxmQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/sonarr/deployment.yaml
+++ b/k3s/applications/sonarr/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sonarr
+  template:
+    metadata:
+      labels:
+        app: sonarr
+        app.kubernetes.io/name: sonarr
+    spec:
+      securityContext:
+        fsGroup: 100
+      containers:
+        - name: sonarr
+          image: lscr.io/linuxserver/sonarr:latest
+          ports:
+            - name: http
+              containerPort: 8989
+              protocol: TCP
+          env:
+            - name: PUID
+              value: "1027"
+            - name: PGID
+              value: "100"
+            - name: TZ
+              value: America/New_York
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: media
+              mountPath: /data/media
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8989
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8989
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.3.0
+          args:
+            - sonarr
+          ports:
+            - name: metrics
+              containerPort: 9707
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "9707"
+            - name: URL
+              value: http://localhost:8989
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: sonarr-apikey
+                  key: api-key
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: sonarr-config
+        - name: media
+          persistentVolumeClaim:
+            claimName: sonarr-media

--- a/k3s/applications/sonarr/deployment.yaml
+++ b/k3s/applications/sonarr/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         fsGroup: 100
       containers:
         - name: sonarr
-          image: lscr.io/linuxserver/sonarr:latest
+          image: lscr.io/linuxserver/sonarr:4.0.17
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8989

--- a/k3s/applications/sonarr/ingress.yaml
+++ b/k3s/applications/sonarr/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sonarr
+  namespace: media
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: sonarr.homelab.properties
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sonarr
+                port:
+                  number: 8989
+  tls:
+    - hosts:
+        - sonarr.homelab.properties
+      secretName: sonarr-tls

--- a/k3s/applications/sonarr/kustomization.yaml
+++ b/k3s/applications/sonarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - servicemonitor.yaml
+  - sonarr-apikey.sops.yaml

--- a/k3s/applications/sonarr/pvc.yaml
+++ b/k3s/applications/sonarr/pvc.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sonarr-media
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: sonarr-media-volume
+    volumeAttributes:
+      source: //192.168.1.20/data
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-media
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: sonarr-media
+  resources:
+    requests:
+      storage: 10Ti

--- a/k3s/applications/sonarr/service.yaml
+++ b/k3s/applications/sonarr/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarr
+  namespace: media
+  labels:
+    app.kubernetes.io/name: sonarr
+spec:
+  type: ClusterIP
+  selector:
+    app: sonarr
+  ports:
+    - name: http
+      port: 8989
+      targetPort: 8989
+      protocol: TCP
+    - name: metrics
+      port: 9707
+      targetPort: 9707
+      protocol: TCP

--- a/k3s/applications/sonarr/servicemonitor.yaml
+++ b/k3s/applications/sonarr/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 4m
+      scrapeTimeout: 90s

--- a/k3s/applications/sonarr/sonarr-apikey.sops.yaml
+++ b/k3s/applications/sonarr/sonarr-apikey.sops.yaml
@@ -1,14 +1,29 @@
-# SOPS-encrypted Secret — DO NOT commit plaintext in production.
-# After first deploy, extract the API key from the Sonarr UI:
-#   Settings -> General -> API Key
-# Then encrypt this file:
-#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
-#     k3s/applications/sonarr/sonarr-apikey.sops.yaml > /tmp/sonarr-apikey.sops.yaml
-#   mv /tmp/sonarr-apikey.sops.yaml k3s/applications/sonarr/sonarr-apikey.sops.yaml
-apiVersion: v1
-kind: Secret
+#ENC[AES256_GCM,data:OjH933TuMybyKXACn/TKgLh6yu5FHVklXzuTKB67RwaFedeFHUz/Kj8Bnlojw9kOiK23nLFcMAuagNtXhfqWbIE=,iv:hzAXYdoWHpzdH2NejxR9eqwjyrm58eFTgToRqes4YHk=,tag:3nJVZ8HdMmy0Q/ULTth2ZQ==,type:comment]
+#ENC[AES256_GCM,data:SZ0/HWEoXzJQd1zt0BFaa+aR0h0/EybpqNLjWMSkjmxQzbVQN+r/22dtddiJ8xMn/+uZWq121r5Rg3We,iv:9h6VVRBX3hzgUug/4ePZLtdq9gbbeo14SBOqaomjwnM=,tag:xI1bvkO5ZotH3rMg/NnM/g==,type:comment]
+#ENC[AES256_GCM,data:FWsZiRbivAJCNPm/hI47NQtNz/VEHifeSo2a53BRfrfU,iv:j0XgN64vrxmUU3BcqhlsW05/cWa1rAXUi+9UxIuluME=,tag:La9N+6dJOakfv713ZWPS6w==,type:comment]
+#ENC[AES256_GCM,data:jKJADDY8xeYmHrXt1/uxTtiLW6uqzETh,iv:gDpVYbroT0BIXfC93RcztndJrLqm7UDXNo+0tjgHIGQ=,tag:MS57JbQdkosn3lCt0ZLjbA==,type:comment]
+#ENC[AES256_GCM,data:BGuOkqXzA7M1D5DBBmgt9moPeFgzsrdrlukue3nOaZi50gCYf4pQI4tCQWQGmHfzR6YLqKYpSUaJ3Zygkua4j6io/21GO35jYjdtnoHd+dQHrEYHpc/y2A==,iv:NdW6/BxVgXPEbbssyF6m42tVpq5WCgAxbIT6UfPgUjY=,tag:brQ/bmtntWrkXmPRoosF3w==,type:comment]
+#ENC[AES256_GCM,data:cEYZQKl90/5ypNOccVAqnX9doUhRBg1uWtd/sHWu5ZWeIB/e6VjuVp19Z3MWggJ1GpY1kscQX+mxy4dOdgaE7Z85TSIUiBUT+aPjyVJ7vsUuY9c=,iv:KqSEtkBEMTF2tGfVYZXThIccmNY9aJCgOtNoCBoc3rM=,tag:wccsifho4idVKk9p0opP1Q==,type:comment]
+#ENC[AES256_GCM,data:AUybIpGNrW52TCO/cEMFpkA76XBz+WFECW4MKK7q6wGK4IBy+H1r0YzAPFMBJmePWr4PqX4O8s/tiVMzJVuozDdNL6cmwl8LYub4bmn9MElwdQ==,iv:zQNFaglVvvC9OxyVPnjWfQwNj8v6Nz3/WNon2RtFA3Y=,tag:s5rlKQeWJ2waX27v7b1sgg==,type:comment]
+apiVersion: ENC[AES256_GCM,data:AjM=,iv:aCKdu+WtTrntimuUwKQTX88RXhgKsg25tOh0eJNGcSI=,tag:wIQdl3qiU/CUt0uacmfz5Q==,type:str]
+kind: ENC[AES256_GCM,data:VMr4anz5,iv:ImNei7zURkqZPwS9WnoXbkmu2oSKcs6WD93sX9PWcMs=,tag:vhM20Vka3AJZkAxphRR3Xg==,type:str]
 metadata:
-  name: sonarr-apikey
-  namespace: media
+    name: ENC[AES256_GCM,data:YAC2Sz6S6MmzBT6x9w==,iv:arqam9Hysmi3j6FHjCPLXsAmifLwbbxTK1BQXWjVfsg=,tag:P2hlyIj9a5vblghfXAIG4g==,type:str]
+    namespace: ENC[AES256_GCM,data:sFxrwXE=,iv:5LmLGnqNbGr6zzmD78WAPhBjEdcwEmSQxH2OkYxoZcM=,tag:ZecGQMhS8pP0GKrwGVxiyQ==,type:str]
 stringData:
-  api-key: REPLACE_ME_AFTER_FIRST_DEPLOY
+    api-key: ENC[AES256_GCM,data:KwTfjcXZixSCVMe4ALUj4/95UU+B8vztZBWXHSQ=,iv:N8ZiaD6BuUtDVMukOpCuWgPn3ZdoRTxMH046PzUOdGk=,tag:NI+jg39Bk1+LGpUq+4kd0w==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByUmppeDR2dE56MGVkWWha
+            RG9xRGt4WnFNZk9FL21tWDFNUk1hMmRvNXo0Ck9IMzJldFdrZW5VdlNjT1ZUWENm
+            RkI5RGxvczVPTzc3SisrdFJndW5jUXMKLS0tIEJ1WVVOdUh2aE96ZlhGK0lDSEt1
+            bDdxeXMwWHhhRWk1WEpjd0RXQjYrV1UKbEIzR7opWOBEVxQ/1JfA33AM8e+OP9bI
+            as+uRkcDhcrhEeYjN4mMwUvL+Cu5+8H8y9o+IFquDjoW/SUN+yCXww==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T18:08:36Z"
+    mac: ENC[AES256_GCM,data:hdoQGKUDf6cC1d9Nqq310mPthZuhr3Uhu8x4bg/49gH1+ar4voa51aqP28Lh3xQKBmS6D9yPj8RYfpvZalapO975a1Vg6BzvN8LjgnLy/idmErRJOa2ScIazAtFM6yoVJaF3PZSjpM5qMWKiWt10g7seEhO8ghIF26bXDGDKV0g=,iv:bUi/t8yih8XYWejbAULKBDbxmf2bLsGJ1NMYacMxEcQ=,tag:ZaYmxjUWp+7V+WTrZrCV+Q==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/sonarr/sonarr-apikey.sops.yaml
+++ b/k3s/applications/sonarr/sonarr-apikey.sops.yaml
@@ -1,0 +1,14 @@
+# SOPS-encrypted Secret — DO NOT commit plaintext in production.
+# After first deploy, extract the API key from the Sonarr UI:
+#   Settings -> General -> API Key
+# Then encrypt this file:
+#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     k3s/applications/sonarr/sonarr-apikey.sops.yaml > /tmp/sonarr-apikey.sops.yaml
+#   mv /tmp/sonarr-apikey.sops.yaml k3s/applications/sonarr/sonarr-apikey.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sonarr-apikey
+  namespace: media
+stringData:
+  api-key: REPLACE_ME_AFTER_FIRST_DEPLOY

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - authentik.yaml
   - tdarr.yaml
   - portainer.yaml
+  - media.yaml

--- a/k3s/platform/namespaces/media.yaml
+++ b/k3s/platform/namespaces/media.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media


### PR DESCRIPTION
## Summary

Adds Sonarr, Radarr, and Recyclarr to the K3s cluster as raw manifests (matching the tdarr pattern), with Prometheus exporters and TRaSH Guides sync via Recyclarr.

## Changes

### Infrastructure
- **`k3s/platform/namespaces/media.yaml`** — new `media` namespace for all arr apps

### Sonarr (`k3s/applications/sonarr/`)
- `pvc.yaml` — `sonarr-config` (local-path/2Gi) + static SMB PV/PVC (`sonarr-media-volume`, mounts `//192.168.1.20/data`)
- `deployment.yaml` — Recreate strategy, linuxserver/sonarr:latest + exportarr v2.3.0 sidecar (port 9707, args: `sonarr`)
- `service.yaml` — ClusterIP, ports `http:8989` + `metrics:9707`
- `ingress.yaml` — Traefik + letsencrypt-prod → `sonarr.homelab.properties`
- `servicemonitor.yaml` — interval 4m, scrapeTimeout 90s
- `sonarr-apikey.sops.yaml` — **plaintext placeholder**, must be encrypted after first deploy

### Radarr (`k3s/applications/radarr/`)
- Same structure as Sonarr with radarr substitutions: port 7878, `radarr.homelab.properties`, `radarr-media-volume`

### Recyclarr (`k3s/applications/recyclarr/`)
- `cronjob.yaml` — runs `recyclarr sync` daily at 02:30, `concurrencyPolicy: Forbid`
- `configmap.yaml` — full TRaSH Guides config: Sonarr WEB-1080p profile + Radarr HD Bluray + WEB profile
- `recyclarr-secrets.sops.yaml` — **plaintext placeholder**, must be encrypted after first deploy

## Post-Deploy Steps (REQUIRED before cluster is healthy)

> ⚠️ The `.sops.yaml` files are committed as plaintext templates. Flux will fail to apply them until they are encrypted.

### 1. Let Sonarr and Radarr initialize
Wait for pods to start and generate their API keys.

### 2. Encrypt the API key secrets
```bash
# Sonarr — copy API key from Sonarr UI (Settings → General)
# Edit k3s/applications/sonarr/sonarr-apikey.sops.yaml, replace REPLACE_ME_AFTER_FIRST_DEPLOY
sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
  k3s/applications/sonarr/sonarr-apikey.sops.yaml \
  > /tmp/sonarr-apikey.sops.yaml && \
  mv /tmp/sonarr-apikey.sops.yaml k3s/applications/sonarr/sonarr-apikey.sops.yaml

# Radarr — same process
sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
  k3s/applications/radarr/radarr-apikey.sops.yaml \
  > /tmp/radarr-apikey.sops.yaml && \
  mv /tmp/radarr-apikey.sops.yaml k3s/applications/radarr/radarr-apikey.sops.yaml

# Recyclarr secrets — fill in both API keys first
sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
  k3s/applications/recyclarr/recyclarr-secrets.sops.yaml \
  > /tmp/recyclarr-secrets.sops.yaml && \
  mv /tmp/recyclarr-secrets.sops.yaml k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
```

### 3. Commit and push encrypted secrets
```bash
git add k3s/applications/sonarr/sonarr-apikey.sops.yaml \
        k3s/applications/radarr/radarr-apikey.sops.yaml \
        k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
git commit -m "chore(secrets): encrypt sonarr/radarr/recyclarr api keys"
git push
```

## Architecture Notes

- **Media volumes**: Both apps share the NAS `/data` share via separate static PVs (`sonarr-media-volume`, `radarr-media-volume`). Sonarr mounts at `/data/media` (expects `/data/media/tv`), Radarr at `/data/media` (expects `/data/media/movies`).
- **Exporters**: exportarr v2.3.0 runs as a sidecar — no ReadWriteOnce scheduling conflicts, shared pod lifecycle.
- **Prometheus**: ServiceMonitors use `interval: 4m` + `scrapeTimeout: 90s` — arr apps are slow to respond.
- **Recyclarr**: Uses `!env_var` YAML tags for API keys injected from the Secret via `envFrom`.
- **TRaSH IDs**: Sonarr `72dae194fc92bf828f32cde7744e51a1` (WEB-1080p), Radarr `d1d67249d3890e49bc12e275d989a7e9` (HD Bluray + WEB).
