### PR TITLE
fix(recyclarr): migrate to v8 guide-backed quality profiles

### DIFF
--- a/k3s/applications/recyclarr/configmap.yaml
+++ b/k3s/applications/recyclarr/configmap.yaml
@@ -10,11 +10,11 @@ data:
         base_url: !env_var SONARR_BASE_URL
         api_key: !env_var SONARR_API_KEY
         delete_old_custom_formats: true
-        replace_existing_custom_formats: true
         quality_definition:
           type: series
         quality_profiles:
-          - name: WEB-2160p
+          - trash_id: d1498e7d189fbe6c7110ceaabb7473e6  # WEB-2160p
+            name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
             upgrade:
@@ -22,21 +22,17 @@ data:
               until_quality: WEB 2160p
               until_score: 10000
             min_format_score: 0
-        include:
-          - template: sonarr-quality-definition-series
-          - template: sonarr-v4-quality-profile-web-2160p
-          - template: sonarr-v4-custom-formats-web-2160p
 
     radarr:
       movies:
         base_url: !env_var RADARR_BASE_URL
         api_key: !env_var RADARR_API_KEY
         delete_old_custom_formats: true
-        replace_existing_custom_formats: true
         quality_definition:
           type: movie
         quality_profiles:
-          - name: UHD Bluray + WEB
+          - trash_id: 64fb5f9858489bdac2af690e27c8f42f  # UHD Bluray + WEB
+            name: UHD Bluray + WEB
             reset_unmatched_scores:
               enabled: true
             upgrade:
@@ -44,7 +40,3 @@ data:
               until_quality: Bluray-2160p
               until_score: 10000
             min_format_score: 0
-        include:
-          - template: radarr-quality-definition-movie
-          - template: radarr-quality-profile-uhd-bluray-web
-          - template: radarr-custom-formats-uhd-bluray-web

--- a/k3s/applications/recyclarr/configmap.yaml
+++ b/k3s/applications/recyclarr/configmap.yaml
@@ -14,23 +14,18 @@ data:
         quality_definition:
           type: series
         quality_profiles:
-          - name: WEB-1080p
+          - name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
             upgrade:
               allowed: true
-              until_quality: WEB 1080p
+              until_quality: WEB 2160p
               until_score: 10000
-            score_set: default
-        custom_formats:
-          - trash_ids:
-              - 72dae194fc92bf828f32cde7744e51a1
-            quality_profiles:
-              - name: WEB-1080p
+            min_format_score: 0
         include:
           - template: sonarr-quality-definition-series
-          - template: sonarr-v4-quality-profile-web-1080p
-          - template: sonarr-v4-custom-formats-web-1080p
+          - template: sonarr-v4-quality-profile-web-2160p
+          - template: sonarr-v4-custom-formats-web-2160p
 
     radarr:
       movies:
@@ -41,20 +36,15 @@ data:
         quality_definition:
           type: movie
         quality_profiles:
-          - name: HD Bluray + WEB
+          - name: UHD Bluray + WEB
             reset_unmatched_scores:
               enabled: true
             upgrade:
               allowed: true
-              until_quality: Bluray-1080p
+              until_quality: Bluray-2160p
               until_score: 10000
-            score_set: default
-        custom_formats:
-          - trash_ids:
-              - d1d67249d3890e49bc12e275d989a7e9
-            quality_profiles:
-              - name: HD Bluray + WEB
+            min_format_score: 0
         include:
           - template: radarr-quality-definition-movie
-          - template: radarr-quality-profile-hd-bluray-web
-          - template: radarr-custom-formats-hd-bluray-web
+          - template: radarr-quality-profile-uhd-bluray-web
+          - template: radarr-custom-formats-uhd-bluray-web


### PR DESCRIPTION
## Problem

Recyclarr v8 (released February 2026) removed all official include templates from the `v8` config-templates branch. Our config was using the old v7-style `include: template:` directives which no longer resolve, causing the job to fail with:

```
[ERR] Exiting due to fatal error: Instance 'movies': Unable to find include template with name 'radarr-quality-definition-movie'
```

## Fix

Replace all `include: template:` directives with the v8 guide-backed approach:
- `quality_definition: type: series/movie` (inline, no template needed)
- `quality_profiles: - trash_id: <id>` (guide-backed, replaces separate quality profile + custom formats + quality definition templates)
- Remove `replace_existing_custom_formats` (option removed in v8)

**Trash IDs used:**
- Sonarr WEB-2160p: `d1498e7d189fbe6c7110ceaabb7473e6`
- Radarr UHD Bluray + WEB: `64fb5f9858489bdac2af690e27c8f42f`

Profile `name` overrides are included to enable adoption of existing profiles in Sonarr/Radarr rather than creating duplicates.