### PR TITLE
fix: set KRR-recommended resource requests/limits on all K3s workloads

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -54,6 +54,12 @@ spec:
           name: headlamp-oidc-secret
     clusterRoleBinding:
       clusterRoleName: cluster-admin
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
     initContainers:
       - name: headlamp-plugins
         image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.6.0

--- a/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
+++ b/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
@@ -60,6 +60,12 @@ spec:
             port: http-webhook
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
 
     # Gate startup on Pi-hole web API being reachable.
     # The webhook provider authenticates to POST /api/auth immediately on

--- a/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
+++ b/k3s/applications/pihole/helmrelease-external-dns-k3s.yaml
@@ -98,3 +98,10 @@ spec:
     registry: noop
 
     logLevel: info
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -117,6 +117,12 @@ spec:
         image:
           # ekofr/pihole-exporter: v1.2.0 required for Pi-hole v6 API
           tag: "v1.2.0"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
 
     # -- Pod DNS config: ensure pihole pod uses external DNS, not itself
     podDnsConfig:
@@ -124,6 +130,14 @@ spec:
       policy: "None"
       nameservers:
         - 8.8.8.8
+
+    # -- Resource requests/limits for the Pi-hole container
+    resources:
+      requests:
+        cpu: 25m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
 
     # -- Required for Pi-hole to listen on all interfaces in K3s CNI
     extraEnvVars:

--- a/k3s/applications/portainer/helmrelease.yaml
+++ b/k3s/applications/portainer/helmrelease.yaml
@@ -51,3 +51,10 @@ spec:
       size: "10Gi"
       storageClass: local-path
       accessMode: ReadWriteOnce
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -179,11 +179,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 500m
+              memory: 2Gi
             limits:
               cpu: 2000m
-              memory: 2Gi
+              memory: 3Gi
         - name: qbt-exporter
           image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:latest
           imagePullPolicy: IfNotPresent
@@ -210,7 +210,7 @@ spec:
             timeoutSeconds: 10
           resources:
             requests:
-              cpu: 25m
+              cpu: 100m
               memory: 32Mi
             limits:
               cpu: 100m

--- a/k3s/applications/radarr/deployment.yaml
+++ b/k3s/applications/radarr/deployment.yaml
@@ -54,8 +54,8 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 1000m
+              memory: 900Mi
             limits:
               cpu: 1000m
               memory: 1Gi

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -143,8 +143,8 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 2000m
+              memory: 2200Mi
             limits:
               cpu: 3000m
               memory: 4Gi

--- a/k3s/applications/sonarr/deployment.yaml
+++ b/k3s/applications/sonarr/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 256Mi
+              memory: 800Mi
             limits:
               cpu: 1000m
               memory: 1Gi

--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -53,11 +53,11 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: 100m
-              memory: 512Mi
+              cpu: 250m
+              memory: 1Gi
             limits:
               cpu: 1000m
-              memory: 1Gi
+              memory: 2Gi
           livenessProbe:
             httpGet:
               path: /api/v2/status
@@ -114,11 +114,11 @@ spec:
               value: "2"
           resources:
             requests:
-              cpu: 500m
-              memory: 3072Mi
-            limits:
               cpu: 4000m
               memory: 4Gi
+            limits:
+              cpu: 4000m
+              memory: 6Gi
               nvidia.com/gpu: "1"
           volumeMounts:
             - name: media

--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -83,6 +83,12 @@ spec:
         username: authentik
         database: authentik
       primary:
+        resources:
+          requests:
+            cpu: 25m
+            memory: 400Mi
+          limits:
+            memory: 512Mi
         persistence:
           size: 2Gi
           storageClass: local-path
@@ -97,6 +103,12 @@ spec:
           storageClass: local-path
 
     server:
+      resources:
+        requests:
+          cpu: 200m
+          memory: 1Gi
+        limits:
+          memory: 1500Mi
       ingress:
         enabled: true
         ingressClassName: traefik
@@ -111,6 +123,12 @@ spec:
               - auth.homelab.properties
 
     worker:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 800Mi
+        limits:
+          memory: 1Gi
       volumes:
         - name: custom-blueprints
           configMap:

--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -52,6 +52,12 @@ spec:
               name: http
             - containerPort: 9443
               name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
 ---
 apiVersion: v1
 kind: Service

--- a/k3s/infrastructure/configs/monitoring/helmrelease-blackbox.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease-blackbox.yaml
@@ -33,3 +33,9 @@ spec:
             preferred_ip_protocol: ip4
             valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
             valid_status_codes: [200, 302, 401]
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -65,6 +65,12 @@ spec:
         serviceMonitorSelectorNilUsesHelmValues: false
         scrapeConfigSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          limits:
+            memory: 2Gi
         storageSpec:
           volumeClaimTemplate:
             spec:
@@ -90,6 +96,12 @@ spec:
     alertmanager:
       alertmanagerSpec:
         configSecret: alertmanager-pagerduty-config
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
         storage:
           volumeClaimTemplate:
             spec:
@@ -112,6 +124,12 @@ spec:
 
     # Grafana: SOPS-backed secret, persistent storage
     grafana:
+      resources:
+        requests:
+          cpu: 20m
+          memory: 900Mi
+        limits:
+          memory: 1Gi
       initChownData:
         enabled: false
       envFromSecret: grafana-oidc-secret

--- a/k3s/infrastructure/controllers/cert-manager/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/cert-manager/helmrelease.yaml
@@ -28,3 +28,23 @@ spec:
       enabled: true
     prometheus:
       enabled: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+    cainjector:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+    webhook:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi

--- a/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
@@ -65,3 +65,10 @@ spec:
     registry: noop
 
     logLevel: info
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
+++ b/k3s/infrastructure/controllers/external-dns/helmrelease-docker.yaml
@@ -50,6 +50,12 @@ spec:
             port: http-webhook
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
 
     sources:
       - ingress

--- a/k3s/infrastructure/controllers/metallb/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/metallb/helmrelease.yaml
@@ -23,3 +23,18 @@ spec:
   upgrade:
     remediation:
       retries: 3
+  values:
+    controller:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+    speaker:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi


### PR DESCRIPTION
## Summary

Sets resource requests and limits on all K3s workloads based on a KRR (Kubernetes Resource Recommender) scan. KRR score was **F (25 points)** with ~55 containers missing or misconfigured resources.

## CRITICAL fixes (under-provisioned)

| Workload | Change |
|---|---|
| `sabnzbd` | cpu req 200m→2000m, mem req 256Mi→2200Mi (limits: 3000m/4Gi) |
| `tdarr-server` | cpu req 100m→250m, mem req 512Mi→1Gi, limit 1Gi→2Gi |
| `tdarr-node` | cpu req 500m→4000m, mem req 3072Mi→4Gi, limit 4Gi→6Gi |
| `radarr` | cpu req 200m→1000m, mem req 256Mi→900Mi |
| `qbittorrent` | cpu req 200m→500m, mem req 256Mi→2Gi, limit 2Gi→3Gi |
| `sonarr` | mem req 256Mi→800Mi |

## Baseline resources added (UNSET workloads)

HelmRelease `values:` blocks updated with baseline `requests: {cpu: 10m, memory: 128Mi}` / `limits: {memory: 256Mi}` (adjusted per component role):

- **headlamp**, **portainer**
- **pihole** (container: 25m/256Mi req, 512Mi limit; exporter sidecar: 10m/32Mi, 64Mi)
- **authentik** server (200m/1Gi, 1500Mi limit), worker (100m/800Mi, 1Gi limit), postgresql (25m/400Mi, 512Mi limit), outpost
- **cert-manager** controller, cainjector, webhook
- **metallb** controller, speaker
- **kube-prometheus-stack**: prometheus (100m/1Gi, 2Gi), alertmanager (10m/64Mi, 128Mi), grafana (20m/900Mi, 1Gi)
- **prometheus-blackbox-exporter**
- **external-dns-docker**, **external-dns-k3s**

## Files changed

- `k3s/applications/{sabnzbd,tdarr,radarr,qbittorrent,sonarr}/deployment.yaml` — CRITICAL fixes
- `k3s/applications/{headlamp,portainer,pihole}/helmrelease*.yaml` — baseline resources
- `k3s/infrastructure/configs/authentik/{helmrelease,outpost-deployment}.yaml`
- `k3s/infrastructure/configs/monitoring/{helmrelease,helmrelease-blackbox}.yaml`
- `k3s/infrastructure/controllers/{cert-manager,metallb,external-dns}/helmrelease*.yaml`
