### PR TITLE
fix(monitoring): scope FluxReconciliationStale to Kustomizations only

### DIFF
--- a/k3s/infrastructure/configs/monitoring/prometheusrule-flux.yaml
+++ b/k3s/infrastructure/configs/monitoring/prometheusrule-flux.yaml
@@ -23,10 +23,10 @@ spec:
             description: "Flux resource has been in a failed Ready state for more than 10 minutes."
         - alert: FluxReconciliationStale
           expr: |
-            increase(gotk_reconcile_duration_seconds_count[30m]) == 0
+            increase(gotk_reconcile_duration_seconds_count{kind="Kustomization"}[30m]) == 0
           for: 5m
           labels:
             severity: warning
           annotations:
             summary: "Flux {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }} not reconciling"
-            description: "Flux resource has not reconciled in the last 30 minutes."
+            description: "Flux Kustomization has not reconciled in the last 30 minutes (expected every 5-10m)."


### PR DESCRIPTION
## Problem

`FluxReconciliationStale` was firing on every HelmRelease, HelmChart, and HelmRepository in the cluster because the expression `increase(gotk_reconcile_duration_seconds_count[30m]) == 0` **always fires true** for resources with reconcile intervals >= 30m.

Actual intervals in this cluster:
- HelmReleases: 30m–1h
- HelmRepositories: 1h–24h
- HelmCharts: derived from source interval

This produced 30+ simultaneous false-positive warnings on startup.

## Fix

Scope the alert to `kind="Kustomization"` only. Kustomizations reconcile every 5–10m, so 30 minutes with zero reconciliations is a genuine signal that something is stuck.

HelmRelease/HelmRepository error states are already covered by `FluxReconciliationFailed` (watches `gotk_reconcile_condition{type="Ready",status="False"}`).