### PR TITLE
fix(ansible): support Flux upgrade via flux install when controllers exist

### DIFF
--- a/k3s/bootstrap/ansible/playbooks/bootstrap-flux.yml
+++ b/k3s/bootstrap/ansible/playbooks/bootstrap-flux.yml
@@ -1,10 +1,13 @@
 ---
 # bootstrap-flux.yml
-# Bootstraps Flux CD on a running K3s cluster and sets up SOPS/age encryption.
+# Bootstraps or upgrades Flux CD on a running K3s cluster and sets up SOPS/age encryption.
 # Run AFTER bootstrap-k3s.yml completes successfully.
 #
 # Usage:
-#   export GITHUB_TOKEN=ghp_xxxx
+#   Fresh install:  export GITHUB_TOKEN=ghp_xxxx
+#   ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml -v
+#
+#   Upgrade (controllers already running — no token needed):
 #   ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml -v
 #
 # The playbook runs tooling on the Ansible controller (delegate_to: localhost)
@@ -15,8 +18,10 @@
 #   2. Pre-creates the flux-system namespace
 #   3. Generates an age key and creates the sops-age Secret in flux-system
 #      (BEFORE bootstrap so Flux can decrypt from first reconciliation)
-#   4. Runs `flux bootstrap github` to install Flux controllers and commit
-#      flux-system/ into k3s/clusters/homelab/ on the master branch
+#   4a. (Fresh install) Runs `flux bootstrap github` to install Flux controllers and commit
+#       flux-system/ into k3s/clusters/homelab/ on the master branch. Requires GITHUB_TOKEN.
+#   4b. (Upgrade)       Runs `flux install` to apply updated controller manifests directly
+#       to the cluster from the pinned CLI version. No git push, no token required.
 #   5. Waits for all Flux controllers to be healthy
 
 - name: Bootstrap Flux CD

--- a/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-bootstrap/tasks/main.yml
@@ -1,19 +1,64 @@
 ---
 # roles/flux-bootstrap/tasks/main.yml
-# Bootstraps Flux CD onto a running K3s cluster using flux bootstrap github.
+# Bootstraps or upgrades Flux CD on a running K3s cluster.
 #
 # All tasks run on the Ansible controller (delegate_to: localhost) using the
 # kubeconfig that the k3s-server role fetched during K3s installation.
 #
 # Ordering is intentional:
-#   1. Install tooling (flux CLI, age CLI)
-#   2. Pre-create {{ sops_secret_namespace }} namespace
-#   3. Generate age key and create sops-age Secret *before* bootstrap runs
-#      so that Flux can decrypt secrets from first reconciliation.
-#   4. Run flux bootstrap github (idempotent)
-#   5. Wait for Flux controllers to be healthy
+#   1. Detect install vs upgrade path (controllers already running?)
+#   2. Install tooling (flux CLI, age CLI)
+#   3. Pre-create {{ sops_secret_namespace }} namespace
+#   4. Generate age key and create sops-age Secret *before* bootstrap runs
+#      so that Flux can decrypt secrets from first reconciliation. (first install only)
+#   5a. (Fresh install)  Run flux bootstrap github — clones repo, pushes flux-system/ manifests,
+#       and installs controllers. Requires GITHUB_TOKEN with repo write access.
+#   5b. (Upgrade)        Run flux install — applies controller manifests from the pinned CLI
+#       version directly to the cluster without touching git. No token required.
+#   6. Wait for Flux controllers to be healthy
 
 # ─── Prerequisites ────────────────────────────────────────────────────────────
+
+- name: Check that kubeconfig exists on controller
+  ansible.builtin.stat:
+    path: "{{ flux_kubeconfig }}"
+  register: kubeconfig_stat
+  delegate_to: localhost
+  become: false
+
+- name: Fail if kubeconfig is missing
+  ansible.builtin.fail:
+    msg: >-
+      Kubeconfig not found at {{ flux_kubeconfig }}.
+      Run bootstrap-k3s.yml first so the k3s-server role fetches it:
+
+        ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
+  when: not kubeconfig_stat.stat.exists
+  delegate_to: localhost
+  become: false
+
+# ─── Detect install vs upgrade path ──────────────────────────────────────────
+# Must run before assertions so token/GitHub vars are only required when needed.
+
+- name: Check if Flux controllers are already installed
+  ansible.builtin.command: >
+    kubectl --kubeconfig={{ flux_kubeconfig }}
+    get deployment source-controller kustomize-controller helm-controller notification-controller
+    -n flux-system
+  register: flux_controllers_check
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+  become: false
+
+- name: Set fact — Flux install mode
+  ansible.builtin.set_fact:
+    flux_is_upgrade: "{{ flux_controllers_check.rc == 0 }}"
+  delegate_to: localhost
+  become: false
+
+# ─── Assertions (fresh install only) ─────────────────────────────────────────
+# Upgrades use flux install and do not push to git, so no token is required.
 
 - name: Assert flux_github_token is set
   ansible.builtin.assert:
@@ -29,6 +74,7 @@
 
       The token needs 'repo' scope to push the flux-system bootstrap files.
     quiet: true
+  when: not flux_is_upgrade | bool
   delegate_to: localhost
   become: false
 
@@ -47,24 +93,7 @@
       inventory/group_vars/all.yml or host/group vars before running
       bootstrap-flux.yml.
     quiet: true
-  delegate_to: localhost
-  become: false
-
-- name: Check that kubeconfig exists on controller
-  ansible.builtin.stat:
-    path: "{{ flux_kubeconfig }}"
-  register: kubeconfig_stat
-  delegate_to: localhost
-  become: false
-
-- name: Fail if kubeconfig is missing
-  ansible.builtin.fail:
-    msg: >-
-      Kubeconfig not found at {{ flux_kubeconfig }}.
-      Run bootstrap-k3s.yml first so the k3s-server role fetches it:
-
-        ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
-  when: not kubeconfig_stat.stat.exists
+  when: not flux_is_upgrade | bool
   delegate_to: localhost
   become: false
 
@@ -283,20 +312,9 @@
   delegate_to: localhost
   become: false
 
-# ─── Flux Bootstrap ───────────────────────────────────────────────────────────
+# ─── Flux Bootstrap / Upgrade ─────────────────────────────────────────────────
 
-- name: Check if Flux controllers are already installed
-  ansible.builtin.command: >
-    kubectl --kubeconfig={{ flux_kubeconfig }}
-    get deployment source-controller kustomize-controller helm-controller notification-controller
-    -n flux-system
-  register: flux_controllers_check
-  changed_when: false
-  failed_when: false
-  delegate_to: localhost
-  become: false
-
-- name: Bootstrap Flux CD via GitHub
+- name: Bootstrap Flux CD via GitHub (fresh install)
   ansible.builtin.command: >
     {{ flux_install_dir }}/flux bootstrap github
     --kubeconfig={{ flux_kubeconfig }}
@@ -309,11 +327,23 @@
   environment:
     GITHUB_TOKEN: "{{ flux_github_token }}"
   changed_when: >
-    flux_controllers_check.rc != 0 or
     'committed' in ((flux_bootstrap_result.stdout | default('')) ~ (flux_bootstrap_result.stderr | default(''))) or
     'pushed' in ((flux_bootstrap_result.stdout | default('')) ~ (flux_bootstrap_result.stderr | default(''))) or
     'installing components' in ((flux_bootstrap_result.stdout | default('')) ~ (flux_bootstrap_result.stderr | default('')))
   register: flux_bootstrap_result
+  when: not flux_is_upgrade | bool
+  delegate_to: localhost
+  become: false
+
+- name: Upgrade Flux controllers via flux install (upgrade path)
+  ansible.builtin.command: >
+    {{ flux_install_dir }}/flux install
+    --kubeconfig={{ flux_kubeconfig }}
+  changed_when: >
+    'applying manifests' in ((flux_install_result.stdout | default('')) ~ (flux_install_result.stderr | default(''))) or
+    'waiting for' in ((flux_install_result.stdout | default('')) ~ (flux_install_result.stderr | default('')))
+  register: flux_install_result
+  when: flux_is_upgrade | bool
   delegate_to: localhost
   become: false
 
@@ -328,10 +358,10 @@
   delegate_to: localhost
   become: false
 
-- name: Display Flux bootstrap summary
+- name: Display Flux summary
   ansible.builtin.debug:
     msg:
-      - "Flux CD is healthy."
+      - "Flux CD is healthy ({{ 'upgraded to' if flux_is_upgrade | bool else 'bootstrapped at' }} v{{ flux_cli_version }})."
       - "Watching branch '{{ flux_git_branch }}' at path '{{ flux_cluster_path }}'."
       - "Flux will reconcile {{ flux_cluster_path }} on every push to {{ flux_git_branch }}."
   delegate_to: localhost


### PR DESCRIPTION
## Problem

`flux bootstrap github` always attempts to push `gotk-components.yaml` to git, even when the manifests are already committed. With branch protection enabled on `master`, this push is rejected:

```
✗ failed to push manifests: failed to push to remote: command error on refs/heads/master: push declined due to repository rule violations
```

This meant upgrading Flux controllers required either temporarily disabling branch protection or manually running `kubectl apply`.

## Solution

Add a two-path approach based on whether Flux controllers are already installed:

**Fresh install** (no controllers running in `flux-system`):
- Runs `flux bootstrap github` as before
- Requires `GITHUB_TOKEN` with repo write access
- Commits and pushes `flux-system/` manifests, installs controllers

**Upgrade** (controllers already running):
- Runs `flux install` instead
- Applies controller manifests from the pinned CLI version directly to the cluster
- No git push, no `GITHUB_TOKEN` required

Controller detection now runs **before** the token/GitHub assertions, so upgrade runs don't need `GITHUB_TOKEN` exported.

## Usage after this change

```bash
# Fresh install (same as before)
export GITHUB_TOKEN=ghp_xxxx
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml -v

# Upgrade (no token needed)
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-flux.yml -v
```

## Files changed

- `playbooks/bootstrap-flux.yml` — updated header comments to document both paths
- `roles/flux-bootstrap/tasks/main.yml` — restructured to detect install vs upgrade, split bootstrap task, added `flux install` upgrade task, made token/GitHub assertions conditional on fresh install
