### PR TITLE
feat: migrate usenet downloader to SABnzbd+gluetun on K3s

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - radarr/
   - recyclarr/
   - prowlarr/
+  - sabnzbd/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -1,0 +1,223 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd
+  namespace: sabnzbd
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sabnzbd
+  template:
+    metadata:
+      labels:
+        app: sabnzbd
+        app.kubernetes.io/name: sabnzbd
+    spec:
+      securityContext:
+        fsGroup: 100
+      volumes:
+        - name: sabnzbd-config
+          persistentVolumeClaim:
+            claimName: sabnzbd-config
+        - name: sabnzbd-downloads
+          persistentVolumeClaim:
+            claimName: sabnzbd-downloads
+        - name: sabnzbd-media
+          persistentVolumeClaim:
+            claimName: sabnzbd-media
+        - name: gluetun-config
+          persistentVolumeClaim:
+            claimName: gluetun-config
+        - name: tun-device
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+      containers:
+        - name: gluetun
+          image: ghcr.io/qdm42/gluetun:v3.42.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          ports:
+            - name: health
+              containerPort: 9999
+              protocol: TCP
+            - name: control
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: VPN_SERVICE_PROVIDER
+              value: "nordvpn"
+            - name: VPN_TYPE
+              value: "wireguard"
+            - name: WIREGUARD_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nordvpn-credentials
+                  key: wireguard-private-key
+            - name: WIREGUARD_ADDRESSES
+              value: "10.5.0.2/32"
+            - name: SERVER_COUNTRIES
+              value: "Netherlands"
+            - name: HEALTH_SERVER_ADDRESS
+              value: "0.0.0.0:9999"
+            - name: HTTP_CONTROL_SERVER_ADDRESS
+              value: "0.0.0.0:8000"
+            - name: FIREWALL_INPUT_PORTS
+              value: "8080,9711,9586"
+            - name: FIREWALL_OUTBOUND_SUBNETS
+              value: "10.244.0.0/16,192.168.1.0/24"
+            - name: DNS_KEEP_NAMESERVER
+              value: "on"
+            - name: DOT
+              value: "off"
+            - name: TZ
+              value: "America/New_York"
+          volumeMounts:
+            - name: gluetun-config
+              mountPath: /gluetun
+            - name: tun-device
+              mountPath: /dev/net/tun
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9999
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9999
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+        - name: sabnzbd
+          image: lscr.io/linuxserver/sabnzbd:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: PUID
+              value: "1027"
+            - name: PGID
+              value: "100"
+            - name: TZ
+              value: "America/New_York"
+          volumeMounts:
+            - name: sabnzbd-config
+              mountPath: /config
+            - name: sabnzbd-downloads
+              mountPath: /downloads
+            - name: sabnzbd-media
+              mountPath: /data
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.3.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - sabnzbd
+          ports:
+            - name: metrics
+              containerPort: 9711
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "9711"
+            - name: URL
+              value: "http://localhost:8080"
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: sabnzbd-apikey
+                  key: api-key
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9711
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9711
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+        - name: gluetun-exporter
+          image: ghcr.io/crstian19/gluetun-exporter:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: gluetun-metrics
+              containerPort: 9586
+              protocol: TCP
+          env:
+            - name: GLUETUN_URL
+              value: "http://localhost:8000"
+            - name: INTERFACE_NAME
+              value: "tun0"
+            - name: LISTEN_ADDRESS
+              value: ":9586"
+            - name: METRICS_PATH
+              value: "/metrics"
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9586
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9586
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -105,7 +105,7 @@ spec:
               cpu: 500m
               memory: 256Mi
         - name: sabnzbd
-          image: lscr.io/linuxserver/sabnzbd:latest
+          image: lscr.io/linuxserver/sabnzbd:5.0.3
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -185,7 +185,7 @@ spec:
               cpu: 200m
               memory: 256Mi
         - name: gluetun-exporter
-          image: ghcr.io/crstian19/gluetun-exporter:latest
+          image: ghcr.io/crstian19/gluetun-exporter:v0.1.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: gluetun-metrics

--- a/k3s/applications/sabnzbd/ingress.yaml
+++ b/k3s/applications/sabnzbd/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sabnzbd
+  namespace: sabnzbd
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: sabnzbd.homelab.properties
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sabnzbd
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - sabnzbd.homelab.properties
+      secretName: sabnzbd-tls

--- a/k3s/applications/sabnzbd/kustomization.yaml
+++ b/k3s/applications/sabnzbd/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - servicemonitor.yaml
+  - nordvpn-credentials.sops.yaml
+  - sabnzbd-apikey.sops.yaml

--- a/k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml
+++ b/k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:/sg=,iv:VNfpodPEzm76QDJaty0ibu7pVg/BeCSojgvjTmhvV7A=,tag:JCjVdF/juq5WnoP0Re312Q==,type:str]
-kind: ENC[AES256_GCM,data:PmU7aW6q,iv:/QNqtlvYeYDXQmPJXJ/pPvJ8E8em+OGDrRCcpM/BiGk=,tag:dfDwlktRVMNqIUnCu2yM/A==,type:str]
+apiVersion: ENC[AES256_GCM,data:hH8=,iv:8rW8cH+25IdIW7s9yiIebcIipBepbewo/xwZ8CLPjqQ=,tag:47OgMx3ahhb+nj6kxW9jCw==,type:str]
+kind: ENC[AES256_GCM,data:anjU3eUa,iv:OxfJOQ45jbRdnifMqRgccBhPgozQxiS/XbWN00kK+u0=,tag:NVdYMVAKooN35TzDzOyYbQ==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:0pUr9CEXAY+LhDirXON1J/EkSQ==,iv:Hu88X+6y/dAvm9UlRQtlngn1wIfpXVoI5JryZ3YMDNg=,tag:hIdcAFjb7QFxtv1VzrLABg==,type:str]
-    namespace: ENC[AES256_GCM,data:RCRIi0OnIA==,iv:B+NAtSTiLd7QPgi91d9SkU59bsgJ0OjPQWr93Wup9Dw=,tag:STwVj/CFpfMVJG5F6f+8sA==,type:str]
+    name: ENC[AES256_GCM,data:5nYCzDcaRcFTtMt817wRHI5ULw==,iv:5KXFhsdR9VnHtG6RBRYEg+uKM/e6hRVrmxIL8uygQ1w=,tag:UjhtjbyF6F9GZCdF+Lj74w==,type:str]
+    namespace: ENC[AES256_GCM,data:bt+nUdPEfw==,iv:yS5azqLw5AWF0MCyj+8MZ81cD9t8nkmNSwtmouLDY+k=,tag:QC67jaF2V6s0t+NOzeEs7Q==,type:str]
 stringData:
-    wireguard-private-key: ENC[AES256_GCM,data:VsYBimoQdDZK3StiHx3YS0UJ7xZhAi1v6M7iLCzyAtuaTb9VxMOS/TlpLUTrFw==,iv:AK3QXiY/WxduY9oU1CaA6lYzuRuY+yJtq0ih9A0BRJY=,tag:JvxAuW68L5JVZbmW0/jVPA==,type:str]
+    wireguard-private-key: ENC[AES256_GCM,data:ANvebLnfDs7rRw9unkEq7azlSfp7REy8EEcy1a7gU+vPnELQ/RYqu1BumP151sptr9WCVL7jMvkozgxQDyPdow==,iv:HyMkXUk+9nrjVY2EMa0Ii9MMApGGLI2yuMLjdQrNMgQ=,tag:wRmERfZKOREQ8uPhKys6Ag==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBYjRXWVdleHJ4L3dnK1hi
-            QnhGdXdsZzJMK2VCWUUxeWphN0wySFhPVVFjCjFMVTc1aThjL0QxUmN4aTdTdGJR
-            b215L1lZVFhWcGxUWjhQQ2Nqek5talUKLS0tIE9heGp5RFVnaFd3dDJmbDB1NG8v
-            UFE0SEhWOG1YdW8vUlFQaFJWMjg2V3cKwK4fxVNJtvamx8C57i561PXFQXQ/PI7l
-            E7TBPXdOZh1DuVf8LLRmdLJ39LucnR/7CNsO/6/r/Sa6sIoLeOmxPA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIbnMxV3ZqVGFMYTRVTnFa
+            VmVtbzVZamU2VTNUdmFpZ1QvWHhQZlZ4bFdrCm92N1JVcndZeHN5WFpyVlh3TFE3
+            MmVEbzV6bEZBNTdkejlYREdsWjNraFEKLS0tIFVIOUFSVjM0dFVrTCtMUnZTSmJk
+            bXV0RG02L3ZHZHI3djBhaWhWM1VKTncKGscLDWdA4taAqo7aJBlPV15soL8GlCPw
+            2/Ok/0vNz+Ti0Pi6sWcqpnqTGVU6YGWLcluJ8MB+WUXaV5xrnaHOIg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T23:22:29Z"
-    mac: ENC[AES256_GCM,data:yfKB7vLPj/PNbI2camBbCfwYzpQkwcN0c/p0xxBb9xraAYD1WJjggRCzuI61SrIT2fRG1Si+Tg6XdeErPNg3wAU4uUg2Y3Lm8siLFU6hLiLHClf97EhqOBydZcaoRBgfm9g8Pyso/hw4FLRTmrdeaEjhNbHIkR/eqyhRrg9Gf0s=,iv:ciRfeEY4tZ81ap9W5M2ZU9NDQwDp29ImjnOM4mRjLU8=,tag:3RjGxF7agc205qylnDeD+A==,type:str]
+    lastmodified: "2026-05-23T23:35:50Z"
+    mac: ENC[AES256_GCM,data:tmOZcoJGqhtcA3ADmWuKhRRD9is0Z2KW2BL+ncXHPlVAdXyRArO/6YhpzRBSLSvfyJb29P6IB2NIrd1SII1LtEcFlV2Nl6cUmneq9Bt98zeEbKy0nYDY+SbFL4KWq1jqTFw35/scpWZwcMM188StCmk3nQj2+UGLmwJgLRw7wpg=,iv:eY8+fAnQGanKFu5d4sRpKQ9kPsGPtbBzexlxNfOE5KQ=,tag:0tjF7akqYyqn/gsoJy5hJQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml
+++ b/k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:/sg=,iv:VNfpodPEzm76QDJaty0ibu7pVg/BeCSojgvjTmhvV7A=,tag:JCjVdF/juq5WnoP0Re312Q==,type:str]
+kind: ENC[AES256_GCM,data:PmU7aW6q,iv:/QNqtlvYeYDXQmPJXJ/pPvJ8E8em+OGDrRCcpM/BiGk=,tag:dfDwlktRVMNqIUnCu2yM/A==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:0pUr9CEXAY+LhDirXON1J/EkSQ==,iv:Hu88X+6y/dAvm9UlRQtlngn1wIfpXVoI5JryZ3YMDNg=,tag:hIdcAFjb7QFxtv1VzrLABg==,type:str]
+    namespace: ENC[AES256_GCM,data:RCRIi0OnIA==,iv:B+NAtSTiLd7QPgi91d9SkU59bsgJ0OjPQWr93Wup9Dw=,tag:STwVj/CFpfMVJG5F6f+8sA==,type:str]
+stringData:
+    wireguard-private-key: ENC[AES256_GCM,data:VsYBimoQdDZK3StiHx3YS0UJ7xZhAi1v6M7iLCzyAtuaTb9VxMOS/TlpLUTrFw==,iv:AK3QXiY/WxduY9oU1CaA6lYzuRuY+yJtq0ih9A0BRJY=,tag:JvxAuW68L5JVZbmW0/jVPA==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBYjRXWVdleHJ4L3dnK1hi
+            QnhGdXdsZzJMK2VCWUUxeWphN0wySFhPVVFjCjFMVTc1aThjL0QxUmN4aTdTdGJR
+            b215L1lZVFhWcGxUWjhQQ2Nqek5talUKLS0tIE9heGp5RFVnaFd3dDJmbDB1NG8v
+            UFE0SEhWOG1YdW8vUlFQaFJWMjg2V3cKwK4fxVNJtvamx8C57i561PXFQXQ/PI7l
+            E7TBPXdOZh1DuVf8LLRmdLJ39LucnR/7CNsO/6/r/Sa6sIoLeOmxPA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T23:22:29Z"
+    mac: ENC[AES256_GCM,data:yfKB7vLPj/PNbI2camBbCfwYzpQkwcN0c/p0xxBb9xraAYD1WJjggRCzuI61SrIT2fRG1Si+Tg6XdeErPNg3wAU4uUg2Y3Lm8siLFU6hLiLHClf97EhqOBydZcaoRBgfm9g8Pyso/hw4FLRTmrdeaEjhNbHIkR/eqyhRrg9Gf0s=,iv:ciRfeEY4tZ81ap9W5M2ZU9NDQwDp29ImjnOM4mRjLU8=,tag:3RjGxF7agc205qylnDeD+A==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/sabnzbd/pvc.yaml
+++ b/k3s/applications/sabnzbd/pvc.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-config
+  namespace: sabnzbd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-downloads
+  namespace: sabnzbd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 200Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gluetun-config
+  namespace: sabnzbd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sabnzbd-media
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: sabnzbd-media-volume
+    volumeAttributes:
+      source: "//192.168.1.20/data"
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-media
+  namespace: sabnzbd
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: sabnzbd-media
+  resources:
+    requests:
+      storage: 10Ti

--- a/k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml
+++ b/k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:cG8=,iv:w28TwnFLXhtPHzrFTTk5vv3HOAkqxwEyLW/u7SS0Ylk=,tag:Ta8T4Nja5jytjyzxKhInlg==,type:str]
+kind: ENC[AES256_GCM,data:Zs9kjH54,iv:kyO+QDuiah05LkGpwLdfM0fRBldmPoXIpKcgBWQ9gd4=,tag:NZipi8eYLM00uduT2Bw3Lg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:Y+LkDfcYcMKhStysVrw=,iv:OB+2Pe7iOLvWSshsmv9CSgGaDifCFSOd2/EFB6S6mGA=,tag:a+T05GGwTAtCL8kuO5MDww==,type:str]
+    namespace: ENC[AES256_GCM,data:YjEFvPj3jA==,iv:bYgTBD+DCGdwgmtgSRH8Xm9XzJ0yPOw6qjOSRPrXxxo=,tag:CNlwBouJ4EQj68jWr1q70g==,type:str]
+stringData:
+    api-key: ENC[AES256_GCM,data:wMSOteuO/Ay04XUqCMF2/2mjFyIhXzqrdZb37htl3v8SI4N0,iv:nZD/6DuEvKx77QqnF7EuAGm0PKl+oZfx9c3RqBc/ico=,tag:KRqS0eNcL06jSFWvWZmf8w==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwL1BwVHlQTFUvY1NrVkMz
+            ZjZjVmE3Q0EvRC9PbldLU1lTZCtXU01oWEVzCnI4Z1NCWFg0d1lYQWcxWEp0amEy
+            ZC9YSm41ZWZKTjhmM3dGNXlGWjM4elEKLS0tIFpZWUJESExINFlva0JsUEwrYWdw
+            ZzdGY2s4UWZRMGN5NWh6YWJqcGFGaDQK/lyLVbCqje5pRSncPudaPfBHikuVwbcl
+            0HMdywSEVKj2xTxE+kIDt/UOx1Sd9TBdS9PEsRpmlJbK9xkLYpBipw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-23T23:22:29Z"
+    mac: ENC[AES256_GCM,data:P9o7r+AHMD/YUm4lf73c+6t4fDPc5L5DVROY8aLZrsvAQrBQI59/6g0YxLKsMbyQfCtJ+nfrK9ffPKtiDRBbHQ/dTzjYTsbpZKwEVbEqFZuoxsqPUfmpq0Vt13+26plXvHUXiffXKu9e6NXS8X+TbU5FDHXZv9FHggabBjJh9Jc=,iv:DIf/+Xy1JSRnpSvjqIh0d533P72xkldKeSMqHIrfVEY=,tag:/Ue7BB9XiHLyY6C5arUwAA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/applications/sabnzbd/service.yaml
+++ b/k3s/applications/sabnzbd/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sabnzbd
+  namespace: sabnzbd
+  labels:
+    app.kubernetes.io/name: sabnzbd
+spec:
+  type: ClusterIP
+  selector:
+    app: sabnzbd
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: metrics
+      port: 9711
+      targetPort: 9711
+      protocol: TCP
+    - name: gluetun-metrics
+      port: 9586
+      targetPort: 9586
+      protocol: TCP

--- a/k3s/applications/sabnzbd/servicemonitor.yaml
+++ b/k3s/applications/sabnzbd/servicemonitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sabnzbd-exportarr
+  namespace: sabnzbd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 4m
+      scrapeTimeout: 90s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sabnzbd-gluetun
+  namespace: sabnzbd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  endpoints:
+    - port: gluetun-metrics
+      path: /metrics
+      interval: 4m
+      scrapeTimeout: 90s

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - portainer.yaml
   - media.yaml
   - external-dns.yaml
+  - sabnzbd.yaml

--- a/k3s/platform/namespaces/sabnzbd.yaml
+++ b/k3s/platform/namespaces/sabnzbd.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sabnzbd


### PR DESCRIPTION
## Summary

Migrates the usenet download stack from Docker NZBGet to SABnzbd + Gluetun on K3s.

## Changes

### Platform
- Add  namespace

### Application (k3s/applications/sabnzbd/)
- **Deployment**: 4-container pod — gluetun VPN sidecar, sabnzbd, exportarr, gluetun-exporter
- **Storage**: local-path PVCs for config/downloads staging; smb-media PV/PVC for final /data mount
- **Security**: gluetun uses NET_ADMIN capability + /dev/net/tun hostPath (no privileged mode)
- **Networking**: FIREWALL_INPUT_PORTS includes 8080,9711,9586 so Prometheus scrapes through VPN
- **Ingress**: sabnzbd.homelab.properties via traefik + letsencrypt-prod
- **Monitoring**: ServiceMonitors for exportarr (port 9711) and gluetun-exporter (port 9586)
- **Secrets**: SOPS-encrypted stubs for nordvpn-credentials and sabnzbd-apikey

### Flux Activation
- Add sabnzbd to apps kustomization (this PR's final commit)

## Post-merge Manual Steps
1. Fill in real NordVPN WireGuard private key in nordvpn-credentials.sops.yaml
2. After first SABnzbd boot: get API key → update sabnzbd-apikey.sops.yaml
3. Configure SABnzbd download paths: incomplete=/downloads/incomplete, complete=/downloads/complete
4. Update Sonarr/Radarr: replace nzbget client with SABnzbd at sabnzbd.sabnzbd.svc.cluster.local:8080

## Architecture Notes
- Download staging uses local-path PVC (avoids SABnzbd CIFS atomicity failures documented for SMBv3)
- Final completed files moved to /data/usenet/complete (smb-media CIFS mount)
- gluetun-exporter INTERFACE_NAME=tun0 (may need wg0 if metrics missing — Day-2 fix)
