### PR TITLE
fix(sops): add encrypted_regex to limit encryption to data/stringData fields

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -20,4 +20,5 @@
 
 creation_rules:
   - path_regex: k3s/.*\.sops\.yaml$
+    encrypted_regex: ^(data|stringData)$
     age: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085

--- a/k3s/applications/sense-exporter/sense-secret.sops.yaml
+++ b/k3s/applications/sense-exporter/sense-secret.sops.yaml
@@ -1,23 +1,23 @@
-apiVersion: ENC[AES256_GCM,data:V2s=,iv:6fEmHD3PGuS10ie+uJ7CQyaisFKIu0mwkLpb7E5VCRg=,tag:97/AGUfOwG/drkzDoaJ71Q==,type:str]
-kind: ENC[AES256_GCM,data:Kz0uM/uF,iv:n+mYwGbXgAXOprN3LEucQWSeMHtx8zj1ufQ/cM5lwAI=,tag:wtG8KQbTxrA+LNfUb9aowA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:vU1TTeGhzkV3s2u97SzhdVg=,iv:uCNHCl4xSc2SAFeUdDvvKMYsA554VjWRu0NO+N3gPws=,tag:6Q93DuM3k0IQcPR2cPQlqQ==,type:str]
-    namespace: ENC[AES256_GCM,data:s277C18+Zg08mDP/L0I=,iv:zjLoNeQfKCRvjXbYnlTH+WHuRLIzuSR8DUUJG+qs1tk=,tag:UsmH8+0bHXEYt4XUwuue7w==,type:str]
+    name: sense-credentials
+    namespace: sense-exporter
 stringData:
-    SENSE_ACCOUNT_USERNAME_1: ENC[AES256_GCM,data:H+yPLVGrDIHSABfwG3IUt3qc,iv:D4lICgbMGUOIQegFG8mM2VwmDZaH9InebfTodvXS5Lo=,tag:qYvuiF/nwLTbU7911mlUkw==,type:str]
-    SENSE_ACCOUNT_PASSWORD_1: ENC[AES256_GCM,data:54NXo1rPGmAILDU=,iv:Oea2VP9LB/4pPif67Qwt3F9qyTGXXUNwwcQKOs1u/ds=,tag:4kEDXLtrcY1vb+mB2iJ+Vg==,type:str]
+    SENSE_ACCOUNT_USERNAME_1: ENC[AES256_GCM,data:pY2MnfWJYHWIqsCz4QdgxNq5,iv:D959NqDMSv6eSXCU1ZVrNtuMXJwhfVykmf/hKfeeKIg=,tag:qWN799nRkyjqjaNaLWjxYQ==,type:str]
+    SENSE_ACCOUNT_PASSWORD_1: ENC[AES256_GCM,data:Dk/+eO+D6AvOJ0Y=,iv:AkFNoEh0S44P/Gfyqr4UqD6Wv2J/kcxwkF5lhXUaK3s=,tag:KpJqWp7mF/IQ5jb7SB3Kug==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhN1pUdjltUWxyY2xXdnJE
-            cVRoaG9aZUxzaWpkcklrRVZhTGNCcjZWRUdJCmZJWG92cFVGWURDQm41bVA3b2V5
-            dHpkSHZYVXBUZFNpbmlsWncxWjhqaFEKLS0tIDFGdEhJZGpsMjcySC9FZ1ZURTht
-            MDBUeUhWeUN3ckFkUzg0dXdidjh1aFUKt+Q0mdM7tZqXT/gT7gb31+SFuDgzI3MW
-            ATNC71Tt+KaoZHCx85sNRbu0gXZKfTNJlCpSQ1RbEC4EspDtXkOtAQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRWNaNTY2L0NBaUQvSHlQ
+            NkZxODUxUVJzcURDM0U3cXpTc3EvZ0dWSG1BCmF2VzlRTm9tQ2dBcXRYRzNiZWlD
+            SGtCVHJ0SzZ0ZEd2VllPWTZVVHZZbjQKLS0tIDF4cW5SOFZFMHdxUUdzcXlmdWJG
+            L1RWc3VjcmZacFloWnhkcTZDRXErd0kKrMQgc6giJLDTN3VtNMDrPvx/tlRkNjN3
+            T7bFXROVL8f/G+7+PHVjAXKWLtDg8vH37HyosXaRmgrmAC8xPH+oxA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-02T00:27:35Z"
-    mac: ENC[AES256_GCM,data:BzrtUC1dJMwWg7se9JIS2bvujVPJSVVSbZ+qqRri6lmV2eXkZJRSLRHFo9S6kUuZqqZF85vui007VBZOUXPTr2OdwpAp3FFfCRbLxOuUP4nTl6cFFu8SgXv1jrO5oSj/shMUaEoWL+JUGAk20dqV5qKt0Q5iMS6C6tR3MX9P/yA=,iv:U9Ar7RY3DglAuod/Wjr3vQx7pcKVXQIrbTzB8XDE4Bg=,tag:kUBQ2BUAnvVi8z7vzE+FYw==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T00:50:53Z"
+    mac: ENC[AES256_GCM,data:9FF54aj9iXyxHh6ReZMI2PbL2Cs+Qy53pAARAqpxbF/9mpUGEFJV+ITiXSDf91NxomnUrODm6u0CVuDkoqOSA6XF0rGRtiiULIxr34EkLqvSu44+bArvPKyBdEnXcs52JXKHwGyAnxA8W80ExG2A/SIyrzzdxvC0jTwJwX7yGMY=,iv:yw1vDF0QGaPm3BZxl6kj9wPAbyV69pWBSMfZ3NaxASA=,tag:r1LTlm0+AzfzSqXcVNTReQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/alertmanager-pagerduty-secret.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/alertmanager-pagerduty-secret.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:gjw=,iv:7phMefxhslzTN2hZjqlJPmBl2bnLm8v+42+hhr9oT3g=,tag:rUW720D7OZqgsqN9DYN0RA==,type:str]
-kind: ENC[AES256_GCM,data:1Vxo1tmr,iv:dD6lFZQseuRk1YLfqAMsabDjZEDL6DptYR0cks6VndU=,tag:e6+fBsFTe+1Y9Aa/vO8djw==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:OQSNRzWrBFAWfCYQbUSrOlNlTXGhfFCTFIlVNmA=,iv:N2Cx7R5J57tFimGkhYVFzskYhKDBav7/Va7DGL7CHNM=,tag:No8Ovb/5HQW18lgNpAkBiA==,type:str]
-    namespace: ENC[AES256_GCM,data:HxO+CIonC/F77g==,iv:ZrcQGmh2OoPiZWd1m6kmyRbYF76qJ6mp6MihCNW0Jd8=,tag:kx0NK606k2rfr1DPbSqnyQ==,type:str]
+    name: alertmanager-pagerduty-config
+    namespace: monitoring
 stringData:
-    alertmanager.yaml: ENC[AES256_GCM,data:0fSl+FwSr0J4IiSukEPmEj/ugEQ+sPVAsSw/7xYQqWd+cRdRJewSWkMUH04wXbYn+ed69LAO1wyynGFts1qo+xYFSo43o/iyDuI1UlBjvp6fcDVevkV+KLsLQuOcIIJQNPNB2jfSMm8b2ohRWfdr8B9QVjwMZ5TALeorBaNYvsgIzU2cxxpwtqqC9dzJtl3OZMdwnhMhElvAjJtvoDJGxPuhBfNMMzZAHByBez/4LDdOn0Wk4sVbWpMbxgUvZFN+J6SgC0yRgAW+m2vLkEt0XgmkY1GkoH2Yife7IhZzZ188JrNs5I6AQbholiIQSM8RaWXivI/LLOToewnhil9Sn7XeNQYbIOSUDE9NLUONe0LHraseDmiNBHPBaAlWm8X6Bi9jsKq93JQMzs6jwrdRJrk1a7PDa/b1n0Ls7wfoLizSTJQcEtImWIOUQYCKyJod++0AznihGumLudrhKdRf++VbAUtPIm2tMhhxjm7cEdbXCHO2/Cp8+cXXwqFC7f9ENhAMFnp/FKL6lCabioNs0Ki7Y394Us/L3zxTfiDBQMHsbe6xeYAKaZUYTs3IdhirXAcYcPYAcMFBlwNlRxrdwcT0atYOuZy20ZJKV41U3ZDI6T14XVDfxX66NFdb6Tgbe70w7418G5gEy0IG+DhId7z7WCL/Xh3a9qvK9aj6tgIaidqbE7e31UdcnquyAIY8RRlMT9oGdU+yMC4M8D5twvTjxjbYb1TEnhuoOLmo+kdOLeNDIQ8qCMVvzatK34bpyImLl+oTZjzO+/Q9DJ9NMMhrarrk5ncx0XUkhBohsMZxQOEE03hOuf3AIqisSzJmVXQGm5ZkzsepgeUnTVFVTQJniqGNTLP2po2Hyle1GLqXRbjmr6blmqs+Bf9Ivva2OnwqmBap377X6dLv1GxZzgz6EjQdSEXLh96lqvHdNj8Vlc09TVmw6bB1J4yUPGZs0W33XNVSkGq3JUw4IZOJMEHyZclR/zjz4s+/0uq+HH824VstPXr0E5AAWwgSA82svpO84dDo7KINdwqaIgWVXfF9,iv:lven5meiiDT+1kZMlhpN9wEZMrQJ10nDGI03aOHK5WQ=,tag:wLFQM3vVR4luoBjE/KHcaw==,type:str]
+    alertmanager.yaml: ENC[AES256_GCM,data:3OWQlD0SFbjoezDos0IuwBy9Ia9VTzSJ/oqb1/9tZRsH0q8OXse/hbARabKaOgabK7xcGzIaddU6F+ijHErnSVhLtnl5vvcIcsTpKBkw/7X1KfP9A77Dkiw5lq3Xto0fXh/P08329FzsVhkEB63wKp7UxRjbaYCWdBg4PUqiiUdp5RYpoJsu+ukmE4fi5DSyqarF+8IFGpsicRi0fr61hDTulWLaJnQXjUm0WBFNHfmd2KsIDKXPAaiDGiCIBx+fFmfu/wGGUmTp2dmwqzfZhrX7/GLOQR74WWhjvVmeHjhWSHOlkJ9FeN4k7t44y8HmHUs0tPZEHTGkmwjr1w9M9vUJ6QEz1DHAkdZ4QgTOMluk4tvkqpjAwntuwuIiZyb5PGNtlmFvgYy940WiRairjqw8A/OAJKSC3g6Fye5rzjj86Ds0GKxwE4umk9y5R6RqnW9hvhEpwZgajgRFXzF2uGKPipnDJBkiybyXsN8UbxpQ6JGoqW4MeXUzmw7fLeQSsDy7+73LAZeXEcEpRMr5RMbkmZ5ECx+ro/mLryi2ydSyG/XKN5UoPSTlX+tbryxD6i2TzY7gkSMnYeMK3BpRj6wyO9kFSLDu8wrF1u/OmNC/+le2GF5HSo4X+x6pSlBBbAk8R6uMkHmuS8zGqGCNN6g4Jntkgg6WYwmEhaVt+xDX3OLxiApEmbIk0UquGZI2vWvZc+39kZkyA16GVmtd/aH6clgFz9ZgI0lVlt/DbVEUSF+bwFEnBrKmlp32Y1zg+RmoLH7TVlWiXhr7QlKWVT4HhI31DxqSqQ0AMaYZWBqPKmTpo8erKxhR6ewIxflLC5RLgQgFx5mxQFOrNZpTU7k8jwveo5hK2ydFhMLuVqlHCdpy15TSCzt1HXNyv1M3RtMPvrj5ClWCNds6APTaOWnblmGvzd0MkOmcYqk872d+lEGbwXAdehA81BxvjK9rUbrB+/D7F9pvVVaTcJnOYl4R5Ct68PETCU/wQ8ZMlnZHowbKX8PkvKCXEUKX1oO+2TqVjG8lvD5rXybDGn0Ruu+5,iv:ubPl/m0xD2/C2gnRNfz9mLsHijnZOqlU7/cPGFBGb1k=,tag:a2Ist/U3q93S/0EuwiB6hw==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhWUN0M1cxRzFqcDdnWDBs
-            WWZVLzRnMlpsOStHQ2ZIVU1HN1gvZk56VUc4CjBUMHRBZ2JTaHJ6anh1YlhpUDlC
-            dTN2cXZORTN6ZitUengwbWxKczN3WFUKLS0tIDVyRWpLSlQ0QWFFNy9zU2hQT3Vl
-            S3dvWngyeHhwbERzSHlzUWhvNXc5VHMKFOuyywQ2MKo8PXmsKdTUUbd05VZeT86n
-            TYe/nASO6TMPcTTdM+gXqauBLglEhkjqaXVkpu+jNT6vKzUlspKCqw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuTGg0bXAxTVJaZS9HQ2pu
+            N3ovUEcxc2cxY1hzc0pFeWEzTy81NVliMkZJCkFVUHdaTUVLbXE5K3BGU1hJaUlE
+            QVFyMmkva2lCdnRSRWNQZjJJY1BKNm8KLS0tIGVKWmJPa2ZnNlEraysxYkNobHYr
+            SkRaZXdoNURPTDBpN1R1R1dzUUxPRUEKw41ko6poYPUVbS062mC56j5htl3S7rUB
+            nT4lduwjMe0dZiO69tqzAeX9mj+FekWN3VGK1sJ1MHvMXSy+yizKAQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-24T22:47:49Z"
-    mac: ENC[AES256_GCM,data:tUvAco0jK3sx7H0mbeQDiYkiFhOjiN1v1Bo8ISo0HZhxjdKwt+nFz+QWH3niSFplWhocQ9Xkb3YSz2FtlpdBlN/9NocoGw8HG37Pgb0ZYNPNnvNwXGRulDbxdsELP8IduCD1Tyig9pZ8MBovOb9g3d3vJ2QB/6d/RjojKGmbdSU=,iv:ap0G7j5qKWibgY3LHg0OYjKMeDBQlOdRMQT3yl8rTcA=,tag:5PlHLCPiWMNKGDnYpm3kng==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T00:50:53Z"
+    mac: ENC[AES256_GCM,data:b0RXqR2MJri/ybL5jhKfhDZEnKP+puDx1YMpF7Rvf7FRm0sXxEtWXCt2nq5J51lJiZ0NFYNlVLoMVvDQ7d2JyYN2NqYQq0dWWjc77MzA32wch7u0KxZ3qZwCc3Yr8rcMF4o3Oa2eX7/3NZeVFTf3LxULr/HX68wDStDxImCdrD4=,iv:bhAL6FqwFv97RTBJSdOTqaQeac+3gw5ICf4RfJMW9q8=,tag:nJO5c487+x7bNIXTw1aStw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml
@@ -1,23 +1,23 @@
-apiVersion: ENC[AES256_GCM,data:LTQ=,iv:JY+TJ4vcbEx2onezQmp7OV/fp0Muta4vSrgoG1MUiMM=,tag:BUk+xRovMtC9M5D8o9N1/A==,type:str]
-kind: ENC[AES256_GCM,data:b9TFLik3,iv:cbwR9C2G4XIFB3uPwtnrajduNcaxTyBVUYDWcJe3el4=,tag:wZUmJY8UZRyAKNImlQSURw==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:Ju0iPO03wFaDRqNdDJ+Q6Chtxg==,iv:28j1qxEU4dnKAgq8mI1CIveTjxkT+3+5Mfua0UkfHAg=,tag:M+iFo+Bjg5LmyUu2YNiaUg==,type:str]
-    namespace: ENC[AES256_GCM,data:eFKic92KfyTzaw==,iv:nofXJPTqE5bwi1PKtbGNWpayxAtZdFvHRaez9Lf5vQU=,tag:mbYZ5fAEuzomTaX3QIPuQg==,type:str]
-type: ENC[AES256_GCM,data:IaOPs9Ge,iv:20NB3n2p4uBtby/O1uFyRUtUA5js9YRc0NxFrJCwPsY=,tag:svI3eyWWKEHOvlY2NKkeyw==,type:str]
+    name: grafana-gitsync-pat
+    namespace: monitoring
+type: Opaque
 stringData:
-    token: ENC[AES256_GCM,data:1Qc/5rrSG2xEXmbshszEpMjYWU3d7yjRocI73+uvBKJ+aKPztUzFZjf6C2yJ0rjQTsRESEUMUl+AfyqfgBd9mQx9+u7bm2Og68QyrnX+6OSpKVo+NWyO4TbJZYos,iv:rmEE/MzrPppMFkGwCS5t5VqTkPOChfbBzsoKIA1a0Dw=,tag:sN3rA5Mr1Yek2lT6bwwCbQ==,type:str]
+    token: ENC[AES256_GCM,data:WOJLveXS3A4sy7iSbBxA25JNwUTZSx+fiHtp25/o95oyiwR+ZBpVdHLXlyTygl4LGfFLeju2uDR5f9MoZukvkXfPEdppT9V8RbqBktmFrmhEpofI4VX37kt+hbrg,iv:ZB+91QBTeli6PoFMkm/Rx/8yI0GppN5DaS1FM5VLgr8=,tag:G7yjy5pgmVafBb3xd0AhYw==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGMThITUhyM1RoM2JtS3hF
-            bU5zRWZOMFhHVzdlTUwwU0JSTFRQUFdMMFJZCmtrU0JFbVdZZk5jVkVQcEh3ZUFm
-            TDZ5VE5iWlBZUGdhT0I1SmZMc3AyTU0KLS0tIC8xQkhsTjViNFl0eHd4YnRYd0Rs
-            elY1WWx4N3RLUkExN2JmWStWUUd1YUEKgjXrYUPouiIL0RsgKRNVSoaATUBBvlm1
-            6QPxgY/s7DzkkmnhHgVDNC4tTlwt4Li1MA/ov/1ct0gi+ar9Cilo/A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxUVhHMGM0SHdVdm02eE5h
+            SDB0QWRjamxDMEp2NVdlK1Rtb091YU13QVVZCjd3all3TGRLWUF2Umxvc1NjZVZJ
+            UllDS2FnODNjT3d5bHhFNEY3SDRrNjgKLS0tIHljalpZbSs3YittSHorUTN6OER2
+            dHo3MjRpdXk3cjRIbnZleDdrT3RtdncKU+SbmmrJt2cc+cf0T+mZkdr0FQMlMKuE
+            1CUis1+8ukQ61ygAZHUiqGypte2zEQBnQ3fpBS1XsCU12hXcY+E7BQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-30T00:12:21Z"
-    mac: ENC[AES256_GCM,data:MbO4cChunXwtklxvRfkhxJKOarl8TBeVK0QeyjaBTE3uVryh7PTFJtMupCM+ko5ndF9SLxdzdghOVRCscXE+D5MydDafWfRC2WEVlPGbJd912joIUXNe7Q9nLh6mvO+lQTAX3Hv8lIKtarEcbfhXTjzBZRKkzSEqLfVwBG9fbac=,iv:R+LcGmQZAUSwlAW3um9OgzrUbKOr+llZxDJfmYNe7T0=,tag:vkMbDv28N67IgX0GQVYqRA==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T00:50:53Z"
+    mac: ENC[AES256_GCM,data:cxjdQrVyv7UHyDmUFzAhKUdUPXKkHLLw36cmETVVb1tura8SdmZ0Y29IrYlKftmOs/VcWbOPeZXDv8xawqasxso8zl09+2QJ9S6atxFbeWwu3nwuPxHZyRXrbgADaxJIc41u16UMdi7sypiFaVDuvzFxdxtXgF0cYr73juXBy9Y=,iv:ZwMhvdD5CYSs1McPFZzzRKbzRU48o9M16/w6YbG+U4o=,tag:7lel/vuiyM2fhkjY4osjog==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/grafana-oidc-secret.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafana-oidc-secret.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:YEU=,iv:MBNwU17q49ycuBRPNHNQXliJb2eYNkmB0APtQMew3V4=,tag:O1WSi4p0V1OCHH1OElbxUQ==,type:str]
-kind: ENC[AES256_GCM,data:XW7liDP+,iv:morEyC12sidpHGqU9YR1yCoz7OA/Z5KiKA+oZDmwl8k=,tag:rJzFsBzNqTn+fIy7dY0iWA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:fTzpFGJ4TX+YOqhFHb13pWmCSA==,iv:8F36pAMduM0Z7b1kQbUWsTSYabxEuiFd1ObkA2KTxjI=,tag:uovjsew2K55ki5a9m7OaYg==,type:str]
-    namespace: ENC[AES256_GCM,data:3nYYpcCMgOuiBQ==,iv:sI/T07gUuhhDxxNAyiBT5pqRl5DfKtSNZgeNZBGfNns=,tag:1HHqSM5aD+oyo3eVZZ1cOg==,type:str]
+    name: grafana-oidc-secret
+    namespace: monitoring
 stringData:
-    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:yi36QuVmIoPW8Qgdw1AR1r2HLmQkjud4BmTdF1oWX70=,iv:JWhUhWISQfy0wb1rNuA4SGmDgwPlohG2i+ItWRv/cDk=,tag:dVgw6thgPxfrIx4Ui84yqQ==,type:str]
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:QSM8/IVA2YCMYsP69xCr21OB769OdqJyE4EHuZF4WC8=,iv:CURj6RatT5iiEP92q2jgOnB8kIxEypyCRZoO1ISmB/Y=,tag:8l9PL+HKRkKmUEm93ICtSQ==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzeDZKK09SWFBTbjNZcWpG
-            Um5kaHk2UitWUGNZNVVYZzZFQXB0alNNc1RjCkxuV0syVEIwZ09aRTg1Wm5LaWs0
-            RWNUbnEvK25zaXVzd043SnhVYkVsd2MKLS0tIElEWWNrcmRtSjVmT0NGTTdMekht
-            Sm5CUFBRMkpCTUJHT3F3cklDWDBHaWcKhH/JmuXEbDvfBKV0J3p2uD9ETrj2BVln
-            XWhmn1WTqAHMTCSdmAaBlDuSzrEVPsSvw0jK0jXGfsj8W0jSx9FC2g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmcDJSMkExRWNFYk84c0Y3
+            T2VrS2l0N2VXeFRDQlh6ZlVhWEVhMHkzQ2prCmVCQUp2OGxJRFB6U3JTQUZ5bEdw
+            azZTbjlzaHVRbWJ4OWRLejJwcVdHUFUKLS0tIFRtRVdONC9MeUlBYWhkSVgwTkNR
+            ZWcrUjAzTkRZVkJhWFM5ZzlVdG03S0kKCiXCQRzODoh7ZsxlHqlrp+q/GUMd/xf5
+            IZ7FL7VO1/jpJoAxahWK6/vnzyLYjXEjgPlF0cDYs9O5kyZ1PMoXbg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-09T19:37:32Z"
-    mac: ENC[AES256_GCM,data:v8+JbvDI7mCcJHX/JWVFuOPu4xiZM8betVov2v9NMFrRQgu1tebmGKvuWpAYp0hbOYFdyQKv4njnljVV/jd2Vmrdk21PN8RxeipapaGDgFjAxjSTHY2bmzfQmgA6V613Lc/NdkkIG5huhn3VrNW6eu6n8drCaCQO9dUqfISIbYo=,iv:UlJm58EB9a/zA2sk8G3YpmE54TeVAZM/0KGVUhj8/8I=,tag:onKPWAF6zHXcwAF+TCoFsQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T00:50:53Z"
+    mac: ENC[AES256_GCM,data:/7J9znTXZwarSSBqC0g0BDbSOAnQ7IUL7F6COGkLMWuvmKi7PR1e/ynBc9jajf1pDiSsP+pq0UMNb67mbZj/SSzJhRy1J+TTQ8ARCeGt/VksDZClR3qW0v0A/hP6mm+vYn+EqysxG+L+uHvR7qexQwOj8xsbErfho4e9LgNghS4=,iv:+hwORlkUNduaZnPDMyPm7RErBU3ylqWf1dkOlvwtrho=,tag:KqDVZyNEsYSHXVrnpX9bKA==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml
@@ -1,23 +1,23 @@
-apiVersion: ENC[AES256_GCM,data:TZ8=,iv:AjpJa+Sm74Ay1d0/M6eeXPAmueX7ITstULRU5/gPFbs=,tag:r99tGwW/FgppgiF3joywHg==,type:str]
-kind: ENC[AES256_GCM,data:WVZ+oE3i,iv:Mh5OBHz1jbFP5J5Fxjpdj9GZERyY2ccTiVltDk6/6Wc=,tag:8aRdC5xeVNTIYLV5JgtVeQ==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:0KxSyClIOQ2OdLBc4LCvZnJNRAc=,iv:xk+HFjlmCzoowMTorOBj17JYAkrjbWQbkGjJnJG0OCk=,tag:av+4K49KEdeDCllZHgXQAQ==,type:str]
-    namespace: ENC[AES256_GCM,data:GGOvLTKheS/1zQ==,iv:r53tEr+YIVxVMhF/5Sme0suWTnFGvcFoLzEODdt3S8c=,tag:NESR2M/bAhpITSSct5c2Yw==,type:str]
+    name: grafana-admin-secret
+    namespace: monitoring
 stringData:
-    admin-user: ENC[AES256_GCM,data:viJL3LI=,iv:b+FOljBhITerHLy397/rDSPnszyzOhyoEqP1X830SnU=,tag:3MPKnJhKVCKbcq+1ffmQTA==,type:str]
-    admin-password: ENC[AES256_GCM,data:2GjopebGNqKfRNEN9G+tMsRBPxOMYpKpBUQTAWTgX0U=,iv:PeYvCKYcEzW9mWaKhNgLKP6F1vG2MIhk1FhS/opr7xY=,tag:kOYiqjOxffu0GeMTlch/qg==,type:str]
+    admin-user: ENC[AES256_GCM,data:NlCyjgk=,iv:9TgHF3v/T6SIdzkuBoa5o7PdBwMVpunHNZnsfL4bp3g=,tag:YoKpQDpV+J5X3XfRuKUgfw==,type:str]
+    admin-password: ENC[AES256_GCM,data:cDAvSvOfGIDltMTG2FhnLIGdpnHVyCIfO0SsrzbemzQ=,iv:ogx+XaI3DB4zyMoyXEWsHm6DxUpwMjdYRuR6S5/CQXw=,tag:hdIYiz9EHRMrR1RkjisrzA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VjBHZWwwWEV1bFFraGwx
-            V2R1V01rcVdFbGVTeEF3WGh5eWUycmVoWVNjCnNmQ3R0dTg2WXFwdGp4SkdDZkFO
-            RlZiK0RRR25ua3RpbFFIWDlkMitmQmcKLS0tIG9mdVVNTUw1MjhvWVVoY21lU2hD
-            SnJ5biswbCtoVzJzQ09WeE1Rb2FaZ2cKq9WHEu5RPMS08TLziOvLlTZCArCvCbOk
-            A5ZUChIkZg3J7Ig9wkN5HNMruYr5PCGIRSpvch4oYJKeWOiTRRj5tw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvMFhmRUpOdm9MYjVnM2d2
+            SzVaWkVzUERVY3ZURDdTbWJRY2NVaDNibno4CjQwTzVRUTNxL0k1YnVDdDFvc0Vo
+            M2l2TDlxWVp4Uzl6Z1JpSDA5bDQ2QUEKLS0tICtlNXpvQ0c5RTJVN0wzM0h0cmRk
+            dkIrQ2VraThVaHJ5bGk4aVdGNHUzT1UKJVRT0CirsX0NNHCpRTs/R+FwYNUdVyS9
+            SmYo6mEtUUtaVRBZcGFaL/euZT8Ko8y/yTy/fgNA1jo63Xiw2zts2g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-06T23:22:29Z"
-    mac: ENC[AES256_GCM,data:vylwu6ddjTDf2R2IKHNf2mcBReIKnV+YacfIZHXo2II8xvveBtFwfeTKWzBjPhplZCbGOpHfz0YXVzk2JHG8TIu0CN+8mrOjmMhNyDF7+uVFIU4sF7CTrVb8KrwXZR7wtXEa+k6QJ9Mawrhttax/STYI7tbRYfOilHchVprvRAM=,iv:0ZKX/obxyiw2dgL2bfzVePmkBTzZpzenlXzWcywk6fE=,tag:OigN9eP1D494pRBO4ptygQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T00:50:53Z"
+    mac: ENC[AES256_GCM,data:q6o+ghoxu21Rukxo/Hzh6lUbMsNtvTau0U3UYi9w7ZU42BeTHxeZLBbUNiM71K9183qi6tW0iKNf2TPGAWY449DuqANhjJpRC5KITtyuFmpppbS25H5KIH/bHDEJVq/McVij/DFZhvoDpizDa3UjBguCWg0ez/YsOtolGgUEiMk=,iv:lTptwrwBVWxCQXGv7AxfdYJlJqsKfhpIpv9+vlu4/4Y=,tag:XSqmwhECEZCo7fVzXmrYlQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
Closes #160

## Problem

`flux-validate` CI was failing with:
```
kustomize build failed: error unmarshaling JSON: Object 'Kind' is missing
```

SOPS was encrypting **all fields** by default (including `apiVersion`, `kind`, and `metadata`) because `.sops.yaml` had no `encrypted_regex` configured. Kustomize cannot parse files where `kind` is encrypted.

## Fix

Added `encrypted_regex: ^(data|stringData)$` to `.sops.yaml` creation rules, then re-encrypted all 5 SOPS secrets so only the actual secret values are encrypted:

- `k3s/applications/sense-exporter/sense-secret.sops.yaml`
- `k3s/infrastructure/configs/monitoring/alertmanager-pagerduty-secret.sops.yaml`
- `k3s/infrastructure/configs/monitoring/grafana-gitsync-pat.sops.yaml`
- `k3s/infrastructure/configs/monitoring/grafana-oidc-secret.sops.yaml`
- `k3s/infrastructure/configs/monitoring/grafana-secret.sops.yaml`

`apiVersion`, `kind`, and `metadata` are now plaintext in all secrets, allowing kustomize to build successfully.

## Acceptance Criteria
- [x] `.sops.yaml` uses `encrypted_regex: ^(data|stringData)$`
- [x] All `*.sops.yaml` files re-encrypted; `apiVersion`, `kind`, `metadata` fields are plaintext
- [ ] `kustomize build k3s/infrastructure/configs/monitoring` succeeds locally
- [ ] `flux-local test --path k3s/clusters/homelab` passes without `--skip-invalid-kustomization-paths`
- [x] Secret data (`data:` / `stringData:` values) remains encrypted
- [ ] CI `flux-validate` workflow passes with full kustomization validation