### PR TITLE
feat(recyclarr): upgrade to UHD/2160p quality profiles

### DIFF
--- a/k3s/applications/recyclarr/configmap.yaml
+++ b/k3s/applications/recyclarr/configmap.yaml
@@ -14,23 +14,18 @@ data:
         quality_definition:
           type: series
         quality_profiles:
-          - name: WEB-1080p
+          - name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
             upgrade:
               allowed: true
-              until_quality: WEB 1080p
+              until_quality: WEB 2160p
               until_score: 10000
-            score_set: default
-        custom_formats:
-          - trash_ids:
-              - 72dae194fc92bf828f32cde7744e51a1
-            quality_profiles:
-              - name: WEB-1080p
+            min_format_score: 0
         include:
           - template: sonarr-quality-definition-series
-          - template: sonarr-v4-quality-profile-web-1080p
-          - template: sonarr-v4-custom-formats-web-1080p
+          - template: sonarr-v4-quality-profile-web-2160p
+          - template: sonarr-v4-custom-formats-web-2160p
 
     radarr:
       movies:
@@ -41,20 +36,15 @@ data:
         quality_definition:
           type: movie
         quality_profiles:
-          - name: HD Bluray + WEB
+          - name: UHD Bluray + WEB
             reset_unmatched_scores:
               enabled: true
             upgrade:
               allowed: true
-              until_quality: Bluray-1080p
+              until_quality: Bluray-2160p
               until_score: 10000
-            score_set: default
-        custom_formats:
-          - trash_ids:
-              - d1d67249d3890e49bc12e275d989a7e9
-            quality_profiles:
-              - name: HD Bluray + WEB
+            min_format_score: 0
         include:
           - template: radarr-quality-definition-movie
-          - template: radarr-quality-profile-hd-bluray-web
-          - template: radarr-custom-formats-hd-bluray-web
+          - template: radarr-quality-profile-uhd-bluray-web
+          - template: radarr-custom-formats-uhd-bluray-web


### PR DESCRIPTION
## What

Upgrades Recyclarr quality profile templates from 1080p/HD to 2160p/UHD for both Sonarr and Radarr.

## Why

Tdarr is now configured to transcode everything to HEVC (including HDR 10-bit), so the bottleneck is no longer transcoding capability — it's download quality. The pipeline supports Apple TV 4K (HDR, Plex Pass) and Chromecast with Google TV HD, making 4K HDR downloads the preferred target.

## Changes

### `k3s/applications/recyclarr/configmap.yaml`

**Sonarr:**
- Profile: `WEB-1080p` → `WEB-2160p`
- Upgrade until: `WEB 1080p` → `WEB 2160p`
- Templates: `sonarr-v4-quality-profile-web-1080p` / `sonarr-v4-custom-formats-web-1080p` → `web-2160p` variants
- 1080p WEB remains as the fallback quality tier in the profile

**Radarr:**
- Profile: `HD Bluray + WEB` → `UHD Bluray + WEB`
- Upgrade until: `Bluray-1080p` → `Bluray-2160p`
- Templates: `radarr-quality-profile-hd-bluray-web` / `radarr-custom-formats-hd-bluray-web` → `uhd-bluray-web` variants
- No remuxes (UHD Bluray + WEB excludes remux-only tier)

**Both apps:**
- Removed spurious `custom_formats` blocks that contained quality profile trash_ids (not CF trash_ids — incorrect usage)
- Replaced `score_set: default` with `min_format_score: 0` to ensure H.264 releases aren't blocked (Tdarr converts them to HEVC regardless)

## Notes

- Sonarr must have a quality profile named **"WEB-2160p"** and Radarr must have **"UHD Bluray + WEB"** already configured in the apps, or Recyclarr will create them on next run (2:30am daily CronJob).
- HDR and SDR 4K are both scored by the template CFs; SDR 4K gets a score penalty so 1080p is preferred over SDR 4K (correct for HDR TV usage).
- H.264 4K/1080p grabs are allowed (`min_format_score: 0`) and will be converted by Tdarr.