### PR TITLE
fix(qbittorrent): configure gluetun to use NordVPN P2P servers

### DIFF
--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -93,6 +93,8 @@ spec:
               value: "10.5.0.2/32"
             - name: SERVER_COUNTRIES
               value: "United States"
+            - name: SERVER_CATEGORIES
+              value: "P2P"
             - name: HEALTH_SERVER_ADDRESS
               value: "0.0.0.0:9999"
             - name: HTTP_CONTROL_SERVER_ADDRESS


### PR DESCRIPTION
## Problem

qBittorrent has 5 torrents stuck in `metaDL`/`queuedDL` with 0 peers and 0 KB/s. All UDP trackers return "Operation not permitted" (EPERM), and HTTP trackers time out.

**Root cause**: gluetun was configured with `SERVER_COUNTRIES: "United States"` but no `SERVER_CATEGORIES`. It connected to a standard NordVPN server (185.243.57.191, Miami FL) that filters BitTorrent tracker ports — blocking outbound UDP to ports 1337, 6969, etc.

## Fix

Add `SERVER_CATEGORIES: P2P` to the gluetun container env. This forces gluetun to select a NordVPN P2P-optimized server that permits BitTorrent traffic.

## Impact

- Pod will restart and gluetun will reconnect to a P2P server
- Stuck torrents should begin resolving peers and downloading
- `connection_status: firewalled` will persist (NordVPN dropped port forwarding in 2022 — expected)
- DHT should recover once connected through a P2P server