### PR TITLE
fix(sabnzbd): increase memory limit to 4Gi to prevent OOMKill

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -147,7 +147,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 2000m
-              memory: 2Gi
+              memory: 4Gi
         - name: exportarr
           image: ghcr.io/onedr0p/exportarr:v2.3.0
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Problem

AlertManager was firing three related alerts all caused by the `sabnzbd` pod entering `CrashLoopBackOff`:

- `KubePodCrashLooping` — sabnzbd pod restarting repeatedly
- `TargetDown` — sabnzbd metrics endpoint unreachable
- `AppDown` — sabnzbd HTTP endpoint unreachable

Investigation confirmed the container was being **OOMKilled** (exit code 137) while unpacking a large 4K UHD NZB (`A.Good.Day.To.Die.Hard.2013.2160p.WEB-DL.DTS-HD.MA.7.1.HDR.HEVC`). On each restart, sabnzbd attempts to resume processing the same job → gets OOMKilled again → infinite loop.

## Root Cause

The sabnzbd container had a 2Gi memory limit, which is insufficient for peak memory usage during unpack operations on large 4K HDR content.

## Fix

Increase the sabnzbd container memory limit from `2Gi` → `4Gi`.

```yaml
resources:
  requests:
    cpu: 200m
    memory: 256Mi
  limits:
    cpu: 2000m
    memory: 4Gi  # was 2Gi
```

## Other Alerts Investigated

| Alert | Status | Notes |
|---|---|---|
| Watchdog | ✅ Normal | Always-firing heartbeat, routed to `null` |
| InfoInhibitor | ✅ Normal | System noise suppressor, routed to `null` |
| KubePodCrashLooping | ⚠️ Fixed by this PR | sabnzbd OOMKilled |
| TargetDown | ⚠️ Fixed by this PR | Caused by above |
| AppDown | ⚠️ Fixed by this PR | Caused by above |
