### PR TITLE
feat(tdarr): migrate Tdarr server into K3s

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -2,26 +2,70 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tdarr-node
+  name: tdarr
   namespace: tdarr
   labels:
-    app: tdarr-node
+    app: tdarr
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: tdarr-node
+      app: tdarr
   template:
     metadata:
       labels:
-        app: tdarr-node
+        app: tdarr
     spec:
       runtimeClassName: nvidia
       securityContext:
         fsGroup: 100
       containers:
+        - name: tdarr-server
+          image: haveagitgat/tdarr:2.75.01
+          env:
+            - name: TZ
+              value: America/New_York
+            - name: PUID
+              value: "1027"
+            - name: PGID
+              value: "100"
+            - name: inContainer
+              value: "true"
+            - name: ffmpegVersion
+              value: "7"
+            - name: serverIP
+              value: "0.0.0.0"
+            - name: serverPort
+              value: "8266"
+            - name: webUIPort
+              value: "8265"
+            - name: internalNode
+              value: "false"
+          ports:
+            - name: webui
+              containerPort: 8265
+              protocol: TCP
+            - name: server
+              containerPort: 8266
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+            - name: server-data
+              mountPath: /app/server
+            - name: config
+              mountPath: /app/configs
+            - name: media
+              mountPath: /media
+            - name: transcode-cache
+              mountPath: /temp
         - name: tdarr-node
           image: haveagitgat/tdarr_node:2.75.01
           env:
@@ -36,13 +80,11 @@ spec:
             - name: ffmpegVersion
               value: "7"
             - name: serverURL
-              value: "http://192.168.1.20:8266"
+              value: "http://localhost:8266"
             - name: nodeName
               value: "k3s-rtx3070"
             - name: nodeType
-              value: unmapped
-            - name: unmappedNodeCache
-              value: /cache
+              value: mapped
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: all
             - name: NVIDIA_VISIBLE_DEVICES
@@ -67,16 +109,19 @@ spec:
             - name: media
               mountPath: /media
             - name: transcode-cache
-              mountPath: /cache
+              mountPath: /temp
             - name: config
               mountPath: /app/configs
       volumes:
+        - name: server-data
+          persistentVolumeClaim:
+            claimName: tdarr-server-data
+        - name: config
+          persistentVolumeClaim:
+            claimName: tdarr-node-config
         - name: media
           persistentVolumeClaim:
             claimName: tdarr-media
         - name: transcode-cache
           emptyDir:
             sizeLimit: 200Gi
-        - name: config
-          persistentVolumeClaim:
-            claimName: tdarr-node-config

--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: tdarr
+        app.kubernetes.io/name: tdarr
     spec:
       runtimeClassName: nvidia
       securityContext:
@@ -57,6 +58,20 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /api/v2/status
+              port: 8265
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v2/status
+              port: 8265
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
           volumeMounts:
             - name: server-data
               mountPath: /app/server

--- a/k3s/applications/tdarr/ingress.yaml
+++ b/k3s/applications/tdarr/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tdarr
+  namespace: tdarr
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: tdarr.homelab.properties
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tdarr
+                port:
+                  number: 8265
+  tls:
+    - secretName: tdarr-tls
+      hosts:
+        - tdarr.homelab.properties

--- a/k3s/applications/tdarr/kustomization.yaml
+++ b/k3s/applications/tdarr/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - pvc.yaml
   - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  # migration-job.yaml is intentionally excluded — apply manually, not via Flux.

--- a/k3s/applications/tdarr/migration-job.yaml
+++ b/k3s/applications/tdarr/migration-job.yaml
@@ -16,7 +16,7 @@
 #   kubectl wait --for=condition=complete -n tdarr job/tdarr-data-migration --timeout=300s
 #   kubectl logs -n tdarr job/tdarr-data-migration
 #   kubectl delete -f k3s/applications/tdarr/migration-job.yaml
-#   rm /volume1/data/tdarr-backup/  # (optional cleanup on NAS)
+#   rm -r /volume1/data/tdarr-backup/  # (optional cleanup on NAS)
 #
 # The job extracts server.tar → /app/server and configs.tar → /app/configs
 # in the respective PVCs, preserving file permissions and ownership (uid=1027, gid=100).
@@ -31,9 +31,11 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      # Run as root: tarballs were created on Synology by the admin user;
+      # SMB ACLs deny uid=1027 from reading them. Root bypasses that.
       securityContext:
-        runAsUser: 1027
-        runAsGroup: 100
+        runAsUser: 0
+        runAsGroup: 0
         fsGroup: 100
       containers:
         - name: migrate

--- a/k3s/applications/tdarr/migration-job.yaml
+++ b/k3s/applications/tdarr/migration-job.yaml
@@ -1,0 +1,76 @@
+# ONE-SHOT migration job — do NOT add to kustomization.yaml (Flux must not manage it).
+# Apply manually after creating PVCs but BEFORE starting the tdarr deployment.
+#
+# === PREREQUISITES ===
+# On the Synology NAS, copy server data to the data share so it is accessible
+# via the tdarr-media PVC at /media:
+#
+#   ssh <synology-ip>
+#   mkdir -p /volume1/data/tdarr-backup
+#   cd /volume1/docker/config/tdarr
+#   tar -cpf /volume1/data/tdarr-backup/server.tar server/
+#   tar -cpf /volume1/data/tdarr-backup/configs.tar configs/
+#
+# === USAGE ===
+#   kubectl apply -f k3s/applications/tdarr/migration-job.yaml
+#   kubectl wait --for=condition=complete -n tdarr job/tdarr-data-migration --timeout=300s
+#   kubectl logs -n tdarr job/tdarr-data-migration
+#   kubectl delete -f k3s/applications/tdarr/migration-job.yaml
+#   rm /volume1/data/tdarr-backup/  # (optional cleanup on NAS)
+#
+# The job extracts server.tar → /app/server and configs.tar → /app/configs
+# in the respective PVCs, preserving file permissions and ownership (uid=1027, gid=100).
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tdarr-data-migration
+  namespace: tdarr
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
+      containers:
+        - name: migrate
+          image: alpine:3.21
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -ex
+              echo "=== Verifying source tarballs ==="
+              ls -lh /media/tdarr-backup/
+
+              echo "=== Extracting server data ==="
+              tar -xpf /media/tdarr-backup/server.tar --strip-components=1 -C /app/server
+
+              echo "=== Extracting configs ==="
+              tar -xpf /media/tdarr-backup/configs.tar --strip-components=1 -C /app/configs
+
+              echo "=== Migration complete ==="
+              echo "--- /app/server ---"
+              ls -la /app/server/
+              echo "--- /app/configs ---"
+              ls -la /app/configs/
+          volumeMounts:
+            - name: server-data
+              mountPath: /app/server
+            - name: config
+              mountPath: /app/configs
+            - name: media
+              mountPath: /media
+              readOnly: true
+      volumes:
+        - name: server-data
+          persistentVolumeClaim:
+            claimName: tdarr-server-data
+        - name: config
+          persistentVolumeClaim:
+            claimName: tdarr-node-config
+        - name: media
+          persistentVolumeClaim:
+            claimName: tdarr-media

--- a/k3s/applications/tdarr/pvc.yaml
+++ b/k3s/applications/tdarr/pvc.yaml
@@ -1,7 +1,25 @@
 ---
-# Local PVC for tdarr node config — persists node identity (nodeName, worker config)
+# Local PVC for tdarr server data — persists server DB, samples, plugins, and queues.
 # Uses K3s local-path provisioner; directory auto-created on first bind,
 # pinned to whichever node the pod schedules to (homelab testbed).
+# Populate via migration-job.yaml before starting the tdarr deployment.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tdarr-server-data
+  namespace: tdarr
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi
+---
+# Local PVC for tdarr node/server shared configs — persists node identity (nodeName, worker config)
+# and server config (Tdarr_Server_Config.json). Both tdarr-server and tdarr-node containers
+# mount this at /app/configs, matching the official docker-compose shared-configs pattern.
+# Uses K3s local-path provisioner; pinned to whichever node the pod schedules to.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/k3s/applications/tdarr/service.yaml
+++ b/k3s/applications/tdarr/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: tdarr
   namespace: tdarr
+  labels:
+    app.kubernetes.io/name: tdarr
 spec:
   type: ClusterIP
   selector:

--- a/k3s/applications/tdarr/service.yaml
+++ b/k3s/applications/tdarr/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tdarr
+  namespace: tdarr
+spec:
+  type: ClusterIP
+  selector:
+    app: tdarr
+  ports:
+    - name: webui
+      port: 8265
+      targetPort: 8265
+      protocol: TCP
+    - name: server
+      port: 8266
+      targetPort: 8266
+      protocol: TCP


### PR DESCRIPTION
## Summary

Moves the Tdarr server from Synology Docker into the K3s cluster, co-located with the Tdarr node in the same pod. This eliminates the cross-host heartbeat timeout and EACCES permission storm that caused repeated node deregistration.

## Root Cause (diagnosed in session)

- Tdarr server on Synology was flooding the event loop with 17k+ `EACCES: permission denied, rmdir '/media/tmp-tdarr/tdarr-workDir2-*'` errors (~4min window)
- This stalled the server API, causing the K3s node's heartbeat POSTs (`/api/v2/update-node-relay`) to time out after 30s
- After 3 consecutive failures Tdarr deregisters the node → reconnects → download plugins (loop)
- Confirmed idle at time of failure: NIC at ~54 kbps, Tdarr node CPU at 1m cores

## Changes

### `pvc.yaml`
- Add `tdarr-server-data` PVC (local-path, RWO, 10Gi) for `/app/server` (DB/state)
- Clarify existing `tdarr-node-config` PVC is shared `/app/configs` between both containers

### `service.yaml` (new)
- ClusterIP Service exposing WebUI (8265) and server port (8266) within the cluster

### `ingress.yaml` (new)
- Traefik ingress at `tdarr.homelab.properties` with cert-manager TLS (letsencrypt-prod)

### `deployment.yaml`
- Rename Deployment to `tdarr`, selector `app: tdarr`
- Add `tdarr-server` sidecar container (server moves from Synology into same pod)
- `tdarr-node` now uses `serverURL: http://localhost:8266` (loopback, same pod network)
- Both containers share `/temp` (emptyDir) for transcode cache and `/app/configs` for node config
- Revert `nodeType` back to `mapped` (unmapped requires Tdarr Pro)

### `kustomization.yaml`
- Add service.yaml and ingress.yaml to resources

### `migration-job.yaml` (new, excluded from kustomization)
- One-shot Job to copy Synology Tdarr data into K3s PVCs
- See job header comments for NAS prerequisite steps (tar the data first)

## Pre-migration Steps Required

Before applying this to the live cluster, follow the migration job header:

```bash
# On Synology (stop tdarr first)
docker stop tdarr
mkdir -p /volume1/data/tdarr-backup
tar -cpf /volume1/data/tdarr-backup/server.tar -C /volume1/docker/config/tdarr server/
tar -cpf /volume1/data/tdarr-backup/configs.tar -C /volume1/docker/config/tdarr configs/

# On K3s cluster
kubectl apply -f k3s/applications/tdarr/migration-job.yaml -n tdarr
kubectl wait --for=condition=complete job/tdarr-data-migration -n tdarr --timeout=120s

# Then apply the main kustomization (Flux will handle this automatically after merge)
```

## Validation

```
kubectl kustomize k3s/applications/tdarr/    ✅ clean
rtk kubectl apply --dry-run=server -k k3s/applications/tdarr/    ✅ all resources pass
```