### PR TITLE
fix(qbittorrent): enforce LocalHostAuth=false on every pod start

### DIFF
--- a/k3s/applications/qbittorrent/AGENTS.md
+++ b/k3s/applications/qbittorrent/AGENTS.md
@@ -105,9 +105,14 @@ built-in setting to skip auth for localhost connections:
 WebUI\LocalHostAuth=false
 ```
 
-This is seeded into `qBittorrent.conf` on first boot via a `seed-config` init container that copies
-from the `qbittorrent-config-seed` ConfigMap into the PVC. The `if [ ! -f ]` guard ensures this only
-runs once — qBittorrent then owns the file and can update it freely.
+This setting is enforced on every pod start by the `seed-config` init container:
+
+- **Config missing**: copies the full seed file from the `qbittorrent-config-seed` ConfigMap
+- **Config exists**: checks for `WebUI\LocalHostAuth`; adds `WebUI\LocalHostAuth=false` if absent,
+  or updates the value if it was set to `true`
+
+This ensures `LocalHostAuth=false` survives pod restarts even after qBittorrent modifies its own
+config on shutdown.
 
 - **WebUI external access**: still password-protected (only localhost connections bypass auth)
 - **`qbt-exporter`**: no credentials needed; `QBITTORRENT_USER`/`QBITTORRENT_PASS` env vars removed

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -50,7 +50,14 @@ spec:
                 chown 1027:100 "$CONF"
                 echo "Config seeded."
               else
-                echo "Config exists, skipping seed."
+                echo "Config exists, enforcing LocalHostAuth=false..."
+                if grep -q 'WebUI\\LocalHostAuth' "$CONF"; then
+                  sed -i 's|WebUI\\LocalHostAuth=.*|WebUI\\LocalHostAuth=false|' "$CONF"
+                else
+                  echo 'WebUI\LocalHostAuth=false' >> "$CONF"
+                fi
+                chown 1027:100 "$CONF"
+                echo "Done."
               fi
           volumeMounts:
             - name: qbittorrent-config
@@ -195,6 +202,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 5
+            timeoutSeconds: 10
           resources:
             requests:
               cpu: 25m


### PR DESCRIPTION
## Problem

PR #112 introduced a seed config with `WebUI\LocalHostAuth=false` to fix the `qbt-exporter` CrashLoopBackOff. However, the init container only copied the seed when `qBittorrent.conf` was **absent** (`if [ ! -f ]`). Existing PVCs already had a config file — so the setting was never applied, and the liveness issue persisted:

```
Liveness probe failed: Get "http://10.42.0.16:9090/metrics": context deadline exceeded
```

Root cause chain (same as before):
1. `qBittorrent.conf` exists in PVC without `WebUI\LocalHostAuth=false`
2. qBittorrent generates a random temp password → exporter can't auth
3. `RecursionError` in the `qbittorrent-api` library → `/metrics` endpoint blocks
4. Liveness probe times out → pod restarts → loop

## Fix

Update the `seed-config` init container to **always enforce** `WebUI\LocalHostAuth=false`:

- **Config absent**: copy full seed (unchanged behavior)
- **Config present**: `grep` for the key; `sed` to update if present, `echo >>` to append if absent

This survives pod restarts even when qBittorrent rewrites its config on graceful shutdown.

Also adds `timeoutSeconds: 10` to the `qbt-exporter` liveness probe as defense-in-depth during slow qBittorrent startup.

## Testing

After merge + Flux reconciliation, the next pod restart will:
1. Init container enforces `LocalHostAuth=false` in the existing conf
2. qBittorrent starts → exporter connects from 127.0.0.1 without auth
3. `/metrics` responds → liveness probe passes
