### PR TITLE
fix(monitoring): remove Authentik forward-auth from Prometheus ingress

### DIFF
--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -79,7 +79,6 @@ spec:
         ingressClassName: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-prod
-          traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
         hosts:
           - prometheus.homelab.properties
         tls:


### PR DESCRIPTION
Remove Authentik forward-auth middleware from Prometheus ingress. Internal-only, will revisit auth later.