### PR TITLE
ci: add workflow_dispatch to flux-validate

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -2,6 +2,7 @@ name: Flux Validate
 
 on:
   pull_request:
+  workflow_dispatch:
     paths:
       - "k3s/**"
       - "applications/cdk8s/**"

--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -2,12 +2,12 @@ name: Flux Validate
 
 on:
   pull_request:
-  workflow_dispatch:
     paths:
       - "k3s/**"
       - "applications/cdk8s/**"
       - "package.json"
       - "yarn.lock"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -95,7 +95,7 @@ jobs:
           head -c 30000 /tmp/flux-diff-output.txt >> $GITHUB_STEP_SUMMARY || echo "(no diff output)" >> $GITHUB_STEP_SUMMARY
 
       - name: Post PR comment
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `workflow_dispatch` trigger to the flux-validate workflow so it can be run manually — useful for verifying the `SOPS_AGE_KEY` secret is correctly configured without needing a code change to k3s.