### PR TITLE
ci: restore --skip-secrets guardrail in flux-validate

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: flux-local test
         id: flux_test
         run: |
-          flux-local test --path k3s/clusters/homelab --skip-secrets --skip-invalid-kustomization-paths 2>&1 | tee /tmp/flux-test-output.txt
+          flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths 2>&1 | tee /tmp/flux-test-output.txt
           exit_code=${PIPESTATUS[0]}
           # Exit 4 = no tests collected (acceptable; no pytest fixtures in cluster dir)
           if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 4 ]; then exit "$exit_code"; fi
@@ -76,7 +76,7 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          flux-local diff ks --path k3s/clusters/homelab --skip-secrets --skip-invalid-kustomization-paths 2>&1 | tee /tmp/flux-diff-output.txt
+          flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths 2>&1 | tee /tmp/flux-diff-output.txt
 
       - name: kubeconformist (placeholder)
         # actionlint:ignore[if-cond]


### PR DESCRIPTION
## Summary

Removes `--skip-secrets` from `flux-local test` and `flux-local diff` commands, restoring secret validation in CI.

## Why it was disabled

The `--skip-secrets` flag was added as a workaround when SOPS-encrypted secrets had all fields encrypted (including `apiVersion`/`kind`), causing `kustomize build` to fail with `Object 'Kind' is missing`.

## Why it's safe to re-enable

PR #166 fixed the root cause by adding `encrypted_regex: ^(data|stringData)$` to `.sops.yaml` and re-encrypting all 5 secrets. Structural fields are now plaintext, so flux-local can parse them correctly.

## Changes

- `.github/workflows/flux-validate.yaml`: removed `--skip-secrets` from `flux-local test` and `flux-local diff` steps

Closes #160 (follow-up)