### PR TITLE
chore(sabnzbd): increase CPU limit to 3000m for unpack throughput

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -146,7 +146,7 @@ spec:
               cpu: 200m
               memory: 256Mi
             limits:
-              cpu: 2000m
+              cpu: 3000m
               memory: 4Gi
         - name: exportarr
           image: ghcr.io/onedr0p/exportarr:v2.3.0


### PR DESCRIPTION
## Problem

SABnzbd pod was consuming ~1524m of its 2000m CPU limit while simultaneously downloading, verifying articles, and unpacking RARs. At 25 MB/s download speed, unpack was falling behind — unrar is CPU-intensive and the combined workload was saturating the limit.

Note: Memory (4Gi limit) was not the issue — pod was well within limits at ~1.5Gi total.

## Change

- Increase SABnzbd container CPU limit: `2000m` → `3000m`

This gives unrar additional headroom during heavy parallel unpacking without affecting other containers in the pod (gluetun, exportarr, gluetun-exporter retain their existing limits).

## Testing

Flux will roll this out via a Recreate deployment. No data loss risk — SABnzbd persists queue state to `/config` PVC and resumes cleanly after pod restart.