### PR TITLE
fix: use nc instead of wget for Pi-hole readiness check

### DIFF
--- a/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
+++ b/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
@@ -78,7 +78,7 @@ spec:
           - -c
           - |
             echo "Waiting for Pi-hole web API at http://pihole-web.pihole.svc.cluster.local ..."
-            until wget -qO- http://pihole-web.pihole.svc.cluster.local > /dev/null 2>&1; do
+            until nc -z pihole-web.pihole.svc.cluster.local 80; do
               echo "Pi-hole not ready, retrying in 5s..."
               sleep 5
             done


### PR DESCRIPTION
## Problem

After the `runAsNonRoot` fix landed, the `wait-for-pihole` init container started successfully but loops forever — never passing the readiness check.

Pi-hole returns **HTTP 403** on the root path (`/`). `busybox wget` exits non-zero on any 4xx response, so the `until wget ...` loop never terminates even when Pi-hole is fully up.

## Fix

Replace `wget` with `nc -z` (TCP port check):

```sh
# Before
until wget -qO- http://pihole-web.pihole.svc.cluster.local > /dev/null 2>&1; do

# After
until nc -z pihole-web.pihole.svc.cluster.local 80; do
```

`nc -z` returns 0 as soon as port 80 accepts connections, regardless of HTTP response code. This is sufficient — if Pi-hole is listening, the webhook can reach it.