### PR TITLE
feat: add Renovate dependency automation config

### DIFF
--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -16,4 +16,5 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate renovate.json
-        run: npx --yes @renovatebot/config-validator renovate.json
+      - name: Validate renovate.json
+        run: npx --yes --package renovate -- renovate-config-validator renovate.json

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
 
+env:
+  RENOVATE_VERSION: "39.264.1"
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -16,5 +18,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate renovate.json
-      - name: Validate renovate.json
-        run: npx --yes --package renovate -- renovate-config-validator renovate.json
+        run: npx --yes --package renovate@${{ env.RENOVATE_VERSION }} -- renovate-config-validator renovate.json

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -1,0 +1,19 @@
+name: Renovate Config Validate
+
+on:
+  pull_request:
+    paths:
+      - "renovate.json"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate renovate.json
+        run: npx --yes @renovatebot/config-validator renovate.json

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -185,7 +185,7 @@ spec:
               cpu: 2000m
               memory: 3Gi
         - name: qbt-exporter
-          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:latest
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.7.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: qbt-metrics

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "America/New_York",
+  "schedule": ["before 6am on Monday"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "ignorePaths": [
+    "**/*.sops.yaml",
+    "**/gotk-components.yaml",
+    "node_modules/**",
+    ".venv*/**"
+  ],
+  "flux": {
+    "fileMatch": ["(^|/)k3s/.+\\.yaml$"]
+  },
+  "kubernetes": {
+    "fileMatch": ["(^|/)k3s/.+\\.yaml$"]
+  },
+  "packageRules": [
+    {
+      "description": "Pin nx to a specific version instead of latest",
+      "matchPackageNames": ["nx"],
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Disable updates for floating :latest tags - pin these manually",
+      "matchCurrentValue": "latest",
+      "enabled": false
+    },
+    {
+      "description": "Group Flux HelmRelease infrastructure controller updates",
+      "matchManagers": ["flux"],
+      "matchFileNames": ["k3s/infrastructure/controllers/**"],
+      "groupName": "flux-infra-controllers"
+    },
+    {
+      "description": "Group Flux HelmRelease infrastructure config updates",
+      "matchManagers": ["flux"],
+      "matchFileNames": ["k3s/infrastructure/configs/**"],
+      "groupName": "flux-infra-configs"
+    },
+    {
+      "description": "Group Flux application HelmRelease updates",
+      "matchManagers": ["flux"],
+      "matchFileNames": ["k3s/applications/**"],
+      "groupName": "flux-applications"
+    },
+    {
+      "description": "Group Kubernetes container image updates",
+      "matchManagers": ["kubernetes"],
+      "groupName": "kubernetes-images"
+    },
+    {
+      "description": "Group GitHub Actions version updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group npm/yarn dependency updates",
+      "matchManagers": ["npm"],
+      "groupName": "npm-dependencies"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,8 @@
       "rangeStrategy": "pin"
     },
     {
-      "description": "Disable updates for floating :latest tags - pin these manually",
+      "description": "Disable updates for floating :latest tags in container images - pin these manually",
+      "matchManagers": ["kubernetes", "docker-compose"],
       "matchCurrentValue": "latest",
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "ignorePaths": [
     "**/*.sops.yaml",
     "**/gotk-components.yaml",
+    "docker/**",
     "node_modules/**",
     ".venv*/**"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -58,9 +58,10 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group npm/yarn dependency updates",
+      "description": "Group npm/yarn dependency updates; require 7-day minimum age to guard against supply chain attacks",
       "matchManagers": ["npm"],
-      "groupName": "npm-dependencies"
+      "groupName": "npm-dependencies",
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #109

Sets up **Renovate** as the single dependency automation tool (chosen over Dependabot because Renovate's `flux` manager natively understands `HelmRelease` chart versions and raw Kubernetes manifest image tags).

## Strategy: Renovate only

Dependabot was considered but rejected for this repo's primary use case — it has no native support for Flux HelmRelease fields or raw Kubernetes manifests. Renovate covers all surfaces in one config.

## Dependency surfaces covered

| Surface | Manager | Files |
|---|---|---|
| Flux HelmRelease chart versions | `flux` | `k3s/**/*.yaml` |
| Kubernetes container image tags | `kubernetes` | `k3s/**/*.yaml` |
| GitHub Actions `uses:` versions | `github-actions` | `.github/workflows/**` |
| Yarn/npm packages | `npm` | `package.json` |

## Grouping & schedule

Updates are batched into 6 groups to minimize PR volume:

- `flux-infra-controllers` — HelmReleases under `k3s/infrastructure/controllers/`
- `flux-infra-configs` — HelmReleases under `k3s/infrastructure/configs/`
- `flux-applications` — HelmReleases under `k3s/applications/`
- `kubernetes-images` — container image tags in raw manifests
- `github-actions` — Action `uses:` pins
- `npm-dependencies` — Yarn/Node packages

All scheduled **before 6am Monday** (America/New_York). Max 5 PRs/hour, 10 concurrent.

## Explicit exclusions

- `**/*.sops.yaml` — SOPS-encrypted secrets, never touched
- `**/gotk-components.yaml` — Flux bootstrap artifact, managed by `flux bootstrap`
- `:latest` tags — disabled; these should be pinned manually (one instance found: `ghcr.io/esanchezm/prometheus-qbittorrent-exporter:latest` in `k3s/applications/qbittorrent/deployment.yaml`)

## nx pinning

`package.json` currently has `"nx": "latest"`. The `npm` rule includes `rangeStrategy: pin` for `nx` so Renovate will open a PR to pin it to the current resolved version.