### PR TITLE
fix: add runAsUser: 65534 to wait-for-pihole init container

### DIFF
--- a/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
+++ b/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
@@ -70,6 +70,9 @@ spec:
     initContainers:
       - name: wait-for-pihole
         image: busybox:1.36
+        securityContext:
+          runAsUser: 65534
+          runAsNonRoot: true
         command:
           - sh
           - -c


### PR DESCRIPTION
## Problem

PagerDuty alerts firing:
- `KubePodNotReady` — `external-dns-k3s-58bffb979-wwj54` stuck non-ready for 15+ minutes
- `KubeDeploymentReplicasMismatch` — `external-dns-k3s` not meeting expected replicas

Root cause: the `wait-for-pihole` init container uses `busybox:1.36`, which runs as root (UID 0) by default. The external-dns chart applies `runAsNonRoot: true` at the pod security context level, causing Kubernetes to reject the init container at admission:

```
Error: container has runAsNonRoot and image will run as root
(container: wait-for-pihole)
```

The init container never starts → pod stays in `PodInitializing` → deployment never reaches desired replicas.

## Fix

Add a container-level `securityContext` to the init container overriding the pod default:

```yaml
securityContext:
  runAsUser: 65534   # nobody
  runAsNonRoot: true
```

`busybox` only needs shell + `wget` — both work fine as UID 65534 (nobody). This satisfies the `runAsNonRoot` constraint without changing the image.