### PR TITLE
fix: reduce sabnzbd cpu request 2000m→500m to allow scheduling

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 2000m
+              cpu: 500m
               memory: 2200Mi
             limits:
               cpu: 3000m


### PR DESCRIPTION
## Problem

After PR #150 landed, sabnzbd pod is stuck `Pending` with `Insufficient cpu`:

```
0/1 nodes are available: 1 Insufficient cpu. no new claims to deallocate
```

Node is at 97% CPU requested (7780m/8000m). The KRR-recommended 2000m request leaves only ~220m free — not enough to schedule sabnzbd.

## Fix

Reduce sabnzbd `requests.cpu` from `2000m` → `500m`. The `limits.cpu` stays at `3000m`, so sabnzbd can still burst to 3 cores when the node has capacity. This is a better fit for a single-node homelab where burst matters more than guaranteed allocation.