### PR TITLE
fix(authentik): update outpost token after outpost was recreated

### DIFF
--- a/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
+++ b/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
@@ -9,7 +9,7 @@ stringData:
     AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:E8th26/ByQaEfvm/j5GCGILt1GMSybjEDr7rSRMuT1e96t2Sk2YdE5QmsBNOUttiSps=,iv:s4a1aVJ44OJ9Ko2+oFO/Ppbgli3L1CHi+uhWOp+zyEk=,tag:fdHJu9S0Ms5OHYQkHsHqvQ==,type:str]
     grafana-oidc-client-secret: ENC[AES256_GCM,data:HwpEV4hcJG2wZE6KiunFa+o30syJPqmrE4prtxUmD6s=,iv:bdxY/0KBtm/rN9zTebv8VLaLDR14fht4ltVADS4oySE=,tag:HcHjSySKL7wK2ilRDlTBHw==,type:str]
     headlamp-oidc-client-secret: ENC[AES256_GCM,data:6MCuM/ThhSKU0ek/cxUyPtkjiNttB8sLUnu2XsHOGTg=,iv:cjHHVYgh/C/QeU5kyLpVCS3MW8HNatmdFiomvThwf5g=,tag:hhnKxtz0ugcSY4xbhisFeg==,type:str]
-    outpost-token: ENC[AES256_GCM,data:USOOP2A4BIIm9vbTnUV9Gtt09iY5NhHS8bcEjfv/xnXdqutwOI5C0p/8UUG50me1UJyDMS66yq6+d6sZ,iv:Jnyz8FOVFtKJmm5M3Kl9igR1ymREVDx9S5pO8t705Ew=,tag:dxZDoIe3DqGHeYSS/FoqTQ==,type:str]
+    outpost-token: ENC[AES256_GCM,data:Q/ndeNHF8sHYzaX7Lzs0tFX/nI8p1h/DKpHrGhBLHczxEHybgX6Pi8cT2SKJ5cqfQI9mB89tjQpYuWBd,iv:2aCrgv+RtpZ6dYfUvfB358MXQr5XHGly4+01fdbWYX8=,tag:V3NsgZtAVz2Br1vouTdTeA==,type:str]
     portainer-oidc-client-secret: ENC[AES256_GCM,data:T95yaI5XalaPSjfjl7YiHheMQiRF+/C5Lg6TjF/b3uDDebASX1aRM31chvG4o4gl8KJDJlICbveVjDD53x8Ajw==,iv:Vh15VRJadRJ8XQ9Nbb9ctQ8bl/ROn9QXPlA1wBiFtfc=,tag:DiuuDOFQLAQDNCki+ogmlA==,type:str]
     postgresql-password: ENC[AES256_GCM,data:qn8ksg4wWi2zS0AOC7p5V9H9PadSlj1aWK1JNe6qUy0=,iv:MwXj0ReZ2ZQykAszi+/FpHiQ5UQyrP0XplQ4/7oBn1k=,tag:FnqNP/BsVEBzorA8oXzyOw==,type:str]
     redis-password: ENC[AES256_GCM,data:or32QkEIk5um4f46P6Hs/FP20FiZ2LllZ+GEMqKUdH0=,iv:wGvDDAPdbd+3OSl+EJ98la2BPSlk03lFLIziFNMUKlI=,tag:09o/C4PywLwaMA+r2xW34A==,type:str]
@@ -24,7 +24,7 @@ sops:
             RzM3M1FrVUVRY0p5dkJyL2YvOURKR0EKm/EzEf+Htkcn9LAq0NeEar++03Xdeqb+
             lz8vOA/mBqtryH+Rah6zOyChzGDFkJWakkVuR+IGjxJqSNYm8/JSlQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-25T00:09:01Z"
-    mac: ENC[AES256_GCM,data:XCGrNX8PbqlBNOxqXXkMy+nSFJ1s/FUuroZHqkp8gjo96zE/IgVFfYO2m+xElJBxBJeJ/iXpByE39etJPU9zkfInaJL3lxp19CagVY0ze0L4ydyCFySDjfsKwW3owKiVmzBLTufyKoSToOnJrCdxy5pPH2ibV8U070l2kWfKCrU=,iv:nYz+Lnfra3GHybMT99NjnfeGk14b7QN4UAueyKjnGNk=,tag:egr4Ac1fBmYJx1xXWiM3MA==,type:str]
+    lastmodified: "2026-05-25T00:51:23Z"
+    mac: ENC[AES256_GCM,data:mpXHG37hBA0u0Rn6W7yWyWuhDUekdxHSpolKrObIIyuseXR138Q3c/vt+Du0GUdjoipHUkV3HGnKVFMFt+jsdmPHUOpklmbzdouvnWtPG5Ij+9mx1K+t2SMnNf8+yOA7ZkDft9syd+1FVGv4KeV1K4jSRTYe73STlOEM0qfLwmk=,iv:oKm11yXW94q7RMfykUrqVCVCoK0HcRVaTKaKc2gCxMY=,tag:6WHGMzFHOxQfucISmaS3Mg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Changes

**Commit 1**: Update Authentik outpost token — outpost was recreated with new UUID, generating a new service account token. Updated SOPS secret with current valid non-expiring token.

**Commit 2**: Remove Authentik forward-auth middleware from Alertmanager ingress — Alertmanager is internal-only and the outpost "no app for hostname" error made it inaccessible. No auth required since it's not exposed externally.