### PR TITLE
feat(tdarr): increase tdarr-node memory request from 1Gi to 3072Mi

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 3072Mi
             limits:
               cpu: 4000m
               memory: 4Gi


### PR DESCRIPTION
## Summary

Increases the tdarr-node memory **request** from `1Gi` to `3072Mi` based on KRR analysis.

## KRR Finding

- **Workload**: `tdarr/tdarr-node`
- **Current request**: 1024Mi
- **KRR recommendation**: 3084Mi (+2060Mi)
- **Applied value**: 3072Mi (user choice, nearest clean value)
- **Limit unchanged**: 4Gi (still provides headroom)

tdarr-node is a GPU transcoding workload and was flagged as the **most urgent underprovisioned workload** in the cluster (KRR score: 25/100).

## Change

```yaml
# k3s/applications/tdarr/deployment.yaml
resources:
  requests:
    memory: 3072Mi  # was: 1Gi
  limits:
    memory: 4Gi     # unchanged
```