### PR TITLE
feat(monitoring): grafana gitsync PAT secret + RUNBOOK

### DIFF
--- a/k3s/applications/monitoring/RUNBOOK.md
+++ b/k3s/applications/monitoring/RUNBOOK.md
@@ -1,0 +1,108 @@
+# Monitoring Operations Runbook
+
+## Grafana Git Sync — Configuration & Recovery
+
+### Overview
+
+Grafana v13 Git Sync is configured to sync dashboards from `jander99/homelab-dashboards`
+(branch: `main`, path: `dashboards/`). It polls every 60s — no webhook is configured
+because Grafana is MetalLB-internal only (not externally reachable by GitHub).
+
+The PAT used is stored in Grafana's database and survives pod restarts. A SOPS-encrypted
+backup is kept at `k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml`
+(K8s secret `grafana-gitsync-pat` in namespace `monitoring`).
+
+---
+
+### PAT Details
+
+| Field | Value |
+|---|---|
+| Scope | `jander99/homelab-dashboards` only |
+| Permissions | Contents R/W, Pull requests R/W, Webhooks R/W, Metadata R |
+| Expiry | ~1 year from creation — check BitWarden |
+| BitWarden entry | `homelab-dashboards grafana-gitsync PAT` |
+
+---
+
+### Initial Configuration (UI — preferred)
+
+1. Open <https://grafana.homelab.properties>
+2. Navigate: **Administration → General → Provisioning → Git Sync** tab
+3. Add repository:
+   - **Provider:** GitHub
+   - **Repository URL:** `https://github.com/jander99/homelab-dashboards`
+   - **Branch:** `main`
+   - **Path:** `dashboards/`
+   - **PAT:** _(decrypt secret below and paste the token value)_
+4. Save. Grafana will begin syncing within 60 seconds.
+
+---
+
+### Recovery — Grafana DB Wiped
+
+If Grafana's database is wiped, the Git Sync configuration is lost. To recover:
+
+**Step 1 — Retrieve the PAT:**
+
+```bash
+SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey \
+  sops --decrypt k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml \
+  | grep token
+```
+
+**Step 2 — Re-configure via the UI** (see "Initial Configuration" above) using the
+decrypted token.
+
+#### Alternative: API (headless)
+
+First obtain a Grafana service account token, then:
+
+```bash
+curl -X POST "https://grafana.homelab.properties/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories" \
+  -H "Authorization: Bearer <grafana-service-account-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "apiVersion": "provisioning.grafana.app/v0alpha1",
+    "kind": "Repository",
+    "metadata": {"name": "homelab-dashboards"},
+    "spec": {
+      "title": "Homelab Dashboards",
+      "type": "github",
+      "github": {
+        "url": "https://github.com/jander99/homelab-dashboards",
+        "branch": "main",
+        "path": "dashboards/"
+      },
+      "sync": {"enabled": true, "intervalSeconds": 60, "target": "folder"},
+      "workflows": ["write", "branch"]
+    },
+    "secure": {"token": {"create": "<PAT-from-SOPS>"}}
+  }'
+```
+
+---
+
+### PAT Rotation
+
+1. Generate a new fine-grained PAT at <https://github.com/settings/tokens?type=fine-grained>
+   with the same permissions as listed in [PAT Details](#pat-details) above.
+2. Update the BitWarden entry `homelab-dashboards grafana-gitsync PAT` with the new value and expiry.
+3. Update the SOPS-encrypted secret:
+   ```bash
+   # Opens $EDITOR with decrypted YAML; saves encrypted in-place on exit
+   SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey \
+     sops k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml
+   ```
+4. Commit, push, and open a PR with the updated SOPS file.
+5. Re-configure Git Sync in the Grafana UI (or via API) using the new PAT. The old
+   configuration will stop working once the old PAT expires.
+
+---
+
+### Verifying Sync Status
+
+In the Grafana UI: **Administration → General → Provisioning → Git Sync**
+
+Check the last sync timestamp and any error banners. Dashboards in `dashboards/` of
+`jander99/homelab-dashboards` (branch `main`) should appear within 60 seconds of a commit.

--- a/k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: ENC[AES256_GCM,data:LTQ=,iv:JY+TJ4vcbEx2onezQmp7OV/fp0Muta4vSrgoG1MUiMM=,tag:BUk+xRovMtC9M5D8o9N1/A==,type:str]
+kind: ENC[AES256_GCM,data:b9TFLik3,iv:cbwR9C2G4XIFB3uPwtnrajduNcaxTyBVUYDWcJe3el4=,tag:wZUmJY8UZRyAKNImlQSURw==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:Ju0iPO03wFaDRqNdDJ+Q6Chtxg==,iv:28j1qxEU4dnKAgq8mI1CIveTjxkT+3+5Mfua0UkfHAg=,tag:M+iFo+Bjg5LmyUu2YNiaUg==,type:str]
+    namespace: ENC[AES256_GCM,data:eFKic92KfyTzaw==,iv:nofXJPTqE5bwi1PKtbGNWpayxAtZdFvHRaez9Lf5vQU=,tag:mbYZ5fAEuzomTaX3QIPuQg==,type:str]
+type: ENC[AES256_GCM,data:IaOPs9Ge,iv:20NB3n2p4uBtby/O1uFyRUtUA5js9YRc0NxFrJCwPsY=,tag:svI3eyWWKEHOvlY2NKkeyw==,type:str]
+stringData:
+    token: ENC[AES256_GCM,data:1Qc/5rrSG2xEXmbshszEpMjYWU3d7yjRocI73+uvBKJ+aKPztUzFZjf6C2yJ0rjQTsRESEUMUl+AfyqfgBd9mQx9+u7bm2Og68QyrnX+6OSpKVo+NWyO4TbJZYos,iv:rmEE/MzrPppMFkGwCS5t5VqTkPOChfbBzsoKIA1a0Dw=,tag:sN3rA5Mr1Yek2lT6bwwCbQ==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGMThITUhyM1RoM2JtS3hF
+            bU5zRWZOMFhHVzdlTUwwU0JSTFRQUFdMMFJZCmtrU0JFbVdZZk5jVkVQcEh3ZUFm
+            TDZ5VE5iWlBZUGdhT0I1SmZMc3AyTU0KLS0tIC8xQkhsTjViNFl0eHd4YnRYd0Rs
+            elY1WWx4N3RLUkExN2JmWStWUUd1YUEKgjXrYUPouiIL0RsgKRNVSoaATUBBvlm1
+            6QPxgY/s7DzkkmnhHgVDNC4tTlwt4Li1MA/ov/1ct0gi+ar9Cilo/A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-30T00:12:21Z"
+    mac: ENC[AES256_GCM,data:MbO4cChunXwtklxvRfkhxJKOarl8TBeVK0QeyjaBTE3uVryh7PTFJtMupCM+ko5ndF9SLxdzdghOVRCscXE+D5MydDafWfRC2WEVlPGbJd912joIUXNe7Q9nLh6mvO+lQTAX3Hv8lIKtarEcbfhXTjzBZRKkzSEqLfVwBG9fbac=,iv:R+LcGmQZAUSwlAW3um9OgzrUbKOr+llZxDJfmYNe7T0=,tag:vkMbDv28N67IgX0GQVYqRA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/kustomization.yaml
+++ b/k3s/infrastructure/configs/monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - grafana-secret.sops.yaml
   - alertmanager-pagerduty-secret.sops.yaml
   - grafana-oidc-secret.sops.yaml
+  - grafana-gitsync-pat.sops.yaml
   - helmrepository.yaml
   - helmrelease.yaml
   - helmrelease-blackbox.yaml


### PR DESCRIPTION
Adds SOPS-encrypted backup of the Grafana Git Sync fine-grained PAT and a recovery runbook.

## Changes

- **Secret:** `k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml`
  - K8s `Secret` named `grafana-gitsync-pat` in namespace `monitoring`
  - Scoped PAT: `jander99/homelab-dashboards` only (Contents R/W, Pull requests R/W, Webhooks R/W, Metadata R)
  - SOPS-encrypted with age key; token value is `ENC[AES256_GCM,...]`

- **Kustomization:** `k3s/infrastructure/configs/monitoring/kustomization.yaml`
  - Added `grafana-gitsync-pat.sops.yaml` to resources list (matches existing SOPS secret pattern)

- **Runbook:** `k3s/applications/monitoring/RUNBOOK.md`
  - Overview of Git Sync configuration (poll every 60s, no webhook)
  - PAT details and expiry reference (BitWarden: `homelab-dashboards grafana-gitsync PAT`)
  - UI setup steps
  - DB-wipe recovery procedure (SOPS decrypt + UI re-config or API curl)
  - PAT rotation procedure

Closes part of #144