### PR TITLE
fix(secrets): update authentik outpost token and sabnzbd API key

### DIFF
--- a/k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml
+++ b/k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml
@@ -4,7 +4,7 @@ metadata:
     name: ENC[AES256_GCM,data:Y+LkDfcYcMKhStysVrw=,iv:OB+2Pe7iOLvWSshsmv9CSgGaDifCFSOd2/EFB6S6mGA=,tag:a+T05GGwTAtCL8kuO5MDww==,type:str]
     namespace: ENC[AES256_GCM,data:YjEFvPj3jA==,iv:bYgTBD+DCGdwgmtgSRH8Xm9XzJ0yPOw6qjOSRPrXxxo=,tag:CNlwBouJ4EQj68jWr1q70g==,type:str]
 stringData:
-    api-key: ENC[AES256_GCM,data:wMSOteuO/Ay04XUqCMF2/2mjFyIhXzqrdZb37htl3v8SI4N0,iv:nZD/6DuEvKx77QqnF7EuAGm0PKl+oZfx9c3RqBc/ico=,tag:KRqS0eNcL06jSFWvWZmf8w==,type:str]
+    api-key: ENC[AES256_GCM,data:aeVQ9wapFQHHNv6f6efdgjvOOK49ZV+tzlqo75XIkwA=,iv:JeLKJ990YOf0ArNTP5u/7br76AjAzvuF+hZVJELmAaM=,tag:fDxx2i60df1Apquy1kqVJw==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
@@ -16,7 +16,7 @@ sops:
             ZzdGY2s4UWZRMGN5NWh6YWJqcGFGaDQK/lyLVbCqje5pRSncPudaPfBHikuVwbcl
             0HMdywSEVKj2xTxE+kIDt/UOx1Sd9TBdS9PEsRpmlJbK9xkLYpBipw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T23:22:29Z"
-    mac: ENC[AES256_GCM,data:P9o7r+AHMD/YUm4lf73c+6t4fDPc5L5DVROY8aLZrsvAQrBQI59/6g0YxLKsMbyQfCtJ+nfrK9ffPKtiDRBbHQ/dTzjYTsbpZKwEVbEqFZuoxsqPUfmpq0Vt13+26plXvHUXiffXKu9e6NXS8X+TbU5FDHXZv9FHggabBjJh9Jc=,iv:DIf/+Xy1JSRnpSvjqIh0d533P72xkldKeSMqHIrfVEY=,tag:/Ue7BB9XiHLyY6C5arUwAA==,type:str]
+    lastmodified: "2026-05-25T00:10:40Z"
+    mac: ENC[AES256_GCM,data:1yqYbt0vuoRScWlTAEOHwGJEgqcxVOL6pRmjD5BM7BQy3gmdhjdvirrroasOlDP+e1QfXhGgo7v3WYPkY+msCH4EVxpl3WCSoMdi9ysznej8MdnLoDyKeDzuD9NzO2KU+Gl57VleUaA7FTY4nRaX4V8Qsql5E85IM0j8TaCEhhc=,iv:R4ffpVK4xncnq8xfy0DBTd2K3LGm2i84PjtxLzZajUk=,tag:iVkcuIVm5pe0DxMNMCxN1A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
+++ b/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
@@ -9,7 +9,7 @@ stringData:
     AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:E8th26/ByQaEfvm/j5GCGILt1GMSybjEDr7rSRMuT1e96t2Sk2YdE5QmsBNOUttiSps=,iv:s4a1aVJ44OJ9Ko2+oFO/Ppbgli3L1CHi+uhWOp+zyEk=,tag:fdHJu9S0Ms5OHYQkHsHqvQ==,type:str]
     grafana-oidc-client-secret: ENC[AES256_GCM,data:HwpEV4hcJG2wZE6KiunFa+o30syJPqmrE4prtxUmD6s=,iv:bdxY/0KBtm/rN9zTebv8VLaLDR14fht4ltVADS4oySE=,tag:HcHjSySKL7wK2ilRDlTBHw==,type:str]
     headlamp-oidc-client-secret: ENC[AES256_GCM,data:6MCuM/ThhSKU0ek/cxUyPtkjiNttB8sLUnu2XsHOGTg=,iv:cjHHVYgh/C/QeU5kyLpVCS3MW8HNatmdFiomvThwf5g=,tag:hhnKxtz0ugcSY4xbhisFeg==,type:str]
-    outpost-token: ENC[AES256_GCM,data:mWIfftYQbEMBEdPt7vbpyEGCkbAq4gJDnWsvMUN8HcEUQibj2k8s8g==,iv:nTyxHOixoEMenE994Xt5kMibWmekCFKTE+VPdhEYcrM=,tag:PQxrpjQucnf/O4l0cDwkaQ==,type:str]
+    outpost-token: ENC[AES256_GCM,data:USOOP2A4BIIm9vbTnUV9Gtt09iY5NhHS8bcEjfv/xnXdqutwOI5C0p/8UUG50me1UJyDMS66yq6+d6sZ,iv:Jnyz8FOVFtKJmm5M3Kl9igR1ymREVDx9S5pO8t705Ew=,tag:dxZDoIe3DqGHeYSS/FoqTQ==,type:str]
     portainer-oidc-client-secret: ENC[AES256_GCM,data:T95yaI5XalaPSjfjl7YiHheMQiRF+/C5Lg6TjF/b3uDDebASX1aRM31chvG4o4gl8KJDJlICbveVjDD53x8Ajw==,iv:Vh15VRJadRJ8XQ9Nbb9ctQ8bl/ROn9QXPlA1wBiFtfc=,tag:DiuuDOFQLAQDNCki+ogmlA==,type:str]
     postgresql-password: ENC[AES256_GCM,data:qn8ksg4wWi2zS0AOC7p5V9H9PadSlj1aWK1JNe6qUy0=,iv:MwXj0ReZ2ZQykAszi+/FpHiQ5UQyrP0XplQ4/7oBn1k=,tag:FnqNP/BsVEBzorA8oXzyOw==,type:str]
     redis-password: ENC[AES256_GCM,data:or32QkEIk5um4f46P6Hs/FP20FiZ2LllZ+GEMqKUdH0=,iv:wGvDDAPdbd+3OSl+EJ98la2BPSlk03lFLIziFNMUKlI=,tag:09o/C4PywLwaMA+r2xW34A==,type:str]
@@ -24,7 +24,7 @@ sops:
             RzM3M1FrVUVRY0p5dkJyL2YvOURKR0EKm/EzEf+Htkcn9LAq0NeEar++03Xdeqb+
             lz8vOA/mBqtryH+Rah6zOyChzGDFkJWakkVuR+IGjxJqSNYm8/JSlQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T21:37:38Z"
-    mac: ENC[AES256_GCM,data:ILM4BxwDmmIeWsw44G/+60U63PmL3dke2FeWP5gf+OgLaM2Ht4ve9bRSgVLNJtTBlQKQmvoN8k0Rf+iToMaiawqlcQ6fJ1173EXOOGyKJ/y37/PyeUFZC/1Xb7T+6iNfGB4cLWxoJG3lgqusbL+pbysvCJb9DSIbjFAoHyVO8zM=,iv:Up/GcAcKuPo90ZO1Pt9OnmyowlOqdY3i9f45l6eHm9k=,tag:UWqQArnGIV8FPpvILRPW0A==,type:str]
+    lastmodified: "2026-05-25T00:09:01Z"
+    mac: ENC[AES256_GCM,data:XCGrNX8PbqlBNOxqXXkMy+nSFJ1s/FUuroZHqkp8gjo96zE/IgVFfYO2m+xElJBxBJeJ/iXpByE39etJPU9zkfInaJL3lxp19CagVY0ze0L4ydyCFySDjfsKwW3owKiVmzBLTufyKoSToOnJrCdxy5pPH2ibV8U070l2kWfKCrU=,iv:nYz+Lnfra3GHybMT99NjnfeGk14b7QN4UAueyKjnGNk=,tag:egr4Ac1fBmYJx1xXWiM3MA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Problem

Two integration issues found during post-deploy testing:

### 1. Alertmanager/Prometheus ingress returning HTTP 500

**Root cause**: The Authentik outpost (`authentik-outpost` deployment in `authentik` ns) was using a time-limited API token that expired on 2026-05-20. The outpost logs showed continuous `403 Forbidden (Token invalid/expired)` errors when trying to contact the Authentik server to validate forward-auth requests.

**Fix**: Updated `authentik-secret.sops.yaml` to use the non-expiring service account token for `homelab-proxy-outpost` (identifier: `ak-outpost-599ced7d-5bbd-481b-9899-d5b713bed902-api`). Applied immediately via `kubectl patch secret` + `kubectl rollout restart`.

### 2. sabnzbd exportarr returning HTTP 403 / AppDown alert

**Root cause**: `sabnzbd-apikey.sops.yaml` still had `PLACEHOLDER_REPLACE_AFTER_FIRST_BOOT` as the API key value. The actual API key was set by SABnzbd on first boot into `/config/sabnzbd.ini`.

**Fix**: Updated the SOPS secret with the real API key from the running instance. Applied immediately via `kubectl patch secret` + `kubectl rollout restart`.

### Additional fix (applied directly to PVC, not in this PR)

SABnzbd's `host_whitelist` in `/config/sabnzbd.ini` only contained the pod hostname, causing "Hostname verification failed" when accessing `https://sabnzbd.homelab.properties/`. Updated the ini directly and restarted the pod to add `sabnzbd.homelab.properties` to the whitelist.

## Verification

- Authentik outpost: "Successfully connected websocket" + "Loaded application: alertmanager.homelab.properties" in logs ✅
- SABnzbd exportarr: returning live `sabnzbd_*` metrics (no 403 errors) ✅
- SABnzbd hostname check: `host_whitelist = sabnzbd.homelab.properties,` confirmed in ini ✅