### PR TITLE
fix(headlamp): remove non-functional ServiceMonitor

### DIFF
--- a/k3s/applications/headlamp/kustomization.yaml
+++ b/k3s/applications/headlamp/kustomization.yaml
@@ -4,5 +4,4 @@ kind: Kustomization
 resources:
   - helmrepository.yaml
   - helmrelease.yaml
-  - servicemonitor.yaml
   - headlamp-oidc-secret.sops.yaml


### PR DESCRIPTION
## Summary

Removes the headlamp `ServiceMonitor` from `kustomization.yaml`.

## Problem

Headlamp is a Kubernetes web UI — it does **not** expose Prometheus metrics. The `ServiceMonitor` was scraping `/metrics` on port `4466` (`http`), which returns HTML (the web UI), causing Prometheus to record `up == 0` and triggering `TargetDown` alerts routed to PagerDuty.

**Confirmed:** No `/metrics` endpoint exists in headlamp v0.41.0. The Helm chart has no `serviceMonitor` values. No community exporter exists. The "Prometheus" feature in headlamp is a *client plugin* that queries an external Prometheus API for dashboard display — it is not a metrics producer.

## Replacement Coverage

Uptime/availability for the headlamp ingress is covered by the blackbox `Probe` added in PR #116 (`probe-headlamp.yaml` → `https://headlamp.homelab.properties`).

## Files Changed

- `k3s/applications/headlamp/kustomization.yaml` — removed `servicemonitor.yaml` from resources list
- `k3s/applications/headlamp/servicemonitor.yaml` — left in place (not deleted) in case it's needed as a reference

## Expected Outcome

- `TargetDown` alert for `job=headlamp` clears within 5–10 minutes of merge + Flux reconciliation
- PagerDuty incident auto-resolves (confirming `send_resolved: true` works end-to-end)