### PR TITLE
feat(monitoring): deploy NVIDIA DCGM exporter for RTX 3070 GPU metrics

### DIFF
--- a/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dcgm-exporter
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: dcgm-exporter
+      version: '4.8.2'
+      sourceRef:
+        kind: HelmRepository
+        name: dcgm-exporter
+        namespace: flux-system
+  targetNamespace: kube-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  dependsOn:
+    - name: nvidia-device-plugin
+  values:
+    runtimeClassName: nvidia
+    extraEnv:
+      - name: DCGM_EXPORTER_COLLECTORS
+        value: /etc/dcgm-exporter/default-counters.csv

--- a/k3s/infrastructure/controllers/dcgm-exporter/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dcgm-exporter
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://nvidia.github.io/dcgm-exporter/helm-charts

--- a/k3s/infrastructure/controllers/dcgm-exporter/kustomization.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - nvidia-device-plugin
   - node-feature-discovery
   - csi-driver-smb
+  - dcgm-exporter
   - external-dns


### PR DESCRIPTION
Deploys the NVIDIA DCGM exporter via Flux HelmRelease to expose GPU metrics from the RTX 3070 to kube-prometheus-stack.

## Changes
- New `dcgm-exporter` HelmRepository pointing to `https://nvidia.github.io/dcgm-exporter/helm-charts`
- New `dcgm-exporter` HelmRelease (chart 4.8.2), targeting `kube-system` namespace
- Consumer GPU compatibility mode: `DCGM_EXPORTER_COLLECTORS=/etc/dcgm-exporter/default-counters.csv`
- `dependsOn: nvidia-device-plugin` to ensure correct startup ordering
- Added `dcgm-exporter` to `infrastructure/controllers/kustomization.yaml`

## Notes
- Tdarr ServiceMonitor (part of #139) was investigated and cancelled: Tdarr does not expose Prometheus-format metrics at port 8265 or 8266. Dashboard issue created at jander99/homelab-dashboards#12.

Closes #138
Closes #139