### PR TITLE
fix: reduce tdarr-node cpu request 4000m→2000m

### DIFF
--- a/k3s/applications/tdarr/deployment.yaml
+++ b/k3s/applications/tdarr/deployment.yaml
@@ -114,7 +114,7 @@ spec:
               value: "2"
           resources:
             requests:
-              cpu: 4000m
+              cpu: 2000m
               memory: 4Gi
             limits:
               cpu: 4000m


### PR DESCRIPTION
## Problem

sabnzbd is stuck `Pending` (`Insufficient cpu`) even after PR #151. Node has 7780m/8000m allocated — only 220m free. sabnzbd pod total request is 825m.

Root cause: tdarr-node reserves 4000m (4 cores) at all times.

## Fix

Drop tdarr-node `requests.cpu` from `4000m` → `2000m`. Limit stays at `4000m` so it can still burst to 4 cores when available. Frees ~2000m, giving sabnzbd room to schedule.