### PR TITLE
fix(qbittorrent): switch VPN from WireGuard to OpenVPN for P2P compatibility

### DIFF
--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -83,14 +83,17 @@ spec:
             - name: VPN_SERVICE_PROVIDER
               value: "nordvpn"
             - name: VPN_TYPE
-              value: "wireguard"
-            - name: WIREGUARD_PRIVATE_KEY
+              value: "openvpn"
+            - name: OPENVPN_USER
               valueFrom:
                 secretKeyRef:
                   name: nordvpn-credentials
-                  key: wireguard-private-key
-            - name: WIREGUARD_ADDRESSES
-              value: "10.5.0.2/32"
+                  key: openvpn-username
+            - name: OPENVPN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: nordvpn-credentials
+                  key: openvpn-password
             - name: SERVER_COUNTRIES
               value: "United States"
             - name: SERVER_CATEGORIES

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -93,6 +93,8 @@ spec:
               value: "10.5.0.2/32"
             - name: SERVER_COUNTRIES
               value: "United States"
+            - name: SERVER_CATEGORIES
+              value: "P2P"
             - name: HEALTH_SERVER_ADDRESS
               value: "0.0.0.0:9999"
             - name: HTTP_CONTROL_SERVER_ADDRESS

--- a/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml
+++ b/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml
@@ -1,36 +1,38 @@
-#ENC[AES256_GCM,data:poI6IkKmIPi94tj+BzIXsL00IpskX5s6Vy5Bi74sViaJR3hzga0HQ9aW8J34cgj3Vj+KbxyZjCcIzKTTiqyLihUSExoNdmXX+JYll/5L/xDiQ3LiNrp+cVo=,iv:RjO8WPh/JCwVKXcr9WlZngi/nLwHqrRq/nlnWJ7lccc=,tag:Wm+NLikfKa1y0/+YFkFMYA==,type:comment]
-#ENC[AES256_GCM,data:vgM9gFwkIAvSJVabBlK0pGtATTO5VLpj0JnW9EAPh3SPXb4dfiKfNe30j2fQGMMFfnSrBKvRhn85Ae8iGf3frUQDak+JB6lV4BGYx4jqxd91vqQd4XQLn/a040qe,iv:OV+dClGOZyx3IfvCt/YPe3a9GLP4GpCmWYlnyBrtBi4=,tag:uHC9kD93MA2LQxvvX5jf4Q==,type:comment]
-#ENC[AES256_GCM,data:llK53QNsuVJyL27j2tnolBLhzF7iw5oofGF57nLyPE63lpkk+F3xuCavVxcFDPOIaC8jhK9RfTAaB45Y4gC7L9DvtM3bk2j5pLUAwKqIDEhAiebZN8Q9muKk,iv:o1MazTaqzj5VlSMtzpbYQLv1k4lede2SAfpub3g+GHo=,tag:FVEOOk182SV+3PtkzDUTGw==,type:comment]
-#ENC[AES256_GCM,data:sp+Gq5j8BUjFP5C6pt64oI+KoCtr9Z4//am6E+1/FTIsmvYqQkNTaSNvchPiNjVVrdzL/1S0X1EuiIZI2XTsbEjnQApEvkTeykGFOtMgftTlfUbQ6w==,iv:vh4pOgHYR7ZvR9CUsNJT/i4zcgB6Sr9Jcqlm4AL+esY=,tag:Ybk16Udcmd26Ur1ZDN/C6A==,type:comment]
+#ENC[AES256_GCM,data:QxAC1yhigQaEjwWC9b+L/QblGm+AEjR5bQ7gXcRkDVLzmDzd3zYSsJzmuAOYEP5HQOmhTdZMUW914TguCH3O30Z1GH/3/Cl45PTF9AfIXgJv3FRzQzjYzys=,iv:xPJ7/PXmiF3EWjgJRNm/XV7DENIGfxnGtgyBa0OSTao=,tag:xR7O29JrVAn4y5rKrne6/Q==,type:comment]
+#ENC[AES256_GCM,data:Tnf1jqtMhmtayFzMaW/D5dI0n2jWWjc1typW50NZ7PiFAH99Pk929ldZ7y4UhnFXtis4TrkULGIutFjZUoTz6q8jPzV8FoUaHf99pVzPI3XiH55OSEJPSPWl+tq5,iv:W5t72VFM5GFjp3/kDx+25lwQz+y+UrdMamjgNYNXb2w=,tag:2VG7BJs81hF4E28DZjHIpg==,type:comment]
+#ENC[AES256_GCM,data:0rlVt6wiDzP+7GfvTKOt1dDYbKeFRYJHC80O40uWGF/ZkQWR7Cup+9JyTxGb0FlPrvVKCJZBhR1vetGZrcj6VOCJCxVBdVnKhrjjEo5RjZ/ygCAD2sYNeq5Q,iv:o25kZa2UWPwLNq9JN6cjHAzTurmr4OBKT2/cmxBh6dI=,tag:ME4iF075yV/WOX+4GPBImA==,type:comment]
+#ENC[AES256_GCM,data:rqG0HhjmAEN3ePqpd5CLQr/BcjLDdoIw0EgQCJ2gehCmyep4i/lqm/kzb4rb6EMNV3YN+lU3aV6L9stDcjVWP2BXxk66Gnw8Y1KUaOsD9abL7zLA2A==,iv:DZ1JIMcpoe4ejBtGJPUOxngV2nUGFlOoJrukjGiy/ZE=,tag:TH2qamaB4m1Z0rN93HhgGg==,type:comment]
 #
-#ENC[AES256_GCM,data:y24MmHv2nGfW08IEBoPHzBMKOsudJvjPrmlZjrpRWtcI2nJFhejU69gBW+xI97co8PStELz1vYgSwzQZDtP2mMVUAr9AQPZaEyly5Q==,iv:eNhK2ko5UOCejkNcBgHfmwUNLs+/w6JkJo6BZy6CNiE=,tag:rV6pBSjAyWIIUizG68bIJg==,type:comment]
-#ENC[AES256_GCM,data:KUA4inii5qOBXtu5061M9A1xaOW+ycjgiZ8Z/M66lce+qgpT8SrmLn6Yp8hUmafD7Bo8yC8=,iv:euEOuZjMLJ6ZVTpdS/MPOuzLaWRwyin3GNK4vp313SU=,tag:qE+tTNkisYOzbCT6K38o1Q==,type:comment]
+#ENC[AES256_GCM,data:yo+0r1q9vNsCzNj15yTkxYucpS/sKsyDXn5KgKwropHA6WsmS2eIYKPXMVEtH297AuW0mUtYBnIld36AeRpWSp9S1yXYfoC17vT4bw==,iv:iFvqyQsbaeaaKIHOhB2EnDAJytMJ1L/H6MxXtgpdloc=,tag:61hqxUJFIO6DWnadkLZfXw==,type:comment]
+#ENC[AES256_GCM,data:SwGXsD/2pwGJjEiUrYQe3uE2CX7tZu4Hlpr95pFU/KHDg8yvp7EChNqqUhRme/3GksoMOUs=,iv:5EbsZPJEJzGdezUK7rkYeBGFdQuc+GEGzsn2ahTbIo8=,tag:QWbt5ZW7eRnpHviMh5R9Zg==,type:comment]
 #
-#ENC[AES256_GCM,data:43qrsRPbIycotrs=,iv:8DxbHdQ6JWCDpU0IRuaBgMMPlUszEw01iUHQoTtzzto=,tag:TpE18opmqfC47jRlRwv/yw==,type:comment]
-#ENC[AES256_GCM,data:Vj6MneOqoGRdJkwsxf49Kc2amkqLDceESrqH4oOI5L3UFyaVOyowapQieJ0COOOtYO1HERgrpcmEWqYcySZQw9cJTUPUejXvuw==,iv:EI1DCFJolofBsNv9z3FOsk+he2g7dEefpKa9+iXIZdc=,tag:A42add5z3Qnp5Gk7s4MC1A==,type:comment]
-#ENC[AES256_GCM,data:F8MgDfO7hViL/Klh2WY16AL2spRBhKczc8sMs7NcnfK9+bEblevQXivrvmpCVGHyjO3C8sMFZMox,iv:lzeAZDEY/aFsb+qiOyLrq4e7n6nmim1sV31Yg3l/l2E=,tag:fOTI3PTQimz6FeOUqWARww==,type:comment]
-#ENC[AES256_GCM,data:r7rAdQIVdumJSF8dEkZU1JtTiDQRkbLa/zSvFG/USrAva2Rlj9/cpk3mAg652+8KTp06czhs4H1EWKdRr+/ZJcylobE14zX1MWDGChjdqV8DiBU5xIZVnS3KFm/r6scZFGLOJFdht5C9GvI=,iv:33YF751fJIGSzDXuWLoTLR/M2feRkth/FmrWyw8COgg=,tag:XUtvbgaAzE62laaDf/w+RA==,type:comment]
-#ENC[AES256_GCM,data:WN9eQluPVh5lIKGppLBYo/8R1n0t+/i+y3H4vqErUOlYHhct5uNKzVkLeibVPQH8nXUtPiu36A==,iv:Lgl03fg7aAjIFnlm5sPkHaeulwutCOjy3icNp6QDV/U=,tag:qI+kcLZpbMK6tV7OdtzlFg==,type:comment]
-apiVersion: ENC[AES256_GCM,data:iv8=,iv:J7sFp0/c6d7gJAfzCodG7+4trqoW4df7jOBx6rvNtks=,tag:tZEjUwfhViCBtwm+F54uKg==,type:str]
-kind: ENC[AES256_GCM,data:T7N4RGu2,iv:eE8A2/fn1geRl9JvNOOi821JoPi9ayoo2av1/hq9zw8=,tag:gtq1XGagrSLJPAQFkUcP4g==,type:str]
+#ENC[AES256_GCM,data:JDxXIaihliqphE4=,iv:yOuu+IUMeztpj0GiyU9nZQEqCpunr0YaOthFkYvrZ9E=,tag:OmaKFeaoprXYPJN118bx+w==,type:comment]
+#ENC[AES256_GCM,data:T2E06y/SLB965kHB1/pbB66DYhuNs+7VhpmZwbCsNJ2uKCAstxka57OlElt5sTllIIizbjyOj31YyfemH9m6+vnoQ7NVL6JQXQ==,iv:6BEin7d3+VMRFpkj/hugHF/TWtkPN9i3GMnpQA8HsYM=,tag:b1tCE7G6YQt/4jmEYUanTA==,type:comment]
+#ENC[AES256_GCM,data:1hnTV7YMVVzlYd8y6LXX6owcFe+WwYihrrVTsIOrHDoa6cae0XnOCnH87vTY0vpRAawNMnYzXjMy,iv:HaqyaTx3KRNQvcKoXmAnBnEn2ONcNsX7QRoo+4QbC6o=,tag:G0upHqpFVHYoybBEQFJ/Xw==,type:comment]
+#ENC[AES256_GCM,data:6bUsGx/zQWXdiemMVeuNXYeC2T8teFjwpRYY1du+hemYYs/kypAoOG0vNGV6JXQDu3LfcCaVcab0GjsO/WQTiNwzW+frmlnXCj8IPAZ6j8WCEHYMR0TRCEY2mpz32uSyr1lV0iFnYT0rHPc=,iv:C/OB7cgKgGeeG1s637UBzzim08la/wk9Wd4XFAjxx10=,tag:xcsmFX8e/4nDTg5Bm/X6KQ==,type:comment]
+#ENC[AES256_GCM,data:vqQAyIMOQrvONsKqjI5BQ9iuVkd9GJ6IazA+QwHZ+zcXgNSNM++urvQR57z/7mGnODHdF0lE2A==,iv:n1Db4RK1LyPPe0AmrY0HewuwmO1C8OgPRXglBvJzNTA=,tag:O1zSWr7dXBLiRD1Hn4U8GA==,type:comment]
+apiVersion: ENC[AES256_GCM,data:LEo=,iv:Q6q89IHK7jZTBXdoyz+01d3dqTERBfYOQ6QQ2G4Gvhk=,tag:oSKft8IgyO04V528ewLPVA==,type:str]
+kind: ENC[AES256_GCM,data:+Xz370nb,iv:REBitlKUy0luqi+lxEorOaVnXwfuJc6P+hLcpfdqlbY=,tag:fMs9pqkdT0PvtmsvMujoGg==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:vzvuRVy4z+g82b6dlx4Q50KDhw==,iv:YVUWWfasXmV+rIdRKSDvqb9pz2jH3el2Ww5Z7oJEG7g=,tag:cFAHSCBGxo4Hnis1XL+Y0A==,type:str]
-    namespace: ENC[AES256_GCM,data:l3z0rD7acQSQI2Q=,iv:s9Yjr9ez/CVv5bv4EWz116jY/b3A+o++NP7Rxvdv20o=,tag:TGEy56W111xLC7G7VxtU/g==,type:str]
-type: ENC[AES256_GCM,data:iBptZAG9,iv:ifiHowVmro/61y9IH2WzAdkuFNNEtNUnWXB15zJxTiA=,tag:uLpLD6cOB3D7sPB6G9WMGw==,type:str]
+    name: ENC[AES256_GCM,data:s741itDP3+5O8ATO0jd1FZ2f8A==,iv:mQEDVS6b+zdJbZBu8EuBlDsLENQaH0krhJA1RsOYtgg=,tag:mMVqH9aTbyvctt5ctyl6Ug==,type:str]
+    namespace: ENC[AES256_GCM,data:iUydrG/O31zhONM=,iv:ZS1JDwXSSbQijtLN1yChnZrSThMt5QmQwJjnQJiagyA=,tag:4/AWaiZQvfessrBd3Qeq5Q==,type:str]
+type: ENC[AES256_GCM,data:ELgjkHpY,iv:3ldqDbjB5cdXLGwf148Lewksfif82DKQSgf13pafn9U=,tag:74SnCki6vOTxdvIJTHxgfA==,type:str]
 stringData:
-    wireguard-private-key: ENC[AES256_GCM,data:bWonf+JKDZ4yFElETjJue8GmBS4qlLLzDLtIHvy7TCQkO+7e0ot41O/LpC0=,iv:dRPNN2Lcq6y2BhsD5yvYrZ8IQ6TYafJtyEX4HddVTOg=,tag:f2XJdM8Lpvzju5/c2CZ2Fg==,type:str]
+    wireguard-private-key: ENC[AES256_GCM,data:vbd+/vEa/FYhDj8KvnovNJAZh21ZbVfwwWnbHw66A9b3ws+T7hR7AodiWQY=,iv:useKuXUU5hTU6a0nr00BLvqlyI0+IRL/Vo53tIFcmBE=,tag:of/7qcW+4XGUuPdBqajjaw==,type:str]
+    openvpn-username: ENC[AES256_GCM,data:eZcZt56WZ0UNa8WHU/Sc4sztU/WCdwU+,iv:igmzPPRWHX1rWA2UzFcFttrz0CiaI2dVR/aaUNeTieQ=,tag:vFhQVFDS+9ZuZV+CIduxyQ==,type:str]
+    openvpn-password: ENC[AES256_GCM,data:ogV82l/a3w+AZ5aVt+Q7ecR7EcOWyjwy,iv:knILmGw1/UPReD9yWeUPUGN4fioe8c2kMk+w08NhtYo=,tag:EXac9cVEirvGchnx0dOgRA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBySFJMTExSUlVsK1pubHZG
-            VmZzSDZIRWtOM1lERHBmSlplallvSnlnekRjCldudVVHRVM1S1NBT0xKQmdyY2Yz
-            aVF1L2FXMEZhQ1hvL1FuK3hER3JDM1EKLS0tIEdKU0dha01kMmUxYVRRN1ZUNHVp
-            akJHMVB1OGxUeWZzSVBPMzlid0d1SWcKO5ISp6asE5iaPePRea7+OqJyaSHyk7/B
-            QHL6P0/WkhtzAHibu3YwiFYW+vUPcOR/05Y8ZyUHEX9goTtXOBoY+Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAya2JwS1Z6RDNFNDJiQklP
+            Q3U5dGVqZHhQVWY0cXh3cnh6OGE4Q1FPQVRJCmJsbHBjdU8xVWI5Mm5TNEgxVWVu
+            Y0lyWFIwSW9qSjdWNEU3SnRlc1IrTU0KLS0tIFEvVUo2cGxlZHhVQlk0QnJNeXFZ
+            RjYrc003aXY4R2FzSUtuSWRQUk9RK0EKCiprQ35x7PMkJBvPjt7lyh9hP4fhXkrc
+            jHlAZJsVyUUXHFVwm0m8Ffr54NuJid+K/fdm5aKkgwW0MaUcqtVbNw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-24T06:02:54Z"
-    mac: ENC[AES256_GCM,data:zQ8Io/X5DoIghrHrkTp2GkU5s5Gkw98u9gRF+afe4AWmQ/181/lsTw6IMyzETq327wshN55AjUJotB1zt3/9P80oHh4vCgEVFlS8GIPXXIPmYkesRLgxgvibYf4Ri5U1xvhsIWfL9rfEyBbqMZKIt9b6nwmXpCk3Bq2yiYmpQys=,iv:9REO8UIBlWCOhtuf4k7Fbxc4gVbLqrRGrtK9QWcH4Vo=,tag:AlcNSkFAulIpWNj+H4xPYw==,type:str]
+    lastmodified: "2026-05-29T18:32:25Z"
+    mac: ENC[AES256_GCM,data:C7CvYi+DHNxd2sAby09YOlwpZn+XYcP7x4UZv72e5lhrfaSciln1vK2bQNzQCtD4zvd/XaEX8KFh/nirNMLZzXNLhoozM65lMWLvveKoXjQoXdJXukDn77f+RqkiuLhZ4W5kGfdveU78SkmRWEGZDIbAJw67+Xx2mt2eC6WIuYY=,iv:CSzYbBN4zxjuwvUTgkx2ciYBOXBxsRmAW+wn8FqBK7E=,tag:mkzkNuQ2qRGVVGTSXwpagg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml.example
+++ b/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml.example
@@ -3,12 +3,12 @@
 # Kubernetes Secrets are namespace-scoped — the nordvpn-credentials secret in the sabnzbd
 # namespace does NOT satisfy this requirement. You must create a separate secret here.
 #
-# The wireguard-private-key VALUE can be the same as the one used in sabnzbd,
-# but the secret MUST exist in namespace: qbittorrent.
+# The openvpn-username and openvpn-password are the NordVPN service credentials
+# (not the account login — use the service credentials from the NordVPN dashboard).
 #
 # To create:
 #   cp nordvpn-credentials.sops.yaml.example nordvpn-credentials.sops.yaml
-#   # Edit the file with your actual WireGuard private key
+#   # Edit the file with your actual NordVPN service credentials
 #   SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey sops --encrypt --in-place nordvpn-credentials.sops.yaml
 #   # Then uncomment the reference in kustomization.yaml
 apiVersion: v1
@@ -19,3 +19,5 @@ metadata:
 type: Opaque
 stringData:
   wireguard-private-key: "YOUR_NORDVPN_WIREGUARD_PRIVATE_KEY_HERE"
+  openvpn-username: "YOUR_NORDVPN_SERVICE_USERNAME_HERE"
+  openvpn-password: "YOUR_NORDVPN_SERVICE_PASSWORD_HERE"


### PR DESCRIPTION
## Problem

NordVPN WireGuard servers block all UDP traffic and non-web TCP ports (80/443 only) at the server-side egress firewall. This made BitTorrent completely non-functional:

- UDP trackers → `Operation not permitted` (EPERM — ICMP admin-prohibited from NordVPN server)
- TCP trackers (1337, 6969, 6881) → timeout
- DHT → 0 nodes
- All 5 torrents stuck in `metaDL`/`queuedDL` with 0 peers

Adding `SERVER_CATEGORIES: P2P` (PR #136) switched to a P2P-optimized server but the WireGuard egress firewall policy remained the same.

## Root Cause

NordVPN WireGuard infrastructure enforces TCP:80/443-only egress, even on P2P servers. This is a server-side policy, not a client configuration issue.

NordVPN OpenVPN infrastructure has a different firewall policy that allows BitTorrent traffic to flow.

## Fix

Switch gluetun from `VPN_TYPE: wireguard` to `VPN_TYPE: openvpn` with NordVPN service credentials.

**deployment.yaml:**
- `VPN_TYPE: wireguard` → `VPN_TYPE: openvpn`  
- Remove `WIREGUARD_PRIVATE_KEY` + `WIREGUARD_ADDRESSES` env vars
- Add `OPENVPN_USER` + `OPENVPN_PASSWORD` from `nordvpn-credentials` secret
- Keep `SERVER_CATEGORIES: P2P`

**nordvpn-credentials.sops.yaml:**
- Add `openvpn-username` + `openvpn-password` fields (SOPS-encrypted)
- Keep existing `wireguard-private-key` for potential future use

## Verified

Tested live on cluster before committing:
- Gluetun connected to `us6911.nordvpn.com:1194` (NordVPN P2P OpenVPN)  
- Exit IP: `185.199.103.77` ✅
- TCP:1337 to `tracker.opentrackr.org` → **OPEN** ✅ (was timing out)
- DHT nodes: **121** ✅ (was 0)
- Active downloads: **~8 MB/s** across 4 torrents ✅