### PR TITLE
feat(k3s): migrate Prowlarr to K3s media stack

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - sonarr/
   - radarr/
   - recyclarr/
+  - prowlarr/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/prowlarr/deployment.yaml
+++ b/k3s/applications/prowlarr/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: prowlarr
+  template:
+    metadata:
+      labels:
+        app: prowlarr
+        app.kubernetes.io/name: prowlarr
+    spec:
+      securityContext:
+        fsGroup: 100
+      containers:
+        - name: prowlarr
+          image: lscr.io/linuxserver/prowlarr:2.3.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9696
+              protocol: TCP
+          env:
+            - name: PUID
+              value: "1027"
+            - name: PGID
+              value: "100"
+            - name: TZ
+              value: America/New_York
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 9696
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 9696
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.3.0
+          args:
+            - prowlarr
+          ports:
+            - name: metrics
+              containerPort: 9710
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "9710"
+            - name: URL
+              value: http://localhost:9696
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: prowlarr-apikey
+                  key: api-key
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9710
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9710
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: prowlarr-config

--- a/k3s/applications/prowlarr/ingress.yaml
+++ b/k3s/applications/prowlarr/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prowlarr
+  namespace: media
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: prowlarr.homelab.properties
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prowlarr
+                port:
+                  number: 9696
+  tls:
+    - hosts:
+        - prowlarr.homelab.properties
+      secretName: prowlarr-tls

--- a/k3s/applications/prowlarr/kustomization.yaml
+++ b/k3s/applications/prowlarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - servicemonitor.yaml
+  - prowlarr-apikey.sops.yaml

--- a/k3s/applications/prowlarr/prowlarr-apikey.sops.yaml
+++ b/k3s/applications/prowlarr/prowlarr-apikey.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:Iw8=,iv:O31wmvnBkHSEl9zQfYNLTAXSdimMn6Kl9tnyjte5m/4=,tag:yq4gor25ISwdwqlaQM9mvQ==,type:str]
+kind: ENC[AES256_GCM,data:SSAtxbhp,iv:sMoc3X/mAXPtC1om5HdsPHG0+KTcxsY/NhO19iaWflg=,tag:0QjjcPbt8zPrwLzjbUGjNA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:TJ+vMRcWeD6/BRTkvKEv,iv:zflgbOq6grGIq5MNNv70y9d7IayYFf9aFVcoQd6Yk+o=,tag:Vct987MPsRJIYZIZlYI2Ng==,type:str]
+    namespace: ENC[AES256_GCM,data:qMhP8aw=,iv:zJJctvlbRkdrA+v7KL8DMWl+RSLUXjnk+/5B0aeiXuQ=,tag:ydiMFjrXPHTGPzKhmNpG8w==,type:str]
+stringData:
+    api-key: ENC[AES256_GCM,data:QN7ByKFc1WB369rCQ+EM3uewZKZCCGjcBw==,iv:Y5VjpzOzsRLbiwpthG9bs+foxDLW83oqKtl/SCBHU5M=,tag:6Z0CaXU5eoHa8UyXax9NfQ==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaY01pNDlUZkNZbHpEajEr
+            R1ZGMjBQVzdkTEpUdllvcXlGanJYclBkZldFCklRSEdNOS96VHdEQkl0c1h5eC8v
+            L2gvbWRNd2xXait5c1h6S2JvUTQyY2cKLS0tIHNuVjB0dURuOGtZTWc3cHBGVU4z
+            VC8vaUJkdnYxYitudnNxc2pkOVpxS2cKVlCwbC1F2dyLVn/V+ANLQpEEkQ0ZhGE4
+            Lzt0WTSyBhkn7HitdDQ5TON03AmrhZKtiQWum0fqoBi1LL6zxKu22w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T21:53:24Z"
+    mac: ENC[AES256_GCM,data:FO8PYwzvVw/XfK5l53lG80Wi76Aoqeswb5oUzIBAfSecQEJ5XdyvUd/Ybc+8qwnMq7wpzXY9vOU0R2rMFIn84fPnyWyrGmIKhn1zx0JCjm1uJ2k+soqV1fpmzHVr5H6UGcMfPVDVEKtlJLkLf6p4C2CcAui65gCrmrKOUPPvvT0=,iv:xS3/OEkUNaK9SCB7GBnO0UavAOSMtP4g0ywHqUCt+tE=,tag:MVuN0046OhyjtCfdb8wirA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/prowlarr/pvc.yaml
+++ b/k3s/applications/prowlarr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prowlarr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi

--- a/k3s/applications/prowlarr/service.yaml
+++ b/k3s/applications/prowlarr/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prowlarr
+  namespace: media
+  labels:
+    app.kubernetes.io/name: prowlarr
+spec:
+  type: ClusterIP
+  selector:
+    app: prowlarr
+  ports:
+    - name: http
+      port: 9696
+      targetPort: 9696
+      protocol: TCP
+    - name: metrics
+      port: 9710
+      targetPort: 9710
+      protocol: TCP

--- a/k3s/applications/prowlarr/servicemonitor.yaml
+++ b/k3s/applications/prowlarr/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 4m
+      scrapeTimeout: 90s


### PR DESCRIPTION
## Summary

Migrates Prowlarr from the Docker media stack to K3s, matching the existing Sonarr/Radarr deployment pattern.

## Changes

- **`k3s/applications/prowlarr/deployment.yaml`** — `linuxserver/prowlarr:2.3.5` with `exportarr:v2.3.0` sidecar (port 9710)
- **`k3s/applications/prowlarr/service.yaml`** — ClusterIP exposing ports 9696 (http) and 9710 (metrics)
- **`k3s/applications/prowlarr/ingress.yaml`** — Traefik + Let's Encrypt at `prowlarr.homelab.properties`
- **`k3s/applications/prowlarr/pvc.yaml`** — 2Gi local-path PVC for `/config` (no media volume needed — Prowlarr is indexer-only)
- **`k3s/applications/prowlarr/servicemonitor.yaml`** — Prometheus scrape every 4m via exportarr
- **`k3s/applications/prowlarr/prowlarr-apikey.sops.yaml`** — SOPS-encrypted API key secret (placeholder — see below)
- **`k3s/applications/kustomization.yaml`** — added `prowlarr/` entry

## Post-merge Action Required

The SOPS secret contains a placeholder API key. Before Flux can deploy successfully, update it with the real Prowlarr API key:

```bash
SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey \
  sops k3s/applications/prowlarr/prowlarr-apikey.sops.yaml
# Replace CHANGEME_PROWLARR_API_KEY with the actual key, save and exit
git add k3s/applications/prowlarr/prowlarr-apikey.sops.yaml
git commit -m "secret(prowlarr): set real API key"
git push
```