### PR TITLE
fix(sabnzbd): correct gluetun FIREWALL_OUTBOUND_SUBNETS to match cluster CIDRs

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: FIREWALL_INPUT_PORTS
               value: "8080,9711,9586"
             - name: FIREWALL_OUTBOUND_SUBNETS
-              value: "10.244.0.0/16,192.168.1.0/24"
+              value: "10.42.0.0/16,10.43.0.0/16,192.168.1.0/24"
             - name: DNS_KEEP_NAMESERVER
               value: "on"
             - name: DOT


### PR DESCRIPTION
## Problem

After a power cycle, SABnzbd was experiencing repeated SSL handshake timeouts connecting to Usenet servers (e.g. `news-us.usenetserver.com:563`). Logs showed:

```
Failed to connect: _ssl.c:993: The handshake operation timed out
```

## Root Cause

The `gluetun` sidecar in the SABnzbd deployment had `FIREWALL_OUTBOUND_SUBNETS` set to `10.244.0.0/16,192.168.1.0/24`.

`10.244.0.0/16` is the **kubeadm/Flannel default pod CIDR**, not this cluster's. This K3s cluster uses:
- Pod CIDR: `10.42.0.0/16`
- Service CIDR: `10.43.0.0/16`

With the wrong subnet whitelisted, gluetun's firewall blocked all cluster-internal egress from the SABnzbd pod. The underlying networking was always there post-power-cycle — this misconfiguration was pre-existing but became symptomatic when the pod restarted.

## Fix

Updated `FIREWALL_OUTBOUND_SUBNETS` to match the actual cluster CIDRs, consistent with the qBittorrent deployment:

```
Before: 10.244.0.0/16,192.168.1.0/24
After:  10.42.0.0/16,10.43.0.0/16,192.168.1.0/24
```

## Verification

- Searched entire `k3s/` tree — no other files reference `10.244.0.0`
- `qbittorrent/deployment.yaml` already uses the correct CIDRs (used as reference)
- After Flux reconciles, SABnzbd pod will restart with the corrected firewall rules and Usenet connections should succeed