### PR TITLE
fix(sabnzbd): correct container image references

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             type: CharDevice
       containers:
         - name: gluetun
-          image: ghcr.io/qdm42/gluetun:v3.42.0
+          image: qmcgaw/gluetun:v3.41.1
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -185,7 +185,7 @@ spec:
               cpu: 200m
               memory: 256Mi
         - name: gluetun-exporter
-          image: ghcr.io/crstian19/gluetun-exporter:v0.1.1
+          image: ghcr.io/crstian19/gluetun-exporter:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: gluetun-metrics


### PR DESCRIPTION
## Problem

Two containers failed with `ImagePullBackOff` after #101 merged:

| Container | Bad image | Error |
|---|---|---|
| gluetun | `ghcr.io/qdm42/gluetun:v3.42.0` | 403 Forbidden — gluetun is not published to ghcr.io |
| gluetun-exporter | `ghcr.io/crstian19/gluetun-exporter:v0.1.1` | not found — release workflow publishes binaries only, not container images |

## Fixes

| Container | Corrected image |
|---|---|
| gluetun | `qmcgaw/gluetun:v3.41.1` (Docker Hub, latest stable) |
| gluetun-exporter | `ghcr.io/crstian19/gluetun-exporter:latest` (only tag published to ghcr.io) |

## Notes

- gluetun's canonical registry is Docker Hub (`qmcgaw/gluetun`), not ghcr.io
- crstian19/gluetun-exporter CI pushes `:latest` to ghcr.io; versioned tags are binary-only releases