### PR TITLE
fix: correct gluetun-exporter image tag (v0.1.1 → 0.1.1)

### DIFF
--- a/k3s/applications/qbittorrent/AGENTS.md
+++ b/k3s/applications/qbittorrent/AGENTS.md
@@ -10,7 +10,7 @@ qbittorrent namespace
 ├── gluetun          (VPN sidecar — NordVPN WireGuard)
 ├── qbittorrent      (lscr.io/linuxserver/qbittorrent:5.0.4)
 ├── qbt-exporter     (ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.3.0)
-└── gluetun-exporter (ghcr.io/crstian19/gluetun-exporter:latest)
+└── gluetun-exporter (ghcr.io/crstian19/gluetun-exporter:0.1.1)
 ```
 
 ## Storage / Directory Layout

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -188,7 +188,7 @@ spec:
               cpu: 100m
               memory: 128Mi
         - name: gluetun-exporter
-          image: ghcr.io/crstian19/gluetun-exporter:v0.1.1
+          image: ghcr.io/crstian19/gluetun-exporter:0.1.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: gluetun-metrics

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -185,7 +185,7 @@ spec:
               cpu: 200m
               memory: 256Mi
         - name: gluetun-exporter
-          image: ghcr.io/crstian19/gluetun-exporter:latest
+          image: ghcr.io/crstian19/gluetun-exporter:0.1.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: gluetun-metrics


### PR DESCRIPTION
## Problem

The qbittorrent pod is failing with `ImagePullBackOff`:

```
Failed to pull image "ghcr.io/crstian19/gluetun-exporter:v0.1.1": not found
```

The GHCR package `crstian19/gluetun-exporter` uses `0.1.1` as the tag — no `v` prefix. The tag `v0.1.1` does not exist.

## Changes

- `k3s/applications/qbittorrent/deployment.yaml`: `v0.1.1` → `0.1.1`
- `k3s/applications/sabnzbd/deployment.yaml`: `:latest` → `0.1.1` (consistent pinning)
- `k3s/applications/qbittorrent/AGENTS.md`: update architecture reference

## Verification

https://github.com/crstian19/gluetun-exporter/pkgs/container/gluetun-exporter confirms available tags: `latest`, `0.1.1`, `0.1`