### PR TITLE
fix: correct qbt-exporter image tag (v1.3.0 → latest)

### DIFF
--- a/k3s/applications/qbittorrent/AGENTS.md
+++ b/k3s/applications/qbittorrent/AGENTS.md
@@ -9,7 +9,7 @@ Transmission deployment.
 qbittorrent namespace
 ├── gluetun          (VPN sidecar — NordVPN WireGuard)
 ├── qbittorrent      (lscr.io/linuxserver/qbittorrent:5.0.4)
-├── qbt-exporter     (ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.3.0)
+├── qbt-exporter     (ghcr.io/esanchezm/prometheus-qbittorrent-exporter:latest)
 └── gluetun-exporter (ghcr.io/crstian19/gluetun-exporter:0.1.1)
 ```
 

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -148,7 +148,7 @@ spec:
               cpu: 2000m
               memory: 2Gi
         - name: qbt-exporter
-          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.3.0
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: qbt-metrics


### PR DESCRIPTION
## Problem

The qbittorrent pod is in `ImagePullBackOff` (3/4 containers):

```
Failed to pull image "ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.3.0": not found
```

`prometheus-qbittorrent-exporter` does not publish semver tags. GHCR only has `latest`, `master`, and `sha-*` tags. The tag `v1.3.0` does not exist.

Verified: https://github.com/esanchezm/prometheus-qbittorrent-exporter/pkgs/container/prometheus-qbittorrent-exporter

## Changes

- `k3s/applications/qbittorrent/deployment.yaml`: `v1.3.0` → `latest`
- `k3s/applications/qbittorrent/AGENTS.md`: update reference

## Context

This is the second ImagePullBackOff fix in two PRs. The root cause was the same both times: the `v` prefix convention assumed for GHCR tags that don't actually exist on those images. `exportarr:v2.3.0` (used by radarr/sonarr/sabnzbd/prowlarr) is fine — that project does use semver tags.