### PR TITLE
fix(monitoring): remove Authentik forward-auth from Alertmanager ingress

### DIFF
--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -104,7 +104,6 @@ spec:
         ingressClassName: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-prod
-          traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
         hosts:
           - alertmanager.homelab.properties
         tls:


### PR DESCRIPTION
Remove Authentik forward-auth middleware from Alertmanager ingress. Alertmanager is internal-only and not exposed externally, so auth isn't needed. The outpost "no app for hostname" error was making it completely inaccessible.