### PR TITLE
fix(flux): upgrade authentik HelmRepository apiVersion from v1beta2 to v1

### DIFF
--- a/k3s/infrastructure/configs/authentik/helmrepository.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrepository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: authentik


### PR DESCRIPTION
## Problem

`infra-configs` Kustomization stopped reconciling after the Flux update:

```
infra-configs: HelmRepository/authentik/authentik dry-run failed:
  no matches for kind "HelmRepository" in version "source.toolkit.fluxcd.io/v1beta2"
```

`source.toolkit.fluxcd.io/v1beta2` was removed in the updated Flux source-controller. This caused `infra-configs` to fail its dry-run, which blocked `apps` (depends on `infra-configs`) from reconciling as well.

## Fix

One-line change in `k3s/infrastructure/configs/authentik/helmrepository.yaml`:

```diff
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
```

`HelmRepository` v1 has been GA since Flux v2.1.0.

## Scope

Scanned all `k3s/` YAML files for `v1beta2` — this was the only manifest affected. The remaining `v1beta2` references in `gotk-components.yaml` are deprecation warning strings in CRD definitions, not resource apiVersions.