### PR TITLE
fix(sense-exporter): correct image tag v1.0.0 -> 1.0.0

### DIFF
--- a/k3s/applications/sense-exporter/deployment.yaml
+++ b/k3s/applications/sense-exporter/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: sense-exporter
-          image: ghcr.io/ejsuncy/sense_energy_prometheus_exporter:v1.0.0
+          image: ghcr.io/ejsuncy/sense_energy_prometheus_exporter:1.0.0
           ports:
             - name: metrics
               containerPort: 9993


### PR DESCRIPTION
## Summary

Fixes `ImagePullBackOff` — the tag `v1.0.0` does not exist on `ghcr.io/ejsuncy/sense_energy_prometheus_exporter`. The correct tag is `1.0.0` (no `v` prefix).

Available tags: `0.2.0`, `0.3.0`, `0.4.0`, `0.5.0`, `0.6.0`, `0.6.1`, `0.7.0a`, `0.7.0`, `1.0.0`