### PR TITLE
fix(tdarr): use unmapped local node cache

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -39,6 +39,10 @@ spec:
               value: "http://192.168.1.20:8266"
             - name: nodeName
               value: "k3s-rtx3070"
+            - name: nodeType
+              value: unmapped
+            - name: unmappedNodeCache
+              value: /cache
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: all
             - name: NVIDIA_VISIBLE_DEVICES
@@ -63,7 +67,7 @@ spec:
             - name: media
               mountPath: /media
             - name: transcode-cache
-              mountPath: /tmp
+              mountPath: /cache
             - name: config
               mountPath: /app/configs
       volumes:


### PR DESCRIPTION
## Summary
- configure the K3s Tdarr node as `nodeType=unmapped`
- set `unmappedNodeCache=/cache`
- mount the existing `transcode-cache` emptyDir at `/cache` so node scratch stays local

## Verification
- `kubectl kustomize k3s/applications/tdarr`
- `rtk kubectl apply --dry-run=server -k k3s/applications/tdarr`

## Context
This avoids using the shared `/media/tmp-tdarr` path for node scratch, which was producing Synology-side `EACCES rmdir` cleanup storms and Tdarr node heartbeat timeouts.