### PR TITLE
feat(tdarr): split server and node into separate Deployments

### DIFF
--- a/k3s/applications/tdarr/deployment-node.yaml
+++ b/k3s/applications/tdarr/deployment-node.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tdarr-node
+  namespace: tdarr
+  labels:
+    app: tdarr-node
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tdarr-node
+  template:
+    metadata:
+      labels:
+        app: tdarr-node
+        app.kubernetes.io/name: tdarr-node
+    spec:
+      runtimeClassName: nvidia
+      securityContext:
+        fsGroup: 100
+      containers:
+        - name: tdarr-node
+          image: haveagitgat/tdarr_node:2.75.01
+          env:
+            - name: TZ
+              value: America/New_York
+            - name: PUID
+              value: "1027"
+            - name: PGID
+              value: "100"
+            - name: inContainer
+              value: "true"
+            - name: ffmpegVersion
+              value: "7"
+            - name: serverURL
+              value: "http://tdarr:8266"
+            - name: nodeName
+              value: "k3s-rtx3070"
+            - name: nodeType
+              value: mapped
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: all
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: transcodecpuWorkers
+              value: "0"
+            - name: transcodegpuWorkers
+              value: "1"
+            - name: healthcheckcpuWorkers
+              value: "0"
+            - name: healthcheckgpuWorkers
+              value: "2"
+          resources:
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+            limits:
+              cpu: 4000m
+              memory: 6Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: media
+              mountPath: /media
+            - name: transcode-cache
+              mountPath: /temp
+            - name: config
+              mountPath: /app/configs
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: tdarr-node-config
+        - name: media
+          persistentVolumeClaim:
+            claimName: tdarr-media
+        - name: transcode-cache
+          emptyDir:
+            sizeLimit: 200Gi

--- a/k3s/applications/tdarr/deployment-server.yaml
+++ b/k3s/applications/tdarr/deployment-server.yaml
@@ -2,24 +2,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tdarr
+  name: tdarr-server
   namespace: tdarr
   labels:
-    app: tdarr
+    app: tdarr-server
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: tdarr
+      app: tdarr-server
   template:
     metadata:
       labels:
-        app: tdarr
-        app.kubernetes.io/name: tdarr
+        app: tdarr-server
+        app.kubernetes.io/name: tdarr-server
     spec:
-      runtimeClassName: nvidia
       securityContext:
         fsGroup: 100
       containers:
@@ -79,54 +78,6 @@ spec:
               mountPath: /app/configs
             - name: media
               mountPath: /media
-            - name: transcode-cache
-              mountPath: /temp
-        - name: tdarr-node
-          image: haveagitgat/tdarr_node:2.75.01
-          env:
-            - name: TZ
-              value: America/New_York
-            - name: PUID
-              value: "1027"
-            - name: PGID
-              value: "100"
-            - name: inContainer
-              value: "true"
-            - name: ffmpegVersion
-              value: "7"
-            - name: serverURL
-              value: "http://localhost:8266"
-            - name: nodeName
-              value: "k3s-rtx3070"
-            - name: nodeType
-              value: mapped
-            - name: NVIDIA_DRIVER_CAPABILITIES
-              value: all
-            - name: NVIDIA_VISIBLE_DEVICES
-              value: all
-            - name: transcodecpuWorkers
-              value: "0"
-            - name: transcodegpuWorkers
-              value: "1"
-            - name: healthcheckcpuWorkers
-              value: "0"
-            - name: healthcheckgpuWorkers
-              value: "2"
-          resources:
-            requests:
-              cpu: 2000m
-              memory: 4Gi
-            limits:
-              cpu: 4000m
-              memory: 6Gi
-              nvidia.com/gpu: "1"
-          volumeMounts:
-            - name: media
-              mountPath: /media
-            - name: transcode-cache
-              mountPath: /temp
-            - name: config
-              mountPath: /app/configs
       volumes:
         - name: server-data
           persistentVolumeClaim:
@@ -137,6 +88,3 @@ spec:
         - name: media
           persistentVolumeClaim:
             claimName: tdarr-media
-        - name: transcode-cache
-          emptyDir:
-            sizeLimit: 200Gi

--- a/k3s/applications/tdarr/kustomization.yaml
+++ b/k3s/applications/tdarr/kustomization.yaml
@@ -3,7 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - pvc.yaml
-  - deployment.yaml
+  - deployment-server.yaml
+  - deployment-node.yaml
   - service.yaml
   - ingress.yaml
   # migration-job.yaml is intentionally excluded — apply manually, not via Flux.

--- a/k3s/applications/tdarr/service.yaml
+++ b/k3s/applications/tdarr/service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: tdarr
+    app: tdarr-server
   ports:
     - name: webui
       port: 8265


### PR DESCRIPTION
## Problem

Tdarr server (UI/scheduler) and node (GPU transcoder) were co-located in a single pod with `runtimeClassName: nvidia`. On every node restart, the NVIDIA device plugin briefly marks GPU devices as **unhealthy** during initialization. The old pod would attempt re-admission during this window and fail with:

```
UnexpectedAdmissionError: cannot allocate unhealthy devices nvidia.com/gpu
```

This left a ghost pod in `Failed` state that required manual cleanup after every restart.

## Root Cause

The server container doesn't need GPU access — only the node does. But because they shared a pod with `runtimeClassName: nvidia`, the entire pod was subject to GPU admission validation.

## Changes

| File | Change |
|------|--------|
| `deployment-server.yaml` | New — server only, no `runtimeClassName`, no GPU resources |
| `deployment-node.yaml` | New — node only, `runtimeClassName: nvidia`, `nvidia.com/gpu: "1"` limit |
| `service.yaml` | Selector updated from `app: tdarr` → `app: tdarr-server` |
| `deployment.yaml` | Deleted |

The node connects to the server via `http://tdarr:8266` (the existing ClusterIP service), which now selects `tdarr-server` pods.

## Future

This split enables running multiple `tdarr-node` replicas against a single server — just scale the `tdarr-node` Deployment and add GPU nodes to the cluster.