### PR TITLE
fix(qbittorrent): disable localhost WebUI auth to fix qbt-exporter CrashLoopBackOff

### DIFF
--- a/k3s/applications/qbittorrent/AGENTS.md
+++ b/k3s/applications/qbittorrent/AGENTS.md
@@ -70,6 +70,53 @@ Add the same mapping in Sonarr.
 This maps qBittorrent's view (`/data/torrents/`) to Radarr/Sonarr's view (`/data/media/torrents/`),
 both pointing to NAS `/volume1/data/torrents/`.
 
+## WebUI Authentication Design
+
+### The qBittorrent 5.x Credential Chicken-and-Egg Problem
+
+qBittorrent 5.x changed credential handling: if no `WebUI\Username` / `WebUI\Password_PBKDF2` is set
+in `qBittorrent.conf`, it generates a **random temporary password on every startup** and prints it to
+stdout only:
+
+```
+The WebUI administrator username is: admin
+The WebUI administrator password was not set. A temporary password is provided for this session: TmGfbZjLk
+```
+
+This creates a chicken-and-egg loop for the `qbt-exporter` sidecar:
+
+1. Pod starts → qBittorrent picks a new random password
+2. `qbt-exporter` authenticates with the (wrong) stored credentials
+3. After repeated failures, qBittorrent bans `127.0.0.1`
+4. The `qbittorrent-api` Python library hits 403 → enters infinite recursion → `RecursionError`
+5. Exporter crashes → liveness probe fails → CrashLoopBackOff
+
+Setting persistent credentials via API requires knowing the current password — which is random and
+unknown at automation time. Computing a PBKDF2 hash in an init container (for baking credentials
+directly into `qBittorrent.conf`) requires a Python/openssl init container and is fragile.
+
+### Solution: Disable Localhost Auth
+
+The `qbt-exporter` always connects from `127.0.0.1` (same pod network namespace). qBittorrent has a
+built-in setting to skip auth for localhost connections:
+
+```ini
+[Preferences]
+WebUI\LocalHostAuth=false
+```
+
+This is seeded into `qBittorrent.conf` on first boot via a `seed-config` init container that copies
+from the `qbittorrent-config-seed` ConfigMap into the PVC. The `if [ ! -f ]` guard ensures this only
+runs once — qBittorrent then owns the file and can update it freely.
+
+- **WebUI external access**: still password-protected (only localhost connections bypass auth)
+- **`qbt-exporter`**: no credentials needed; `QBITTORRENT_USER`/`QBITTORRENT_PASS` env vars removed
+- **Config source of truth**: `configmap.yaml` in git
+
+> **Note**: The `qbittorrent-credentials` secret is no longer referenced in the Deployment env vars.
+> It is still applied to the cluster via `kustomization.yaml` and serves as the source of truth for
+> the WebUI password used when configuring Radarr/Sonarr download clients.
+
 ## SOPS Secrets Required
 
 Before Flux can reconcile this app, two encrypted secrets must exist:

--- a/k3s/applications/qbittorrent/configmap.yaml
+++ b/k3s/applications/qbittorrent/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qbittorrent-config-seed
+  namespace: qbittorrent
+data:
+  qBittorrent.conf: |
+    [Preferences]
+    WebUI\LocalHostAuth=false
+    WebUI\Address=*
+    WebUI\ServerDomains=*

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -32,6 +32,30 @@ spec:
           hostPath:
             path: /dev/net/tun
             type: CharDevice
+        - name: qbittorrent-config-seed
+          configMap:
+            name: qbittorrent-config-seed
+      initContainers:
+        - name: seed-config
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              CONF=/config/qBittorrent/qBittorrent.conf
+              if [ ! -f "$CONF" ]; then
+                echo "Seeding qBittorrent config..."
+                mkdir -p /config/qBittorrent
+                cp /seed/qBittorrent.conf "$CONF"
+                echo "Config seeded."
+              else
+                echo "Config exists, skipping seed."
+              fi
+          volumeMounts:
+            - name: qbittorrent-config
+              mountPath: /config
+            - name: qbittorrent-config-seed
+              mountPath: /seed
       containers:
         - name: gluetun
           image: qmcgaw/gluetun:v3.41.1
@@ -159,16 +183,6 @@ spec:
               value: "127.0.0.1"
             - name: QBITTORRENT_PORT
               value: "8080"
-            - name: QBITTORRENT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: qbittorrent-credentials
-                  key: username
-            - name: QBITTORRENT_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: qbittorrent-credentials
-                  key: password
             - name: EXPORTER_PORT
               value: "9090"
             - name: EXPORTER_LOG_LEVEL

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -47,6 +47,7 @@ spec:
                 echo "Seeding qBittorrent config..."
                 mkdir -p /config/qBittorrent
                 cp /seed/qBittorrent.conf "$CONF"
+                chown 1027:100 "$CONF"
                 echo "Config seeded."
               else
                 echo "Config exists, skipping seed."

--- a/k3s/applications/qbittorrent/kustomization.yaml
+++ b/k3s/applications/qbittorrent/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - pvc.yaml
+  - configmap.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml


### PR DESCRIPTION
## Problem

`qbt-exporter` was in CrashLoopBackOff (25+ restarts). Root cause: qBittorrent 5.x generates a **random temporary password** on every startup when no persistent credentials are configured in `qBittorrent.conf`.

### Failure chain

1. Pod starts → qBittorrent generates a new random temp password
2. `qbt-exporter` authenticates with stored credentials (wrong password)
3. After repeated failures, qBittorrent bans `127.0.0.1`
4. `qbittorrent-api` Python library hits 403 → enters infinite recursion → `RecursionError`
5. Exporter crashes (exit 0) → liveness probe on `:9090/metrics` times out → CrashLoopBackOff

### Why not just set persistent credentials?

Setting credentials via the API requires knowing the current password (random, unknown). Computing a PBKDF2 hash for `qBittorrent.conf` in a busybox init container is not feasible. There's no clean GitOps path for baking hashed credentials.

## Solution

Use `WebUI\LocalHostAuth=false` — qBittorrent's built-in setting to skip auth for `127.0.0.1` connections. Since `qbt-exporter` is a sidecar in the same pod (same network namespace), it always connects from localhost.

External WebUI access via ingress remains password-protected.

## Changes

| File | Change |
|------|--------|
| `configmap.yaml` | New — seeds `qBittorrent.conf` with `WebUI\LocalHostAuth=false` |
| `deployment.yaml` | Add `qbittorrent-config-seed` volume; add `seed-config` init container; remove `QBITTORRENT_USER`/`QBITTORRENT_PASS` from `qbt-exporter` |
| `kustomization.yaml` | Add `configmap.yaml` to resources |
| `AGENTS.md` | Document the chicken-and-egg problem and the LocalHostAuth solution |

### Init container behaviour

The `seed-config` init container copies the ConfigMap into the PVC **only if the config file doesn't already exist** (`if [ ! -f ]`). qBittorrent then owns the file and can update it freely without being overwritten on restarts.