### PR TITLE
fix(gluetun): change SERVER_COUNTRIES from Netherlands to United States

### DIFF
--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -92,7 +92,7 @@ spec:
             - name: WIREGUARD_ADDRESSES
               value: "10.5.0.2/32"
             - name: SERVER_COUNTRIES
-              value: "Netherlands"
+              value: "United States"
             - name: HEALTH_SERVER_ADDRESS
               value: "0.0.0.0:9999"
             - name: HTTP_CONTROL_SERVER_ADDRESS

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: WIREGUARD_ADDRESSES
               value: "10.5.0.2/32"
             - name: SERVER_COUNTRIES
-              value: "Netherlands"
+              value: "United States"
             - name: HEALTH_SERVER_ADDRESS
               value: "0.0.0.0:9999"
             - name: HTTP_CONTROL_SERVER_ADDRESS


### PR DESCRIPTION
## Problem

Both `sabnzbd` and `qbittorrent` gluetun containers were configured with `SERVER_COUNTRIES=Netherlands`. The cluster is hosted in Atlanta, GA — Netherlands servers add unnecessary round-trip latency and are geographically suboptimal.

Additionally, during today's post-power-cycle diagnosis, 2 of 3 NordVPN Netherlands servers failed gluetun's WireGuard health check at startup, causing connection churn. US servers should be closer, less congested, and more stable from this location.

## Change

- `k3s/applications/sabnzbd/deployment.yaml`: `Netherlands` → `United States`
- `k3s/applications/qbittorrent/deployment.yaml`: `Netherlands` → `United States`

## Effect

Flux will detect the change and roll out updated pods. Gluetun will reconnect to a US-based NordVPN WireGuard endpoint on next pod restart.