### PR TITLE
tune(sabnzbd): increase gluetun resources and add health/updater settings

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -78,6 +78,10 @@ spec:
               value: "off"
             - name: TZ
               value: "America/New_York"
+            - name: HEALTH_VPN_DURATION_INITIAL
+              value: "30s"
+            - name: UPDATER_PERIOD
+              value: "24h"
           volumeMounts:
             - name: gluetun-config
               mountPath: /gluetun
@@ -99,11 +103,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 100m
+              cpu: 250m
               memory: 128Mi
             limits:
-              cpu: 500m
-              memory: 256Mi
+              cpu: 2000m
+              memory: 512Mi
         - name: sabnzbd
           image: lscr.io/linuxserver/sabnzbd:5.0.3
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Tuning pass on the sabnzbd gluetun sidecar following post-power-cycle diagnosis and US server migration.

## Changes

### Resources
| | Before | After |
|---|---|---|
| CPU request | 100m | 250m |
| CPU limit | 500m | 2000m |
| Memory limit | 256Mi | 512Mi |

Actual working set is ~30MB and CPU is ~1m at idle. Under full load (32–50 parallel SSL Usenet connections), gluetun's routing and health-check logic needs headroom. 500m was a ceiling risk.

### New env vars

**`HEALTH_VPN_DURATION_INITIAL=30s`**
Gluetun's default is 6s — aggressively short. During NIC saturation (Tdarr hammering CIFS at 400–700 Mbps), WireGuard UDP health-check packets get dropped, gluetun declares the server dead after 6s, reconnects, and drops all SABnzbd download threads. 30s gives sluggish-but-functional servers a chance to respond before cycling.

**`UPDATER_PERIOD=24h`**
Without this, gluetun loads the NordVPN server list once at pod start and never refreshes it. Stale/decommissioned endpoints stay in rotation. Daily refresh keeps the list current.

## Companion changes (already merged)
- PR #125: fixed incorrect `FIREWALL_OUTBOUND_SUBNETS` (kubeadm CIDR instead of K3s CIDRs)
- PR #126: switched `SERVER_COUNTRIES` from Netherlands → United States