### PR TITLE
feat: ExternalDNS with Pi-hole webhook for automatic DNS registration

### DIFF
--- a/k3s/clusters/homelab/infra-controllers.yaml
+++ b/k3s/clusters/homelab/infra-controllers.yaml
@@ -22,3 +22,7 @@ spec:
     name: flux-system
   dependsOn:
     - name: platform
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-docker
+  namespace: flux-system
+spec:
+  interval: 30m
+  targetNamespace: external-dns
+  chart:
+    spec:
+      chart: external-dns
+      version: '1.21.1'
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: external-dns-docker
+
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/tarantini-io/external-dns-pihole-webhook
+          tag: main
+        env:
+          - name: PIHOLE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pihole-docker-password
+                key: password
+          - name: PIHOLE_SERVER
+            value: "http://192.168.1.2"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+
+    sources:
+      - ingress
+
+    domainFilters:
+      - homelab.properties
+
+    # upsert-only: creates/updates DNS records but never deletes them.
+    # Safe for a homelab with manually managed Pi-hole entries.
+    policy: upsert-only
+
+    # Pi-hole does not support TXT records; noop skips ownership tracking.
+    registry: noop
+
+    logLevel: info

--- a/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
@@ -29,7 +29,7 @@ spec:
       webhook:
         image:
           repository: ghcr.io/tarantini-io/external-dns-pihole-webhook
-          tag: main
+          tag: v1.0.0
         env:
           - name: PIHOLE_PASSWORD
             valueFrom:

--- a/k3s/infrastructure/controllers/external-dns/helmrelease-k3s.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrelease-k3s.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-k3s
+  namespace: flux-system
+spec:
+  interval: 30m
+  targetNamespace: external-dns
+  chart:
+    spec:
+      chart: external-dns
+      version: '1.21.1'
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: external-dns-k3s
+
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/tarantini-io/external-dns-pihole-webhook
+          tag: main
+        env:
+          - name: PIHOLE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pihole-k3s-password
+                key: password
+          - name: PIHOLE_SERVER
+            value: "http://pihole-web.pihole.svc.cluster.local"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+
+    sources:
+      - ingress
+
+    domainFilters:
+      - homelab.properties
+
+    # upsert-only: creates/updates DNS records but never deletes them.
+    # Safe for a homelab with manually managed Pi-hole entries.
+    policy: upsert-only
+
+    # Pi-hole does not support TXT records; noop skips ownership tracking.
+    registry: noop
+
+    logLevel: info

--- a/k3s/infrastructure/controllers/external-dns/helmrelease-k3s.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrelease-k3s.yaml
@@ -29,7 +29,7 @@ spec:
       webhook:
         image:
           repository: ghcr.io/tarantini-io/external-dns-pihole-webhook
-          tag: main
+          tag: v1.0.0
         env:
           - name: PIHOLE_PASSWORD
             valueFrom:

--- a/k3s/infrastructure/controllers/external-dns/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/external-dns/

--- a/k3s/infrastructure/controllers/external-dns/kustomization.yaml
+++ b/k3s/infrastructure/controllers/external-dns/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease-k3s.yaml
+  - helmrelease-docker.yaml
+  - pihole-k3s-password.sops.yaml
+  - pihole-docker-password.sops.yaml

--- a/k3s/infrastructure/controllers/external-dns/pihole-docker-password.sops.yaml
+++ b/k3s/infrastructure/controllers/external-dns/pihole-docker-password.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:mF8=,iv:ieTPm2yWzdCnDEFcizMIiNv0XOB8Zd4c9hUtDR0KAIE=,tag:yOkNFeG2Exy4HwmG1FItPQ==,type:str]
+kind: ENC[AES256_GCM,data:hRMoGL7P,iv:CY35vm56UZb9AzjuDYieCMoXdYIrssJM8/r0yHth47I=,tag:yYwybzOU5wfqfdDq3zcuSQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:DsmLPQYaDWZccCJQtBo1RsbMdO3JIQ==,iv:ZpwcDINlXZkzhYwFHlwiOQzfUBtaE2YLlXo9O/6u+YU=,tag:LowPyxEch9xcqkR+2GPxLA==,type:str]
+    namespace: ENC[AES256_GCM,data:SDr5aTS++aYOXS5J,iv:e3pNUtshh/j5LRqP4e/77Ff70Pz0+3DsSA08WOzf/8k=,tag:UVOfaVU7ZVCZAe2+o/HO/A==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:BBQBqA0=,iv:g7dK1Ey8AWVJICYQ9LtyNYyHwSt+vp7Bz1J8gTascPA=,tag:QVwTfAAvDtpTNBpkMz8+Dg==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByaVNXYUV6TTc3N1BlTjhW
+            TGgyMnhPOTFKMjhocFNiemtNREtLcXQ5TVN3CjNtRkRqckxqNU4yRjYwKyttZEtR
+            M2dQVUxncVhpbG5ocThaVitaSDRQeWsKLS0tIEFVeW9jV3lUOU5lRjNOYWxrOTdk
+            WFpxL2ZVaTlSVldmRFYwWHNGTlduNjQK/wcQCerjj1ztcoh/vIlow8Ovm/leEZNW
+            mFbPSsu3W1bp7LCyHxjPGWfM0D2uh1dCK/Cn5W4FGYJF6whm7nBTWQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T18:53:47Z"
+    mac: ENC[AES256_GCM,data:++iAlwPgtb7vB9yvINrgm4FSY0DFex+mg7HREVlefQUbb8saCVMNeyFKdvI6W70pSReAxVAMmAiyNtCZzYjtpRPOmKZfxvSX4JDwXtJz8V0XMWJtW4qz7s4IX46dXa/BWVLJAd3nEERKbXeZ+W9n9eYyj7G4z+oad5xSNWtgYHw=,iv:lZNq/rhKRjX7INDrXH2yerbA5E9YWvCSJEr6rHVfS7M=,tag:DIJ8nT21ih2dOQKgPZi9Qg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/controllers/external-dns/pihole-k3s-password.sops.yaml
+++ b/k3s/infrastructure/controllers/external-dns/pihole-k3s-password.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:omE=,iv:bkK7dpPaVQUaIuHx0QoO/WNcpcVDqNjMHf8PLh9m36g=,tag:TESZcpFbnjbVcZBZSZ56Bg==,type:str]
+kind: ENC[AES256_GCM,data:NuFut6e2,iv:Wbx1PbFRdCx0rmmHwpek/mdVggtMrOCrgunrIXT/zqw=,tag:j1T0nAmQXOmO4Rsb6r8Nvg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:Gz++sROWpTymKtUJA4eBqfHt6w==,iv:dentQuQGqouSYsu3qzTo859HZMaFbyeiePzcCb+BH6E=,tag:iDJNs18hB5y+4w1xACBK5A==,type:str]
+    namespace: ENC[AES256_GCM,data:o6Jj9MDCKWmx3Bdp,iv:pUObz3Rg6PdmH7rWBT6iTF86yTX99jiiMocwm9PZIfs=,tag:/J/CLVomwJeteNzA1p35gg==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:QOe2V5q3eK9lQF5EOw==,iv:rpQiB9KHckNpTw4TD1YUI0oe4ntRND3kUxf5X5JoRFc=,tag:+YVHbZSEPMUYlm6/XyfKLA==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1YS9tVXFScHNmQmo1NWo3
+            ajMxMENyUzlsSGRnRno0WkpEckxBTVRId1RVCjRLWGhUWDJwSmxKMzhVSTFPaVpk
+            TXNSeC9DU3MxKzkyaU9CcXl2MHRPUVUKLS0tIFNSZEVNYXpkWjZaMGFKbG11czc4
+            cEtwK1FsRUIraUE2bmdmNTNwU2Y1blUKnO21hamtp4nahthV3IDTYWgbf7Sjboi/
+            pgFVfP8Ju7Y2xHAjk4fRFd24gkxPD5eI03nWovgDo35CD8f1E/TaEg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T18:53:47Z"
+    mac: ENC[AES256_GCM,data:tNLQdhFGd3bis+HeEINxUQGHKbGcetqN4fyK4w9TSawTgyEe7QEfm+Y7tIHQmcBj68DnDB+nrOyufvCNEwMIGHAaHTr26pmD1nNPxouX5+2KX0Qz9mD9g5fNFnQLOYZo3Xwz2+kwc+xbUR+bihOOQI0edKXOaKVzxYaKZtMEjkc=,iv:3kB4/xW/ZBw7IZR3L6QEUl0dEY7MSs0cGrX6sV9Ep4g=,tag:oHEoXm5ng53W4R4Pm3jwiA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - nvidia-device-plugin
   - node-feature-discovery
   - csi-driver-smb
+  - external-dns

--- a/k3s/platform/namespaces/external-dns.yaml
+++ b/k3s/platform/namespaces/external-dns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - tdarr.yaml
   - portainer.yaml
   - media.yaml
+  - external-dns.yaml


### PR DESCRIPTION
## Summary

Deploys ExternalDNS to the K3s cluster so that DNS records in Pi-hole are automatically created/updated whenever Kubernetes Ingress resources are added or modified — no more manual DNS entry management.

## What's Added

### Two ExternalDNS instances (via Flux HelmRelease)

| Instance | Target Pi-hole | Secret |
|---|---|---|
| `external-dns-k3s` | `http://pihole-web.pihole.svc.cluster.local` | `pihole-k3s-password` |
| `external-dns-docker` | `http://192.168.1.2` | `pihole-docker-password` |

Both instances watch the `homelab.properties` domain and sync all Ingress hostnames automatically.

### Provider

Uses [`tarantini-io/external-dns-pihole-webhook`](https://github.com/tarantini-io/external-dns-pihole-webhook) — the only active webhook compatible with Pi-hole v6 (`2026.05.0`). Runs as a sidecar on `localhost:8888`.

### Configuration choices

- **Policy: `upsert-only`** — only adds/updates records, never deletes. Preserves any manually created DNS entries.
- **Registry: `noop`** — Pi-hole does not support TXT records (required by the default `txt` registry).
- **Sources: `[ingress]`** — reads `spec.rules[*].host` automatically; no annotation changes needed on existing Ingresses.

### Files

```
k3s/
├── platform/namespaces/external-dns.yaml              # Namespace
├── infrastructure/controllers/
│   ├── kustomization.yaml                             # +external-dns entry
│   └── external-dns/
│       ├── helmrepository.yaml                        # kubernetes-sigs/external-dns chart repo
│       ├── helmrelease-k3s.yaml                       # ExternalDNS → K3s Pi-hole
│       ├── helmrelease-docker.yaml                    # ExternalDNS → Docker Pi-hole
│       ├── pihole-k3s-password.sops.yaml              # SOPS-encrypted K3s Pi-hole password
│       ├── pihole-docker-password.sops.yaml           # SOPS-encrypted Docker Pi-hole password
│       └── kustomization.yaml
└── clusters/homelab/infra-controllers.yaml            # +SOPS decryption block
```

### Why SOPS decryption was added to `infra-controllers.yaml`

The Pi-hole password Secrets live in `infrastructure/controllers/external-dns/` but the `infra-controllers` Flux Kustomization previously had no `decryption` block. Without it, Flux cannot decrypt the SOPS-encrypted secrets. Added the same `decryption.provider: sops` + `secretRef: sops-age` block already present on `infra-configs`.

## Existing hostnames auto-registered

All 9 existing `*.homelab.properties` Ingresses will be picked up on first sync with no changes:

`headlamp`, `pihole`, `portainer`, `sonarr`, `radarr`, `grafana`, `prometheus`, `alertmanager`, `auth`
