### PR TITLE
fix(sops): re-encrypt remaining 15 secrets with encrypted_regex

### DIFF
--- a/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
+++ b/k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml
@@ -1,25 +1,25 @@
-apiVersion: ENC[AES256_GCM,data:VPs=,iv:hOINFxUPSHcVggYbYIW8Mgqm5EeACgt6shHCVFc55B4=,tag:iZwzvWFug2VHvkmz6EsjzA==,type:str]
-kind: ENC[AES256_GCM,data:J6AmzNj+,iv:kJufyKWN7V7FuqTZlNl/dLbrh77QogAmP7b3ql80Zzw=,tag:SSVZDeOVMfY+Web+7mK0RQ==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:zpuHAWENdlpzTsY5cgqanEHVuPM=,iv:iRQvv/V/9B/u0rFlF4+kZKRFUtz47NkvfYmSvsCXNcs=,tag:CItsm3q7Ejf6g7UHuDRLEg==,type:str]
-    namespace: ENC[AES256_GCM,data:K4Iojxcufng=,iv:zEMhPprZpnnIiASTWfMB8Z3zk2+tZq45Rxjo8uuUDmg=,tag:VFglIs6LHGCOQze5cuKVXw==,type:str]
+    name: headlamp-oidc-secret
+    namespace: headlamp
 stringData:
-    OIDC_CLIENT_ID: ENC[AES256_GCM,data:KzI+9gMQxWw=,iv:ddmMw6cYFAP3I1Vt9WV6yWbC1yT9cq4tLg+gfftqWOs=,tag:JGytTm5xFIocB8MvRL6YvA==,type:str]
-    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:pj4YXARSIUcqnlreY4oWtMp7TnxszlPNmPfDiLtt5xg=,iv:Vb/TsaIjWoKBnzel+Dh+IiChyu5+cerk9m9li6GpMlU=,tag:52dLUh+o/AkCaLr0/sNoqA==,type:str]
-    OIDC_ISSUER_URL: ENC[AES256_GCM,data:sVi7YbRKLMNd3z0Mz3hBLgWxD4efsar6QELg0bXhGeE/Si7tSfr4dxr9KetCvKMpuHs02iRYkw==,iv:WxLGP4epf5OIdNGVWNBXruSk+0qj2w5WgxgY/gf3sj4=,tag:VHireAGpUsXvykceEU7bqw==,type:str]
-    OIDC_SCOPES: ENC[AES256_GCM,data:ikzw22wXsepDdmRhyouX9Cb2XRIhUQYVHa9cE4c+pVUsCjg=,iv:iTeuLa+R3QHDLVoxY+1GwzKJ0iDvuLdzo8t2Hx5oFPY=,tag:O9DCU72UocuRxX1uNlMTlA==,type:str]
+    OIDC_CLIENT_ID: ENC[AES256_GCM,data:S5Lkkt8ufEA=,iv:fvgtSj5SwjTngr07EGiPLoezOdYT5b7DP/FZuQB/72w=,tag:nYvWoq5CWESUceOoCqAZww==,type:str]
+    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:inzBRWOmm1Rc+dRYDwb8mZ3xUGdigs9WrzdeupRsuHo=,iv:/DovsuU0YdgZ+yUa2pRs4za2yAteFBaioTHua0s7Rbg=,tag:sb3Rw76Le+nO6Py431vpAw==,type:str]
+    OIDC_ISSUER_URL: ENC[AES256_GCM,data:8qO5V6Kujt/LeI078fJFxNqvQ1Lsd0laGVw3OR5cqw1sEMqEUsGSyhnPHByajbYe+prPnSYiwA==,iv:2rJiiI+mkFbKIGRmWLP38QSRQ6Ra3RUXtrxD+DA3ftQ=,tag:2DVRUoK+4OMKCwm51Clctg==,type:str]
+    OIDC_SCOPES: ENC[AES256_GCM,data:AQhgmiMGVbjq8ELXHyEM41wMTW+FsctkXYHMV8Emjo7cbA8=,iv:k0MoR3nvLw3X5FoT/MYPFVP8u0pX69DsLLgWo2SmoJI=,tag:GIcjI3s0njJLzAIYNiQV3Q==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxQ1hUTDZhdWQ2NzhpVTlM
-            dllqd0w0ZFdvcXU0T0tnbVNlRlBmYzQ0SEYwCk1uRmRKTitnYWxwa3BwZGV0aFpa
-            WjVRZTI4OVhDT2d3NlMyYkxwVG5NVG8KLS0tICtIeWhlRmFCM0c0NjBIYnVSZWla
-            TS9JOWx1VFhJWHptZHNjdVdqd1AyQncK8MSuitmQCPbqm+27a8Tc9vB5z9x4H09Z
-            A2WBWbistIQk7FwwucyNow9mLnPXhQQMMztnhXefu2z5Tkj7ACxFIA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIY2dabGQvOVVuT3VkV29E
+            a3BtdFl3YmVWckltUmw4emtaSDBHMGxMZTJjCi9yVzk4Vm1CN2FSc2VJVDN1Y3pN
+            UjRranZqRkhkZnYxSnE5MVQ5RlRoeEUKLS0tIE5mQ2lMSldEQnR4cjRJdHJoSlkr
+            eEw1c1Zha0s3T3JNRUhXNXlIRXlWKzgKnfM0seFu/wCQhq7ykesLiWB1jIUaX8AN
+            rQPV9ZqiJMNJqt6mULzHMhjGHr2pCYuh7htUiBDQgivjn5VHwmktwg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-10T21:44:14Z"
-    mac: ENC[AES256_GCM,data:Teb8ZxBbJsNysgXTC6LWKcMUGIG0odocPhkAA2czVLqHGdPeiqDhGKUIFDSRs0v0G3FlsT3wVjTZ7GlTOmewP6mDckjRBJm5XGKll8gu4TrgzbA6NsIOAgf/TWagAP/VXVGmvAUtxjx1kVcd3wKR5mX9F9rjyyIavvMEbR2G2jA=,iv:Xf1+uXF5R5Pe2rRDdVVsuNHk5K7PJMygVOdCQ6uXTHI=,tag:llod2hm9z4116hxd3Bg2Uw==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:6WwuNa7glvrbN0PmhvgfLtD0NO//38xRvWpp1JrvbFw0kisbNjl8BAxtpTo6hIcrY8w00Mr0mVWZU/vuHghlC+XoPrbFPPu5wz73mO+xHVrKNoSpDGnQdixykdryVnK3e6nh1b6aupT0phTJ3Lpo0rORhLCzQrDr9d1OmMFI+W8=,iv:DbEklEsNfrhpCrE84mC6P20tzHW6aQFQq//9nOfjDJI=,tag:7V/+kLf65Cp8wL0fCT050w==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/pihole/pihole-admin-password.sops.yaml
+++ b/k3s/applications/pihole/pihole-admin-password.sops.yaml
@@ -3,7 +3,7 @@
 # =============================================================================
 # Steps to prepare this secret before committing:
 #
-#   1. Replace CHANGE_ME_BEFORE_ENCRYPTING with your desired admin password
+#   1. Decrypt this file, edit stringData.password with your desired admin password, then re-encrypt
 #      (plaintext is fine — Pi-hole v6 hashes it internally on startup)
 #
 #   2. Encrypt this file:

--- a/k3s/applications/pihole/pihole-admin-password.sops.yaml
+++ b/k3s/applications/pihole/pihole-admin-password.sops.yaml
@@ -1,41 +1,41 @@
-#ENC[AES256_GCM,data:XrBw25jloF+FifODSw2q88ncVv3wZ6RfPkxOOGsEWIyagLj7Uj5TtzbTBCXD8BSTT1te2LTaNRkbGZjOFXWiA5gZIMEkqpp5dS/Rkb3e,iv:dF0hNdZ+cnpi4SBBb8puZTKLVnjPbKtPWgeIO8vAA6U=,tag:3yCkV0b4rlYLEgQduTl1Bg==,type:comment]
-#ENC[AES256_GCM,data:QfblzB/CQKg3JgB3wJW4RyMcVvabdMM/6676akGsN7S3gdjPZOsDzJVAKvKpQ3GPcQMp3zTDyy6WhSWXd9uRB+o=,iv:c/Gohowdd6MkVopjMdcTbfmsI1/WpdAfcMk52eESBSA=,tag:+1/eTkwpItQy3p5a6TGgww==,type:comment]
-#ENC[AES256_GCM,data:EIFoqqa8z2JQasy3Ws+Lq7+Py+NFahAUkBv9l4eqZGH1gJNk9j2BtGvp8Xh3LtkqukyLe4drgTFWfFQ+60Y5sXh1LlgCFg6OMuSd2wEN,iv:VtYb3euXaeHF2QTKS9tTUf9nScCv4dmO9teH+WUq3ZU=,tag:hSNbX322s87gzcznIqkyhw==,type:comment]
-#ENC[AES256_GCM,data:n0Kz6h4z48xHUjMZaS/8Jb6pmRDWilXrnAFiJ+Ml7oA/fyUJs+jXyjFEASxp1LBk,iv:/d0dxlydu2C689E/sq1HfI4rwwwaeEbclOiBNPNSAy4=,tag:PVqBoq2bR5IF+CPSPzqrgw==,type:comment]
+# =============================================================================
+# OPERATOR ACTION REQUIRED — DO NOT COMMIT THIS FILE UNENCRYPTED
+# =============================================================================
+# Steps to prepare this secret before committing:
 #
-#ENC[AES256_GCM,data:KvYnFlJ2C5nPGfgimu1AH78HG58r+RZMAIYYK7qCnow0vy/rUR6gs5wJ2k7ufMA0fexX4nWRefKqVIvf2NXMDRq7LNSXQF4gxPE=,iv:OJAHozZr3X49rH2zCRFbsPX6Pao1af6qoMR3Ryie08M=,tag:4cc27dkLd9errQElFyXB7Q==,type:comment]
-#ENC[AES256_GCM,data:KN+Y02xnT+Giwplo50SaNUCWi2p6faYZnVAOF7udncDWRtggZW6MXTpfXb9Vxb9jO8/3yXyHra968mBqoGhRrb3Id8RVGVzJ,iv:yDNN9Vpr36mj+dPpegbaTMJ3KLNB8kWKxZsWlQct9c8=,tag:lxotuHflvHFHmV/M87LpBQ==,type:comment]
+#   1. Replace CHANGE_ME_BEFORE_ENCRYPTING with your desired admin password
+#      (plaintext is fine — Pi-hole v6 hashes it internally on startup)
 #
-#ENC[AES256_GCM,data:6LvhG5ljtZ0d1pAnw7ucp/fQUg6NbZN9,iv:SflZOoMIevhRJys77WTqN9nXVvQfbjprv+3I+q8hTBE=,tag:4LWBs1dm9GuHYvK7Ap4xvw==,type:comment]
-#ENC[AES256_GCM,data:uSMLGKu8K6d7+FiV0cWMrD+3AQySxhM+db6HEZEEmqkXnWjzhMBJ6w0+IcLxWCfXorOctdDQQztKQcnn9kOH87U15QzzzKsdzGBxaMvOe9LSGTjOSH7k,iv:HKgMcEUVu/0eQqVcyU6vpjWGVveEdNKIJyNH4uMCSsY=,tag:DZOFzk1nnTCNjdvWUSl1BQ==,type:comment]
+#   2. Encrypt this file:
+#      sops --encrypt --in-place k3s/applications/pihole/pihole-admin-password.sops.yaml
 #
-#ENC[AES256_GCM,data:Cq30+fV7jppJ3XiRv1F0E8vuPChOeGZPst2vIAfgK12bbqC94T7nURkOjAvWxWcXfFEIAFMYxTS8bACxkHdjRb3ZrqNRUIFAFQ==,iv:3P+RZbeTSc78LpynZxEYKv/+B+ZuoKROSIMAlfE+fd4=,tag:NXSoxfqe6Fk88l4ChWpXqg==,type:comment]
-#ENC[AES256_GCM,data:wZ1krKBGGLX1Aj8zpfJeAA6P6g4cdPsFm8JRajjlR6V45woFtnZGg6cE3PaMPNjzhBH0dkw5GUoSQQ==,iv:XmkZPQwRwKHTxN35hbJWoY8IXXUgeesbN4BaNZG4G2k=,tag:PoHMaxbx1dmac/81QI9k8w==,type:comment]
+#   3. Verify the file now contains a `sops:` metadata block at the bottom
+#      and the password value is ciphertext (not plaintext)
 #
-#ENC[AES256_GCM,data:jShHyMEoMqrnfdWAC8VYQ2J08apOPQeOgUWrocpEHHQfwBc6c6TfTg4=,iv:z8dZ3zqKlTCHdOxTMdFSOhVnY/OZLblsflTwNok1XPk=,tag:JSe6EwGYq4mXnTfqrD+T4w==,type:comment]
+#   4. ONLY THEN commit and push this file
 #
-#ENC[AES256_GCM,data:N/SCQQvnWBBcCb2ITQdRxFwzppNqd3SyvO8/iWosDYC8jNpVknonJnm411tSX/qDUGPtAnX5jiKEmpq4AdPy5Acyn4qSbvZ3xnJiElHtvMArxcmzvt/fzwjGOmIj,iv:+Wo30A0iYst5BDHuIKAfrpG/uKBcORHNgctc1h6+aWw=,tag:RwzrIfjh+C0dQkLWH+NpNQ==,type:comment]
-#ENC[AES256_GCM,data:9MOPB0Y5xhmqfKvxgzcXIMxa55XP6PLIdUnAxZtJwMz15f8HdEjDNATdePUK,iv:h27sj90IFccv+/C7kdlDd6i1gyxxufGD5jeRBPKVHe4=,tag:+ExluljrkR6sXu4BqgsGvQ==,type:comment]
-#ENC[AES256_GCM,data:G1Pq7o8k0elCA7+TCyp3m7NQ8x8pbKB7GboBapoQaLMk9bD85UCKKTE29MPyPr0p7MUelFLX6w7v9JLEVVNKIc5PlhlvuY8dkSNHCQB4,iv:3N36lY6ligayBuIux4CeMOYDZ5u7ObdA246JPwKem40=,tag:+iHpXNFNVQ2yMYEIACLlcQ==,type:comment]
-apiVersion: ENC[AES256_GCM,data:EHQ=,iv:szvyFa6gi6d7f1DisEI4BLOkLtIzLpHQBrkxhA21X5U=,tag:zdqks7urfoqecptqalYD2g==,type:str]
-kind: ENC[AES256_GCM,data:JxEMbf5f,iv:f55J9rVbcfTRW5iaDLKva85izV75cNrfPhgyMf/U83I=,tag:UlakXrpqfT6wrMTKjMuzjA==,type:str]
+# The SOPS age key fingerprint: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+# SOPS path_regex matches: k3s/.*\.sops\.yaml$
+# =============================================================================
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:d9qV+8XdExESTN60UC7J0HKTBV/g,iv:51Oc0PNNWp7Alu5bincwjUZ/w3jBaF57tYplWeVjxic=,tag:V66YDlHFFTxJdQGAnjZGMg==,type:str]
-    namespace: ENC[AES256_GCM,data:WOJMrWpU,iv:3X3by4WCLE5owzRjfWofLvHxSIPlowVPRgzB5j0GbJA=,tag:wP7BVdOkWF4meHLfBWnYtw==,type:str]
+    name: pihole-admin-password
+    namespace: pihole
 stringData:
-    password: ENC[AES256_GCM,data:4+KULxUG9Hj1sF8nSw==,iv:B50j6Z/2qatCrgXeB/9/fArPvdGCDnJf4fsWLh3LGLs=,tag:p2dWrrF62fbaXpoKq6xlgg==,type:str]
+    password: ENC[AES256_GCM,data:sJaECQlliAfNn1L0sw==,iv:4ntt17IKx3d1PqfuNNHyDpMn3hLCmxr9PGoDESiMel4=,tag:lmsqAaSyWsgM4Ms1M2XefA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXa0JvSEFzanJjcDFLcEtI
-            dHhIakxwYVdZdktYRHlXNkhOSzB3OTJCZ1RvCmc3cGd6WmRiY3dhcThuT1FBdkRJ
-            dG9JOWlUK0F4OWpXb2NKTStNaG9UQjgKLS0tIE54dFQyK0NjVXo2UW5iVnJjZzlH
-            TzZ5M3BNNG5mb2w5cHhKNVdlRHJ4bEkKk6Zno0P0bLVRtz0SFjcdBmEtMZU0/QS3
-            4ZYx0pz4zeO4Nl9+IWT/ipWsHONB/E1v/55yYeuZ5fv1yNRk5vYG9Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHeEZWMUNzYlJCdThFdm5w
+            dldmWGJWNk9ZeTNzSXVyWW9nYjBPS2tFM0RNCnNaNm5SalRtSkZmNGZ2VEpycWFL
+            OHR1eEg1Y0hGQTl5RmpscXlCelZQeGcKLS0tIGxZUHNVdTV3aGdPd3BBZ2NKS0ho
+            RG1vQlZlZjYrZU9aNXE4SkRsNE50eEkK8Ogfzg+ihdezqh6FHuImWg9Ch6B0vYsr
+            m9+M8xtbKXh+52wMqLeAOyf6OGrIkihM2b6EffstZWrAP+7nSiA/aA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-06T12:04:18Z"
-    mac: ENC[AES256_GCM,data:TeQWM8n4pqt1ziy157cg0wdvKbo/xmalQ8nMf5GAaSc8NenS0eM1MHGpmWwntR6WrQc5Dwd0VCNATIKNp+hwCR+8ASNJa2FEsjtn033WLOO7zOKQS/MZCQSmTkWQSdRWfB91o5aDiNbWHeI9zaXzJC9MXzuobR2ZKKakothFkaI=,iv:3CXiqeWNQCcdbV0AHqWzmgkHPeAjFlrtRuY4XrmHerg=,tag:9sGRR6NiUZuu6cLSZ0nlkg==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:yDkssqIcKXeTMpSU65miOac0mZfYDhj7prOzG6B2i2UxtkH3csm2BA6f55gEQQPEqlaEP6xjhJrqQ0oxgeV+GlidYZddnWKT3yFyPOOb9t2/26Hlk4k49clz2MJfD8luUo62Fq1mZQE9mRoTSD1lzXv0mI8WLiJONLnkfTpsfOE=,iv:+pL5zqjFVvP8Oe6VzRJSvSwM78Ii1jIJXW44RksW9E8=,tag:Qgo37E6DjbQUNfjqTkAV5g==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/pihole/pihole-k3s-password.sops.yaml
+++ b/k3s/applications/pihole/pihole-k3s-password.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:omE=,iv:bkK7dpPaVQUaIuHx0QoO/WNcpcVDqNjMHf8PLh9m36g=,tag:TESZcpFbnjbVcZBZSZ56Bg==,type:str]
-kind: ENC[AES256_GCM,data:NuFut6e2,iv:Wbx1PbFRdCx0rmmHwpek/mdVggtMrOCrgunrIXT/zqw=,tag:j1T0nAmQXOmO4Rsb6r8Nvg==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:Gz++sROWpTymKtUJA4eBqfHt6w==,iv:dentQuQGqouSYsu3qzTo859HZMaFbyeiePzcCb+BH6E=,tag:iDJNs18hB5y+4w1xACBK5A==,type:str]
-    namespace: ENC[AES256_GCM,data:o6Jj9MDCKWmx3Bdp,iv:pUObz3Rg6PdmH7rWBT6iTF86yTX99jiiMocwm9PZIfs=,tag:/J/CLVomwJeteNzA1p35gg==,type:str]
+    name: pihole-k3s-password
+    namespace: external-dns
 stringData:
-    password: ENC[AES256_GCM,data:QOe2V5q3eK9lQF5EOw==,iv:rpQiB9KHckNpTw4TD1YUI0oe4ntRND3kUxf5X5JoRFc=,tag:+YVHbZSEPMUYlm6/XyfKLA==,type:str]
+    password: ENC[AES256_GCM,data:gXSbf5ltYbeYeUEiPQ==,iv:ffjtCJMETW8l3TZa3ZefHaq5iWVv82LJDywXOnHA82Y=,tag:uklLZ2nLGon6tooG+Cil7w==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1YS9tVXFScHNmQmo1NWo3
-            ajMxMENyUzlsSGRnRno0WkpEckxBTVRId1RVCjRLWGhUWDJwSmxKMzhVSTFPaVpk
-            TXNSeC9DU3MxKzkyaU9CcXl2MHRPUVUKLS0tIFNSZEVNYXpkWjZaMGFKbG11czc4
-            cEtwK1FsRUIraUE2bmdmNTNwU2Y1blUKnO21hamtp4nahthV3IDTYWgbf7Sjboi/
-            pgFVfP8Ju7Y2xHAjk4fRFd24gkxPD5eI03nWovgDo35CD8f1E/TaEg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3OWlINU5DUDJoQitzRlFq
+            N2RoR3FRc2gvMFRnb09tUUlpemhleE11ZjNBCkFLQ2MrWENIeHVKTXpnRGlJZVZv
+            QlJjR3V3MmUzR0VGSDA4am9Nc2lvYlkKLS0tIDZEc3ptTWI2eVNRWVl4WXcwNHRV
+            MHBFbUw0Z0oxVUdHMjZETm9tVSsrUzAKJ4xgWVau3qKNRCSj+i8nQ0aIbHLojJLq
+            4CQRVEBZCSfmpM5xSoXRi3LLo7WhmACMhAub+FZCYuipYxNZ3WKk6A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T18:53:47Z"
-    mac: ENC[AES256_GCM,data:tNLQdhFGd3bis+HeEINxUQGHKbGcetqN4fyK4w9TSawTgyEe7QEfm+Y7tIHQmcBj68DnDB+nrOyufvCNEwMIGHAaHTr26pmD1nNPxouX5+2KX0Qz9mD9g5fNFnQLOYZo3Xwz2+kwc+xbUR+bihOOQI0edKXOaKVzxYaKZtMEjkc=,iv:3kB4/xW/ZBw7IZR3L6QEUl0dEY7MSs0cGrX6sV9Ep4g=,tag:oHEoXm5ng53W4R4Pm3jwiA==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:RNcBjTyiWItCpQH/CHZ/M/qVe2LjJNFC+nGCYGpyHu8Ymg/oVsvRgazAoCS1/eXoKiaq+1pCQQvdjXxd2yzyOp85cQO/BeGQgn2AAI2gO/Y3lTu6ACTs5Vsco0wrK4Wu5ZEgokcVKbODznXrsYKlOcu4zR5QyrEDg+tcuDve4jM=,iv:xBuCiz+e2ji+DWJXxWkdd5DehUtN9H+hpV0aZKNGtHk=,tag:GNq10HORXGzkYMQv5kZ7Yw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/prowlarr/prowlarr-apikey.sops.yaml
+++ b/k3s/applications/prowlarr/prowlarr-apikey.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:Iw8=,iv:O31wmvnBkHSEl9zQfYNLTAXSdimMn6Kl9tnyjte5m/4=,tag:yq4gor25ISwdwqlaQM9mvQ==,type:str]
-kind: ENC[AES256_GCM,data:SSAtxbhp,iv:sMoc3X/mAXPtC1om5HdsPHG0+KTcxsY/NhO19iaWflg=,tag:0QjjcPbt8zPrwLzjbUGjNA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:TJ+vMRcWeD6/BRTkvKEv,iv:zflgbOq6grGIq5MNNv70y9d7IayYFf9aFVcoQd6Yk+o=,tag:Vct987MPsRJIYZIZlYI2Ng==,type:str]
-    namespace: ENC[AES256_GCM,data:qMhP8aw=,iv:zJJctvlbRkdrA+v7KL8DMWl+RSLUXjnk+/5B0aeiXuQ=,tag:ydiMFjrXPHTGPzKhmNpG8w==,type:str]
+    name: prowlarr-apikey
+    namespace: media
 stringData:
-    api-key: ENC[AES256_GCM,data:LRdcV0czufR2GU7HVZ723BR4/U2K1y3Qbv/CljjBVow=,iv:ALYJoxe2z/jKgUEc7cT7/CjKICHsIaT+rJ4+9rTn9+0=,tag:usygcsECv/KFKnb5Ga9M0g==,type:str]
+    api-key: ENC[AES256_GCM,data:TsLisnycpsyDEOARrwd+797mvXtYPvLsKGirVOyDZXY=,iv:Y2b++iYjEevx4l8FrdON1qOQfvk9JAAyiBytkvy1dbQ=,tag:DpRTUo6Iho+Rz8jifMsLzg==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaY01pNDlUZkNZbHpEajEr
-            R1ZGMjBQVzdkTEpUdllvcXlGanJYclBkZldFCklRSEdNOS96VHdEQkl0c1h5eC8v
-            L2gvbWRNd2xXait5c1h6S2JvUTQyY2cKLS0tIHNuVjB0dURuOGtZTWc3cHBGVU4z
-            VC8vaUJkdnYxYitudnNxc2pkOVpxS2cKVlCwbC1F2dyLVn/V+ANLQpEEkQ0ZhGE4
-            Lzt0WTSyBhkn7HitdDQ5TON03AmrhZKtiQWum0fqoBi1LL6zxKu22w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFVzE1NFhSTzZHMG5OYlRO
+            eXNFelp1TStnOGZSbTlRQzJETk5ZMmc5WXdRCjFkb3pwVERMRDZaUDZpY3dqdGZ6
+            TnpqekVudVF6MnRJQnpNWFNDaWFnSDAKLS0tIHFsQ2NNMnZoOVlEUFlwL3RyZ0lO
+            K2ZmWXErcFp0aVNNeXhkUEZpQWh4WFEKTuaw0umcAFjQYZ95m8PgDrfIGTN+gHK3
+            /EOB1Ccnx3Xeop/fb4ZJ3/B8S/eamdETMioxueXpbeJflni3OK6b5Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T22:02:06Z"
-    mac: ENC[AES256_GCM,data:5B4HyWpXNLh7KOYhLKeJtRrfWcacfcUu8em9jOxjr+SVe0umAx3dSpMBuUA8+SR3QzBNXRODVpS8fv3E903qJ41IROBDPYHQ1Yr3PaqgfnqG1xfCpxRNAGm0OL1fAE2DjHJ8x3ptdgwmLoYeK+OIyts16YouhyrKYYNOqf4eT28=,iv:9bnaSaOrL/4NsiWddt6/BSmmgXcjNSx7PJrZ4Jensto=,tag:NKfn8xACpnINSvGsk/5MwA==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:Oj4dkEhchNvrYHeU/Mr2IapH2/oOt+x5t7PJV1DNooFCoPwXZDubcwhYfIDduRSBdkHn5hjlIe1kq8SeGnfCcNZun46Luqz+EofvQLk97WbMSf6x3CJn4wXvQjxnnHu0ctZEZTh/4SKfzfVfWNwGKn2OEwQVw6y4M97grcgeStM=,iv:yY+G/3I/xEzZOVUAIhFb7NKJgNdF15R+JqP9i2C52GE=,tag:zo2fTOF6+Ek7TEGIotq8Sw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml
+++ b/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml
@@ -1,16 +1,14 @@
-# Copy this file to nordvpn-credentials.sops.yaml and encrypt with SOPS before committing.
+# Encrypted SOPS secret. To create from template:
+#   cp nordvpn-credentials.sops.yaml.example nordvpn-credentials.sops.yaml
+#   # Edit stringData with your actual WireGuard private key and OpenVPN credentials
+#   sops --encrypt --in-place nordvpn-credentials.sops.yaml
+#   # Then uncomment the reference in kustomization.yaml
 # This secret MUST be created in the qbittorrent namespace before Flux can reconcile this app.
 # Kubernetes Secrets are namespace-scoped — the nordvpn-credentials secret in the sabnzbd
 # namespace does NOT satisfy this requirement. You must create a separate secret here.
 #
 # The wireguard-private-key VALUE can be the same as the one used in sabnzbd,
 # but the secret MUST exist in namespace: qbittorrent.
-#
-# To create:
-#   cp nordvpn-credentials.sops.yaml.example nordvpn-credentials.sops.yaml
-#   # Edit the file with your actual WireGuard private key
-#   SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey sops --encrypt --in-place nordvpn-credentials.sops.yaml
-#   # Then uncomment the reference in kustomization.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml
+++ b/k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml
@@ -1,38 +1,38 @@
-#ENC[AES256_GCM,data:QxAC1yhigQaEjwWC9b+L/QblGm+AEjR5bQ7gXcRkDVLzmDzd3zYSsJzmuAOYEP5HQOmhTdZMUW914TguCH3O30Z1GH/3/Cl45PTF9AfIXgJv3FRzQzjYzys=,iv:xPJ7/PXmiF3EWjgJRNm/XV7DENIGfxnGtgyBa0OSTao=,tag:xR7O29JrVAn4y5rKrne6/Q==,type:comment]
-#ENC[AES256_GCM,data:Tnf1jqtMhmtayFzMaW/D5dI0n2jWWjc1typW50NZ7PiFAH99Pk929ldZ7y4UhnFXtis4TrkULGIutFjZUoTz6q8jPzV8FoUaHf99pVzPI3XiH55OSEJPSPWl+tq5,iv:W5t72VFM5GFjp3/kDx+25lwQz+y+UrdMamjgNYNXb2w=,tag:2VG7BJs81hF4E28DZjHIpg==,type:comment]
-#ENC[AES256_GCM,data:0rlVt6wiDzP+7GfvTKOt1dDYbKeFRYJHC80O40uWGF/ZkQWR7Cup+9JyTxGb0FlPrvVKCJZBhR1vetGZrcj6VOCJCxVBdVnKhrjjEo5RjZ/ygCAD2sYNeq5Q,iv:o25kZa2UWPwLNq9JN6cjHAzTurmr4OBKT2/cmxBh6dI=,tag:ME4iF075yV/WOX+4GPBImA==,type:comment]
-#ENC[AES256_GCM,data:rqG0HhjmAEN3ePqpd5CLQr/BcjLDdoIw0EgQCJ2gehCmyep4i/lqm/kzb4rb6EMNV3YN+lU3aV6L9stDcjVWP2BXxk66Gnw8Y1KUaOsD9abL7zLA2A==,iv:DZ1JIMcpoe4ejBtGJPUOxngV2nUGFlOoJrukjGiy/ZE=,tag:TH2qamaB4m1Z0rN93HhgGg==,type:comment]
+# Copy this file to nordvpn-credentials.sops.yaml and encrypt with SOPS before committing.
+# This secret MUST be created in the qbittorrent namespace before Flux can reconcile this app.
+# Kubernetes Secrets are namespace-scoped — the nordvpn-credentials secret in the sabnzbd
+# namespace does NOT satisfy this requirement. You must create a separate secret here.
 #
-#ENC[AES256_GCM,data:yo+0r1q9vNsCzNj15yTkxYucpS/sKsyDXn5KgKwropHA6WsmS2eIYKPXMVEtH297AuW0mUtYBnIld36AeRpWSp9S1yXYfoC17vT4bw==,iv:iFvqyQsbaeaaKIHOhB2EnDAJytMJ1L/H6MxXtgpdloc=,tag:61hqxUJFIO6DWnadkLZfXw==,type:comment]
-#ENC[AES256_GCM,data:SwGXsD/2pwGJjEiUrYQe3uE2CX7tZu4Hlpr95pFU/KHDg8yvp7EChNqqUhRme/3GksoMOUs=,iv:5EbsZPJEJzGdezUK7rkYeBGFdQuc+GEGzsn2ahTbIo8=,tag:QWbt5ZW7eRnpHviMh5R9Zg==,type:comment]
+# The wireguard-private-key VALUE can be the same as the one used in sabnzbd,
+# but the secret MUST exist in namespace: qbittorrent.
 #
-#ENC[AES256_GCM,data:JDxXIaihliqphE4=,iv:yOuu+IUMeztpj0GiyU9nZQEqCpunr0YaOthFkYvrZ9E=,tag:OmaKFeaoprXYPJN118bx+w==,type:comment]
-#ENC[AES256_GCM,data:T2E06y/SLB965kHB1/pbB66DYhuNs+7VhpmZwbCsNJ2uKCAstxka57OlElt5sTllIIizbjyOj31YyfemH9m6+vnoQ7NVL6JQXQ==,iv:6BEin7d3+VMRFpkj/hugHF/TWtkPN9i3GMnpQA8HsYM=,tag:b1tCE7G6YQt/4jmEYUanTA==,type:comment]
-#ENC[AES256_GCM,data:1hnTV7YMVVzlYd8y6LXX6owcFe+WwYihrrVTsIOrHDoa6cae0XnOCnH87vTY0vpRAawNMnYzXjMy,iv:HaqyaTx3KRNQvcKoXmAnBnEn2ONcNsX7QRoo+4QbC6o=,tag:G0upHqpFVHYoybBEQFJ/Xw==,type:comment]
-#ENC[AES256_GCM,data:6bUsGx/zQWXdiemMVeuNXYeC2T8teFjwpRYY1du+hemYYs/kypAoOG0vNGV6JXQDu3LfcCaVcab0GjsO/WQTiNwzW+frmlnXCj8IPAZ6j8WCEHYMR0TRCEY2mpz32uSyr1lV0iFnYT0rHPc=,iv:C/OB7cgKgGeeG1s637UBzzim08la/wk9Wd4XFAjxx10=,tag:xcsmFX8e/4nDTg5Bm/X6KQ==,type:comment]
-#ENC[AES256_GCM,data:vqQAyIMOQrvONsKqjI5BQ9iuVkd9GJ6IazA+QwHZ+zcXgNSNM++urvQR57z/7mGnODHdF0lE2A==,iv:n1Db4RK1LyPPe0AmrY0HewuwmO1C8OgPRXglBvJzNTA=,tag:O1zSWr7dXBLiRD1Hn4U8GA==,type:comment]
-apiVersion: ENC[AES256_GCM,data:LEo=,iv:Q6q89IHK7jZTBXdoyz+01d3dqTERBfYOQ6QQ2G4Gvhk=,tag:oSKft8IgyO04V528ewLPVA==,type:str]
-kind: ENC[AES256_GCM,data:+Xz370nb,iv:REBitlKUy0luqi+lxEorOaVnXwfuJc6P+hLcpfdqlbY=,tag:fMs9pqkdT0PvtmsvMujoGg==,type:str]
+# To create:
+#   cp nordvpn-credentials.sops.yaml.example nordvpn-credentials.sops.yaml
+#   # Edit the file with your actual WireGuard private key
+#   SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey sops --encrypt --in-place nordvpn-credentials.sops.yaml
+#   # Then uncomment the reference in kustomization.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:s741itDP3+5O8ATO0jd1FZ2f8A==,iv:mQEDVS6b+zdJbZBu8EuBlDsLENQaH0krhJA1RsOYtgg=,tag:mMVqH9aTbyvctt5ctyl6Ug==,type:str]
-    namespace: ENC[AES256_GCM,data:iUydrG/O31zhONM=,iv:ZS1JDwXSSbQijtLN1yChnZrSThMt5QmQwJjnQJiagyA=,tag:4/AWaiZQvfessrBd3Qeq5Q==,type:str]
-type: ENC[AES256_GCM,data:ELgjkHpY,iv:3ldqDbjB5cdXLGwf148Lewksfif82DKQSgf13pafn9U=,tag:74SnCki6vOTxdvIJTHxgfA==,type:str]
+    name: nordvpn-credentials
+    namespace: qbittorrent
+type: Opaque
 stringData:
-    wireguard-private-key: ENC[AES256_GCM,data:vbd+/vEa/FYhDj8KvnovNJAZh21ZbVfwwWnbHw66A9b3ws+T7hR7AodiWQY=,iv:useKuXUU5hTU6a0nr00BLvqlyI0+IRL/Vo53tIFcmBE=,tag:of/7qcW+4XGUuPdBqajjaw==,type:str]
-    openvpn-username: ENC[AES256_GCM,data:eZcZt56WZ0UNa8WHU/Sc4sztU/WCdwU+,iv:igmzPPRWHX1rWA2UzFcFttrz0CiaI2dVR/aaUNeTieQ=,tag:vFhQVFDS+9ZuZV+CIduxyQ==,type:str]
-    openvpn-password: ENC[AES256_GCM,data:ogV82l/a3w+AZ5aVt+Q7ecR7EcOWyjwy,iv:knILmGw1/UPReD9yWeUPUGN4fioe8c2kMk+w08NhtYo=,tag:EXac9cVEirvGchnx0dOgRA==,type:str]
+    wireguard-private-key: ENC[AES256_GCM,data:f1UADUrq2WHnBLnVk0uvRyk61ObjR9ZbqKQfeWpHvMOPM87xPXb9EG8VwSw=,iv:SW+fk93+YTwuk4g7Q5Oz7mBM6jHxwVrFALtbDU9LsWA=,tag:C1e+yLw3j/wYY6WyUQRn4w==,type:str]
+    openvpn-username: ENC[AES256_GCM,data:hLYSbJXvWRiXvlHL6HXwBPrbwQOkPwEO,iv:8orfwp48Xva53kVQuwGbFzWbD+FBwSanRw4yboGqBrs=,tag:gqblH4znTYr+MzecB9UQDw==,type:str]
+    openvpn-password: ENC[AES256_GCM,data:eApUM+Els0DJ/6LCclJhLJzUHxm/mz5D,iv:17cjDzPrHL9zfYxyzYHMbhbzfVQnIPZDjGLh4JwChT8=,tag:Vhw+X0pdfmSAYP8NmKy0iA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAya2JwS1Z6RDNFNDJiQklP
-            Q3U5dGVqZHhQVWY0cXh3cnh6OGE4Q1FPQVRJCmJsbHBjdU8xVWI5Mm5TNEgxVWVu
-            Y0lyWFIwSW9qSjdWNEU3SnRlc1IrTU0KLS0tIFEvVUo2cGxlZHhVQlk0QnJNeXFZ
-            RjYrc003aXY4R2FzSUtuSWRQUk9RK0EKCiprQ35x7PMkJBvPjt7lyh9hP4fhXkrc
-            jHlAZJsVyUUXHFVwm0m8Ffr54NuJid+K/fdm5aKkgwW0MaUcqtVbNw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNdnZMd2U2Vk5NdTJCRTZM
+            TnBPOE9zSUQydS9FamVhQjVMbkxOUGY0KzAwCjB6UEN3aUhXYU1NWXcvWFkvRmZt
+            OHQ3TWprU092VW41UUdiSHlQQkRXYTAKLS0tIERMbHRwNnF3NHlXRktURUdxUHds
+            RDgvemIyNWpxc2IyRlVIVVkwazlTRWMK11PteRu4LDxxMXekbldyVlqZJ8xah3b4
+            UKhMi0rrTwdL3xciQQtTFspwwqhRPryL4iJZ5AZ/LuNN93xjuNisng==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T18:32:25Z"
-    mac: ENC[AES256_GCM,data:C7CvYi+DHNxd2sAby09YOlwpZn+XYcP7x4UZv72e5lhrfaSciln1vK2bQNzQCtD4zvd/XaEX8KFh/nirNMLZzXNLhoozM65lMWLvveKoXjQoXdJXukDn77f+RqkiuLhZ4W5kGfdveU78SkmRWEGZDIbAJw67+Xx2mt2eC6WIuYY=,iv:CSzYbBN4zxjuwvUTgkx2ciYBOXBxsRmAW+wn8FqBK7E=,tag:mkzkNuQ2qRGVVGTSXwpagg==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:J9uQv5bRSiA9BeVQzMSgCD4fHr4ilNFyHpwdeeBFFfTOjVJdJgPubwhawKEJf63Mnxrj+313wAUOEI/Sw4vRVlXnOh3H/Cx4X0Jg8oHZ7dmTX95qbwvigIrg93nAWQl/gkADjW7zqgrNFmfHj97sWqLn9bo8oWfKiM3xHJs7XuQ=,iv:ojI7A28PHLDWyPqRd5r027M1OSevFF+h5ek10OJIR6g=,tag:SnqsDoMFtrFQXPCTsU7txA==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/qbittorrent/qbittorrent-credentials.sops.yaml
+++ b/k3s/applications/qbittorrent/qbittorrent-credentials.sops.yaml
@@ -1,12 +1,10 @@
-# Copy this file to qbittorrent-credentials.sops.yaml and encrypt with SOPS before committing.
+# Encrypted SOPS secret. To create from template:
+#   cp qbittorrent-credentials.sops.yaml.example qbittorrent-credentials.sops.yaml
+#   # Edit stringData with your chosen credentials
+#   sops --encrypt --in-place qbittorrent-credentials.sops.yaml
 # These credentials are used by the prometheus-qbittorrent-exporter to authenticate with the
 # qBittorrent WebUI. Set the same username/password in the qBittorrent WebUI under:
 #   Tools → Options → Web UI → Authentication
-#
-# To create:
-#   cp qbittorrent-credentials.sops.yaml.example qbittorrent-credentials.sops.yaml
-#   # Edit the file with your chosen credentials
-#   SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey sops --encrypt --in-place qbittorrent-credentials.sops.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k3s/applications/qbittorrent/qbittorrent-credentials.sops.yaml
+++ b/k3s/applications/qbittorrent/qbittorrent-credentials.sops.yaml
@@ -1,33 +1,33 @@
-#ENC[AES256_GCM,data:K69+2OGWzatudKO6pN3Hw0uQgUcMEDWZIiUGzmuQTZNYcsdf+9DAFplHKLODG61sBBhlblyQsAWWA8/Zitrsrk/DYluhQ4qbXKO0LpwA8C58N3qayWYA4Fr6vP2C,iv:04RCuYL7YGcixPp8FLx6yaU6r0i3g6rtTfC35g3DNUg=,tag:eDW05oAPVNm4Jpxm+QZLRw==,type:comment]
-#ENC[AES256_GCM,data:RmXXQyOkWz6znrsJgwdrT4SlIbPpIWYbdChuvX7p+GfSDcnZvzic249Gk4LO9eMdjwk4OwxK8Qg9MwUuAO4OgD7VHAyK40CQL7dlnHa7ghiZ/RT2l081zwanhg==,iv:pa+pIxU4j/i0aWVXrtXQM3fym8hCEebsjITLIQzy/gc=,tag:rjuaYscbF6g+isjbenu6GQ==,type:comment]
-#ENC[AES256_GCM,data:V5sEAJYxeDIEwqnYnLNwSCoju4tVWlN8QBFNX6CEuh7dZfHJsVSeY9P/KKNoNT3+sh7CiguOfYmlqFK/amlK39Yfu6MgiYOeTQ8t25OSdGauhA==,iv:6q+/jWvferhKu1u/S4KdlUov6FCJwTLB1SsudduTubI=,tag:OFmczCK0qb4HpIMJYgGrkQ==,type:comment]
-#ENC[AES256_GCM,data:jJmD6VqdbULiZBbnfgtP2yU7kCU3GdmG+xRbVvesYPOsuC9C6hZFaB+YWa79jyEpfG0=,iv:qTzIQcNpHTqhWvW4AjT2BHX3DrX19DtOLYllcBPFz6A=,tag:8CGjklHrT9AO4nuW45CH0A==,type:comment]
+# Copy this file to qbittorrent-credentials.sops.yaml and encrypt with SOPS before committing.
+# These credentials are used by the prometheus-qbittorrent-exporter to authenticate with the
+# qBittorrent WebUI. Set the same username/password in the qBittorrent WebUI under:
+#   Tools → Options → Web UI → Authentication
 #
-#ENC[AES256_GCM,data:MPAN+ev9YOXVi1M=,iv:Itp4QtRVMvO192x4uKymE+Bzu49TeOEtpdgrcVJqzd4=,tag:bWopYynpaxCE5hv1O/iNAQ==,type:comment]
-#ENC[AES256_GCM,data:ULNINjgZzRpXVU3iIZpix/cMkrLB8jNU50gAtLT9hvaKNTKlS0/6qjdXzc3jT4f+Wm9WkMA1J+HdclCnTr3NmVNp9jQ5IOog+jmSx9fDnX/a,iv:W3Xa4BsUbjjEF8ySkiWnyeGdgtFl9WUlZ5Dbx5y2ZLY=,tag:+nqlLVGwYI0w8Ry6KR/UFg==,type:comment]
-#ENC[AES256_GCM,data:px/QRRQG8+pTZ8P+Q6A2zvVPkZHn6oLN4+qHBT1T7JRlHNuBCPPhqo+QNbwRSsY=,iv:Or3pAwjFtOrv3CMuPSWdiyYRz1trqU+QlSS8JBbWY+0=,tag:oeHwDTFIiaDWlyugRgfZpQ==,type:comment]
-#ENC[AES256_GCM,data:aBHy+zyv/6TYt3fIcNzd1eeksqCYjANjhkVkAMaKZ8LaHhc+0OBDci0LLjVsqhxYJmk5R+aJN0OXMs/PQt28JFcg2OVaTM6KIW6BqzTrVUr3j/q7hXhl0w1t4Fvm3YsXvzxt2cespkGtT2qe79MV,iv:9yHCwNfyJm9VajpNkxjq77FNC2i2XnNwOiFMfbnPy7o=,tag:9xdQeKT6gk2NHfJqzmarNA==,type:comment]
-apiVersion: ENC[AES256_GCM,data:13Y=,iv:FFf5m2TCGuARnjde83iZw8wN/ueFcYZ+pf88oonAG5o=,tag:avjJ9P83aacLyRnLS9C7Iw==,type:str]
-kind: ENC[AES256_GCM,data:Z5a9xY/v,iv:CAj2RnBaccbWwO7dwQokdLDl0GkdLz0/88uG1I5QOi8=,tag:Cqien7aBPJfjfy6MlSCYMg==,type:str]
+# To create:
+#   cp qbittorrent-credentials.sops.yaml.example qbittorrent-credentials.sops.yaml
+#   # Edit the file with your chosen credentials
+#   SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey sops --encrypt --in-place qbittorrent-credentials.sops.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:z801LBe8FGaNm00zJEyDBCR/Qq03X2w=,iv:YUuJbGUJiBCjTv/DfYUmVQeOD0BA2y8II2IvBO7UqP0=,tag:q7nShqclGHtpzufOvJTo4A==,type:str]
-    namespace: ENC[AES256_GCM,data:3WmQTlfR8pt3Nxs=,iv:kvVQ9aYLGmCJwfXcCDWCWpT39o4oa9P+aiynmjF33Us=,tag:lM0FCeSInNjMlLCKzb13/Q==,type:str]
-type: ENC[AES256_GCM,data:1nOxm/ls,iv:YgeFKDXfPCmi0iVoYmxIHRvN6ZJmIyJQDQi+ieD+Ju4=,tag:PzZfeHUde+amSrk5Ib5YDg==,type:str]
+    name: qbittorrent-credentials
+    namespace: qbittorrent
+type: Opaque
 stringData:
-    username: ENC[AES256_GCM,data:Gu7r8g==,iv:xJWi88TioVnzMAuL3nbct//yAfzQ58xsbqDwKDMDt/o=,tag:CjHYMuEWg8SqUkknCoEwKA==,type:str]
-    password: ENC[AES256_GCM,data:p/74/WTcgJIR8Ke4cw==,iv:cBdqddrhf/Q1XoocWFOEXLT003y9a/8c2TvDCz9lChI=,tag:+ZtWC1RUdpC/Zues49C03w==,type:str]
+    username: ENC[AES256_GCM,data:5XrQ2A==,iv:+tXt8zix1VszA7F+O1DEZw0J3wSt4PlVcNfd+7RKug4=,tag:vaV+6ZWrCuHe0/H4aNFr0A==,type:str]
+    password: ENC[AES256_GCM,data:gJ6rqKOJjgjLcCq88Q==,iv:ahvITkkhUAuIslQ+6HCVubvm0QOtBQbitY4vW9z/xcA=,tag:WiK8hc75BzKzLdVt3E9+sg==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBReFdsRmxmdCtTdkpFL1Va
-            Vm1idHNpcGRDUkpMcFlkdmsvN09Ib3NQVkZZCm1HVTRFZ0Roa1ROUlFReWhodThU
-            TFVjekJCcm0zYjFvSURDVjJ4MVVzL1UKLS0tIHp6VUxXbzROaVJvL3lJNGJDL1Vt
-            VlFHcjBoaGxZOEM5RlJxZjhkTXhrWUEKzLBaKn7PdQ2RuNbBL1uykuFOB2tkal2o
-            8yb8KvRzMBZj6evDLbXCD2dKW453EtD6ntA6qt+7FAufW45rh+/HkQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoYUEwWU93U2s1RXZlQUxP
+            UVZYNWh4T2g0ekt5REtSOG5FSXF5eE10dDMwCnB5WmlVbWE0aTFETnBSVjNKc3Fk
+            SWxGM0xPWE04Szh6U2xSS2I0ZTIwWEUKLS0tIDJEMjRxNno2MWdnMGZWRmVEV2t5
+            cUp3UjRPM052bmZ2cDBSTlVvbnhkMjgKEIcUVtJg0HHHA1M/A69qIAbr4F/89MUa
+            LjBbLoE/txhnWxyO7213M9oGkKmw7ZGTPLz6qOt0PT1lY/E+1DL7Gg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-24T06:04:46Z"
-    mac: ENC[AES256_GCM,data:mR4DiLVMsgfcptSKJyI8W1H23RjPjfHd5QAcg4l3cgO1PC4fskRzpcSaeCLH7rbxU/lbhQUM9WozmFIoh06LyujxfVLudP9Zew6Q5aTBkz606zoT7+0NErEa15UzVhf74exh/MxkHmxwLJIAbHdBtn8IT1UPYYo4QE7gXWtl2gQ=,iv:MJG57eTVgo2mhpntElSqhmHQTIEfwo35CuZivFsgWXQ=,tag:H0L9fNhNsbWNUpt02h5f6w==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:ET7sxFDFu4X2f3ek1ob7guUfO+adwW4wwn8JxNZD6Sk4glpgZZ59MibZKgpw1d3mb4HdoHu4G0eSd3ezI24WisRtVd57vSfAjDf6JVsfuabpobXCrxnmxXR2G9k2yyIjmusLQPlCo6zQNPlGwp+a6AhMq84ej7OCVoRqh2UXH70=,iv:XWcmXDYl3j/azTmWbVLJGL8m1KMprkxOxJ6EJLZSKlE=,tag:2lfBdTbEobpreryL9qkZLA==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/radarr/radarr-apikey.sops.yaml
+++ b/k3s/applications/radarr/radarr-apikey.sops.yaml
@@ -1,29 +1,29 @@
-#ENC[AES256_GCM,data:4szCRYSrlQG6qDWrf5vpwFoxfTzJllHY+HF4il0h9V8ikvNcGOsRP5jqgCzHih6NvsXPzxG9UtERLXwVRKDCpOw=,iv:paesKv0L3AL8+11ER1fO+QyeQ/xW+EDjKhr/R5fZnwU=,tag:DfT4nfK9S4ZhnFK2plcBkg==,type:comment]
-#ENC[AES256_GCM,data:5LZRu6UuCSmOkb2iZt+u3sY4sRVsx08cpfKkaVZWn9c5qFrW/iGPzakslQTnsOH/ECLfENVfdCfml6Y4,iv:XEM0guoGzbN11kUyC246wKPBzPqTXX2RutKwGdgUzLE=,tag:AKcuuf6kf7KOPxtz1e5p8A==,type:comment]
-#ENC[AES256_GCM,data:DeOQXIL5nxh6i9Ywhpxs/DEjJRCoMRebZBwrvskaOFUJ,iv:OgXVxFfDYJI0sG/KmvfA1f/2D8j+aJYWUj7zuramRtg=,tag:QJ5VBR/HQSEfjE7HnVd95A==,type:comment]
-#ENC[AES256_GCM,data:cNBjhAfagGI7B6wNgbLgHPWlDayttFHx,iv:EYRxD7vnaKKd8zl8qiHm5zxb4SVSLkRb8OytHN89rZg=,tag:qVj6xBN2cZzL3HIIvi0+SA==,type:comment]
-#ENC[AES256_GCM,data:M28I8PlfxbugTmBMlpPS9cVDQ2Dx+88KwE/jaAiwu2RXHIqZ92zVIlaXO30zZ7KWjoqe/10H53WO1oGfOwegL2bze4s2HJbq96VeOGruTUVgTsi4Hefjgg==,iv:lH+JTek/nX1x9MzqDza2bndXrEdec9BNnjkB4Q4uHOU=,tag:upw6Fm7FXEotClUOALOGFg==,type:comment]
-#ENC[AES256_GCM,data:vK+ttMTcjfy7xn6xa8US4aTZAGrBsXx5n+t3kGm23pQC97ZB+MCikvH56T1xsqbsQcAR7XvUlD/nB4VesH6aDd0x4/CL2ljO0/LpAGw/k3rX0I8=,iv:cJy/3jNpYdD8TprBbzRMvk2HbqWI/vxxrt1ZZE+WSVk=,tag:EKPKjeRd99PNw536KP2+OQ==,type:comment]
-#ENC[AES256_GCM,data:p/P3Xxa/kULfA3jMFB2oQilDCm2cArTGN0nwSPIS06SmlE6gsQ0UqLesye3M1wk3/zSOa9WmIsc6ra/O7Q8cQp5qCWH0RKC/DgylpMUCeqBMLA==,iv:IiQkaFzrPEbkMin+9ASxrKl4u5VrTxkN74+3pKAHMBs=,tag:LQ2R1vO//nIlagBxFGoUqg==,type:comment]
-apiVersion: ENC[AES256_GCM,data:XYw=,iv:qRFdM7kSnRszKBt5kccqM/XqchK43Rao/Tt+GbXyCfQ=,tag:IueBlNka0skvBqKTVyroWA==,type:str]
-kind: ENC[AES256_GCM,data:xK/6Zz3u,iv:rEKIaVpkEKF9nr0fqgiZeOh5fYs5UxORej+WddVQTj4=,tag:tLdln77y13tP3zddYrwZlA==,type:str]
+# SOPS-encrypted Secret — DO NOT commit plaintext in production.
+# After first deploy, extract the API key from the Radarr UI:
+#   Settings -> General -> API Key
+# Then encrypt this file:
+#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     k3s/applications/radarr/radarr-apikey.sops.yaml > /tmp/radarr-apikey.sops.yaml
+#   mv /tmp/radarr-apikey.sops.yaml k3s/applications/radarr/radarr-apikey.sops.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:NzgVk8d81ZamRa85cw==,iv:x3do41bsEfBT8W+74XuBZ4IP+elJfgFdK3JVLwB1SRw=,tag:WEeIvrY0S/Wdaa/cAp9LiA==,type:str]
-    namespace: ENC[AES256_GCM,data:2ir/zzo=,iv:u1/TYqhTXEt+TSdqlLleFFDPCfjDs/2zqMnBiGZS99A=,tag:BMevQYmHpas6tVZCl0wRmQ==,type:str]
+    name: radarr-apikey
+    namespace: media
 stringData:
-    api-key: ENC[AES256_GCM,data:NBUpdrLX/7KxG/dXOQO5UXQ95IiQNpZayaMLYDgk+yQ=,iv:7r/PccD/whvkFnjvDZ4KglcOzebwBr6N4wtqBIIJjWs=,tag:sDZaSDPSBwf9Yiv7sYvAcQ==,type:str]
+    api-key: ENC[AES256_GCM,data:9apoI1vp18XooErQgtfwv3Ihb8bO2xFlnJ5KEWzP2ek=,iv:Yv96HUmUR9Omr2NrIR0IKdjyZS60YNCIe6lgaQgnWdo=,tag:4k/RZmfUTUe4wTmAHv+O4w==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIT2FOVk9yNDhFTzlLRE9D
-            NmdEQVgwZGJCbkY0KzFQZXozR01MbGM1dEVnCnBxT2psOFJkNFFESVFZQVZIcVJy
-            RERhaXlkUU5mdmxzUTRIaDYyZkpoaUEKLS0tIFVVUi9HdWxoYU9hY3luMUk1L1Jp
-            akZrbmp1Uno0Z3RMZll6SnByZVUrU2cKhCK/26YiQ+EBLEUCyJrPfhY8LpfTk3Cq
-            wBAfbXzafPLLT66MeUfivVyaUKQTtqtKorP8knqh7UAoaGO9RlSUrw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEY2RuUnIxYnFwMXY3TEF5
+            RFl5WkNKWjlaa3RSMGkrcm5rYUpBSnVlSUFVCjVPQU9mWko4c0QvKzZ2TlNUYmk0
+            U3M4NVYvaXpUME1UWTl3VzUyYjFKNzQKLS0tIG94YkhuNU1IZk0zK0J2Ukg4cDF0
+            eHZwY3JCajE3UzR5QVBCNjRWNWFJM2cKU2ZB8cuIu+FKDw9tgNcsqWh8dEN8Dg4Y
+            Qm0omT249bOyR0Hszk2q1pd12pdNEOnZg6qe1WjYPq0aKqP4Sh4x9w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T18:33:15Z"
-    mac: ENC[AES256_GCM,data:JidQRh093eNJ6NVvNOYzhEfidKf4gT95zYyhPPxa7ZonNyenffj3WCRtfbV/LMIub0ziOVDnfzxu4Zb8yJYPjNO+qgNelKRhNLeuPLABECdlEy+uinFLj/rE0TSkel9C5q4qod9SwnO0+Fkrqhh8ZYXgoF2Z76iVt+0jJ36aPeM=,iv:0paIrxZu5TzR5FcanqlIWG4ukLGsh5PTsQaU8d+Xbxk=,tag:6n/fLMz0cK5QKz0QBRrKoQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:WI9LhymCnpUEH31MvwNmTnjPOXtVDz4QL015MDr+Hnp5/SALOsLh5uQ/DalkR6Ww43u1eP2GXAf5omMwqQxvt4nTvXOBBnwddwS4V53WqfJW3neAP7QLo0Yv57GBSgxnd1BpWlGtx6QWA8K8y84FjkpQW0SMSavjuGXEeLWy0CQ=,iv:HGeNvh9gR7Y8ISuvFeB6vOqQ2PfGQjo6L/CxVUruXOg=,tag:VkxUwPcs0H3ILRnwW1tO7g==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
+++ b/k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
@@ -1,33 +1,33 @@
-#ENC[AES256_GCM,data:Qj6g8MVzMTl9L7ZfP+9zuQysLoCiTkO1dbQIfZDPL3vloKNOkArDAUT6JsmgQRHFv0DwYSCyD0YGHrf7eVqiTQo=,iv:xrCP5Vd1bmAvVRIr0JWq6Zh4zFMHTHJsV7rWNRhDFVs=,tag:WFsIOkXDlfDs2kZRaRwy8w==,type:comment]
-#ENC[AES256_GCM,data:Kczr7EuFwxOn4KAtFZ5Ms1EnSEVAqWG9b4macGwhZ1oTrjHUPn9Lx/jsCA+B9OVu0FOeaq2XB4712G5YaJBdr4k=,iv:wRB21qxM++u3qXaP6TXVvBQ3gHhlYq4wsvdxWmwMego=,tag:6BdjCLSuJQ9D/hOqo2y1LQ==,type:comment]
-#ENC[AES256_GCM,data:GdWalx3oEVLrn+pHC/m2hhMpi7fKaZ/YsuTQI1E42NUDqQmjJH3wDYY=,iv:zfAwDnbp+GuJcvX46YTt55J2savXtoUPWDeK7bwxZSM=,tag:IimoMxneTishA/tXRM8Thg==,type:comment]
-#ENC[AES256_GCM,data:xvTyG1AqiyzZO5cW+b2FduOB6HxjfVFvKJCZOC0/q2AmDmFKP42q8qnL,iv:XSNGvuqkU5H8Oo8xlwuO/UKFisU0qCvwzb2UhOwL6nU=,tag:2MW0lAJc2ml9YByTh8oViw==,type:comment]
-#ENC[AES256_GCM,data:V+CTfKm2gjD9DRl1JxYiYoFr0wWYDxEM,iv:LFo/99HyD40BKPuLIgoRwEtCHS4fbo8KmYmG1poDSZw=,tag:ugyjsNUzhDcJrzB5DNO2Kg==,type:comment]
-#ENC[AES256_GCM,data:Lc12HqW4AIplMSbeZGLoV6z1aGPUe1KODFgCaWDpGCgUr6OJIkM6tbVkMb+kOPJGLIjgj/xDC8+CezPCbxm9k7Jic8ZWJh2HSvmHSrZyrMgKbm4KHCYrtg==,iv:EUGw5DVUB/k1OZ2ys4fxF9O8t6Qvj81MoJIovRoaCmo=,tag:MmuivBRuMm8l5Fj/035JQQ==,type:comment]
-#ENC[AES256_GCM,data:c8lI7wDRqp1kPuZjtsp/FwCNahxFrnk7v4c8w5IApi1O7eMrSJtlHShLSlRZE1x8KnkuwXNf1XzKkOFQw5RofttCQDRzklBW5FWooVTPR4dKj7u/mzdNz+JRymn9eg==,iv:NGAdLPgl/GXCN8hF0diY4hNkK13ut9TmgFUht5JJG38=,tag:GHrbdMZqg/ObRriaDj16nA==,type:comment]
-#ENC[AES256_GCM,data:567TKWjcP5O9lgYDwEY3nOhUT25nuEKI8n+DA7duz+LCAmPuDnPrmDQZ0eKy4MxfMynxoVbHM47mAACKHojlkI4Vbdo83EUHLcjffmJ5xi/sxXIXnxwg0LbOPTft,iv:XSTW534QS/vxewIdhx4/+hHdEqo4Pu7n8xGDVOExN2E=,tag:1ibsn76KBlssC0NAQ7hGtg==,type:comment]
-apiVersion: ENC[AES256_GCM,data:AQk=,iv:WY/nuA/3XYM6hYAW0PWVg/OMkPq5jkuR8nZXgzcQPjo=,tag:6mMe+c3O02Wc/0VGGPpl3w==,type:str]
-kind: ENC[AES256_GCM,data:7ozRxe02,iv:ZXat06oiaNbvQq73JOkPSF5LzfBlvuFkWCwCniUdY9A=,tag:78A9apdPN5bIG69qIgminA==,type:str]
+# SOPS-encrypted Secret — DO NOT commit plaintext in production.
+# After first deploy, extract API keys from Sonarr and Radarr UIs:
+#   Sonarr: Settings -> General -> API Key
+#   Radarr:  Settings -> General -> API Key
+# Then encrypt this file:
+#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     k3s/applications/recyclarr/recyclarr-secrets.sops.yaml > /tmp/recyclarr-secrets.sops.yaml
+#   mv /tmp/recyclarr-secrets.sops.yaml k3s/applications/recyclarr/recyclarr-secrets.sops.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:JbcFWFyagGS2lnDbGwAPFts=,iv:wBhkMbMBr8sqbZfzHIswy3mIZuUFtb91ZZMIxIdtGuI=,tag:yYRbyKUxKsY+pf7Mdz263w==,type:str]
-    namespace: ENC[AES256_GCM,data:7sUFIsc=,iv:umi4/VS+Y93N6y9nvuGNnWK4fbxs9cki8op6k91eY4w=,tag:9Udv5sUrY3vrpNBog3e75g==,type:str]
+    name: recyclarr-secrets
+    namespace: media
 stringData:
-    SONARR_API_KEY: ENC[AES256_GCM,data:RP9ha6/eDPgfGpI1nvWQXrVRitfURWtmoz4WTALcU8E=,iv:tpT4CASqtDspvZ0juaB7oHxvS/Hm3P3eOYf8b2/dm2A=,tag:E7/0zU6oKVwrkyAQls8ZaA==,type:str]
-    RADARR_API_KEY: ENC[AES256_GCM,data:/fSbLUwYy+0cIJeWNottxaHZJVBrKOmXHJQzo09hC0w=,iv:9KBlnfXgZfHFhR0tlJ8MlWI/lfd8jWlbIE2WpkUr/tw=,tag:uuGmV+eN5+mEURssR/6XPQ==,type:str]
-    SONARR_BASE_URL: ENC[AES256_GCM,data:2KdkSKAaoyzb80wcEnjkUQHXVseqfWY3pZ5A3j1z3TWF5JJ80WYYtSb/,iv:sNEBTTiopAMLct8qL7NDENKUPq0F2XqKO0DJ7GrdAzo=,tag:TGrhkfdRPrhscABZIFL8qQ==,type:str]
-    RADARR_BASE_URL: ENC[AES256_GCM,data:IW2Ghp9zUBwmSYOywOtGfpI2VZvH23Au8IKYz6Sri1GFbrmEq3YaaiNZ,iv:WDuZPDnTCzysqmQOEOsfrsRWTLn7++qNwot2vO6Nj0o=,tag:j0xpuueY0kC9gMPbTTYY1Q==,type:str]
+    SONARR_API_KEY: ENC[AES256_GCM,data:Ot+7Ot4T/LxJIVtdWwy2LT/sZE/T/AOHj24ufRkPUpk=,iv:JoscmpcBp4AOns5ZErIQH0NRPtANonpc3mBr5NsXE1A=,tag:Dr8iTwSHBTLQWloNSyLtkg==,type:str]
+    RADARR_API_KEY: ENC[AES256_GCM,data:FxcPfVqfZh19nWAozLHWJS+4zzXWPqqpct31lt+H5/8=,iv:h0bqH6AkgQFw5QgyoS4t5urDQvapTdu7cexKbJz3C0s=,tag:wPLddR6uZGFHmNS9KpMbUQ==,type:str]
+    SONARR_BASE_URL: ENC[AES256_GCM,data:nPf5LrNuyg+jDNuWXPQ9vROXzOjP3LgAgLEw8AWFgyqQBKWbVBf6nVae,iv:nIDUJpR1CgANMFfLfoY1j+JY6VF6fJKAf585fsRYvG8=,tag:ZOzjpvsTPtkLc+CLwl83jw==,type:str]
+    RADARR_BASE_URL: ENC[AES256_GCM,data:f07lPb9JvbCiRwUWsmBr+iwgGvO/fvLCXo0Pmd7XqsJOjc2CZPnQfv/k,iv:zOXkEIumumx5evIF5ElKweQMeAQDi6Gs9lMqmYpInXk=,tag:LypkOwreC8BheCEJCBZp7w==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5a0Z2UzJnUHQwMGNaNjB4
-            ditWdkpNc2JqandjelJYelZ2OTNnenVVWHlBCmVneFdpdE04KzdHR1J3Z2VVdDV0
-            MVFLVFRmVXQ1Wm5VT1M1YmlkVXIzU2cKLS0tIFpSSWIwOTFrZVpMNlM4Snc5R1Nt
-            eE1oaFJVTnFZVHRIelc3ZUoxY1lYQ00K22qOYQuz8Ax1SPXX3uYeCjt1fYxWuIUb
-            Q+pTQq5IKA6wp0NDesByIJyRrhB78wdFz/i6eK3RPgm3+9Us78kD/w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLVXJnN2N1UTVDYkZCN05m
+            SnhNWFVETGhxOC9CMW1naWYrY3l3T3JmZmswCmRWYncxMU8vR3VDb3A1QUNqa1Ji
+            V2NnaDllSlpMc1ZvUFBIRDN0TGdrY0kKLS0tIERRMzd5bnBaL1plQmg2dHpCR0JV
+            OFZhWmhOZmxrRGpRZFlaWVJkcnAxN3MKnIkutUW8NX0fqCzOhSsC5pZippVIA/+a
+            iZ7MjePV4ahdkJbMC/IOgjYzOQC8cFrvEdMNKdhDhLfACewwXc+lUA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T18:33:45Z"
-    mac: ENC[AES256_GCM,data:4eKNgAIBa6L491nrAZOfBzO+UZ+NB1G9FfcRK3zxxdtyT5/eOUmV7V9qi2NHI6G7EymMg039r1alxIc5PSRPiCn0DX1ed3TVZGT5hA1nZ16G4LZ7ejOWIbZvvbzouTujFyKF+rQ/xMtl1p3IOD1qKlZcEEYPMnuV81BBL0y6jUk=,iv:wbzlcjDbHn5mdeFJ/YMZDcKRUTYxL4ZKYSVh512ErYc=,tag:8zl1wnqQAhVx3ElEg+DklQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:JFuLWAofbLElyTJj8Gv+y8Q2r9wMB0oeaoq3EErqjUtGPGPbOFrEaHqx/sKipbs3gPGgqvjuIwcSTbtXusgLxp2zkP+er/3jGv5XD8M/P06xWNz9JZbuCsJcENCIP4nAPPROuLs+tXB/MC3vwMXJTVfMoxJ9vuLbOkcgH8cFtMI=,iv:PnKsLC0HXWG1FFAmUpKbKSwbw3JxDJOLRyPb7FkFRfw=,tag:Zm4LC+0SuV66tWQ9qTGM7A==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml
+++ b/k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:hH8=,iv:8rW8cH+25IdIW7s9yiIebcIipBepbewo/xwZ8CLPjqQ=,tag:47OgMx3ahhb+nj6kxW9jCw==,type:str]
-kind: ENC[AES256_GCM,data:anjU3eUa,iv:OxfJOQ45jbRdnifMqRgccBhPgozQxiS/XbWN00kK+u0=,tag:NVdYMVAKooN35TzDzOyYbQ==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:5nYCzDcaRcFTtMt817wRHI5ULw==,iv:5KXFhsdR9VnHtG6RBRYEg+uKM/e6hRVrmxIL8uygQ1w=,tag:UjhtjbyF6F9GZCdF+Lj74w==,type:str]
-    namespace: ENC[AES256_GCM,data:bt+nUdPEfw==,iv:yS5azqLw5AWF0MCyj+8MZ81cD9t8nkmNSwtmouLDY+k=,tag:QC67jaF2V6s0t+NOzeEs7Q==,type:str]
+    name: nordvpn-credentials
+    namespace: sabnzbd
 stringData:
-    wireguard-private-key: ENC[AES256_GCM,data:GWMok12RiDbOoiAcp/1tDVSSfuHwp59pvbA5FbQFd7L8GrBHdrmSsFoAMc4=,iv:T5SNE4IW2vLsNPfAdsmD+3pLed2M/K0X3pJbB/5TxpQ=,tag:2vHRXEILsWBl/8r5NFcbog==,type:str]
+    wireguard-private-key: ENC[AES256_GCM,data:g3k5UotYpvLL3yLH62xttJdEy2M5aB/Kyw65Ega8qbdxGDSBcnEI1vL/2sA=,iv:EHS1xXciuSvq5bpewKW+5yeoFdtN5t+i7aE/Hx0LPQM=,tag:BHKEPohlwxyH8Rf+9T7TdA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIbnMxV3ZqVGFMYTRVTnFa
-            VmVtbzVZamU2VTNUdmFpZ1QvWHhQZlZ4bFdrCm92N1JVcndZeHN5WFpyVlh3TFE3
-            MmVEbzV6bEZBNTdkejlYREdsWjNraFEKLS0tIFVIOUFSVjM0dFVrTCtMUnZTSmJk
-            bXV0RG02L3ZHZHI3djBhaWhWM1VKTncKGscLDWdA4taAqo7aJBlPV15soL8GlCPw
-            2/Ok/0vNz+Ti0Pi6sWcqpnqTGVU6YGWLcluJ8MB+WUXaV5xrnaHOIg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0NWsxTmN4eW9hcEJmSkpY
+            WDFTMnBzTkdYc1dQdEF5aDE3b1BnNitYR1dFCjJ1OGIvTjUyN1ZqenBxUUtZWFpW
+            NUVrZ3l1V05Wd1Jtb3ZzeW5PNzdrZFkKLS0tIFJ0Sm9zSXJvMUdHRVNVM0oxSXV1
+            WjQvcTc2eEo5SW9KZTRDeVUxUExvZkkKtR7R7m6qu/3iVmqYHGE5Gczw9umTdzFQ
+            hAvbsZ2XGbAzjSE8ACgZOix4PfOtZUwGl5pOexu+wxCVMRMSxMyJeQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-24T00:44:06Z"
-    mac: ENC[AES256_GCM,data:30hYp6agvQMrOTKVy0TZkM27AhIC5RFfhmntnTcNMb0ZHlFiTrPP1zUMuB7H6dFlCKBr3WwcXH6Vzpy1GzXw8hbyZ/NcDwzF/rpjlvWO1UN1m1gcXyAhQqZ8NkGGGSezsvGJhdMpJtmIVQTF0NxVPqLyGvusD7j87mgxJIZbkWk=,iv:fuM0FCzprqKsCXbzeQKOJJzJtI/MAt42yZO9HxeWdWo=,tag:aHRKZEZFJZfp8vRluTueGg==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:StGn2eIa1DKZcWxLqCHczji2y6MWbgHMRdr/vtCTQq/rTzVa/05FaTdELuSwwQ6H+KUgD6UpqosQKZvXfC14Zm26uzZwdRCQtXzW+kua32E5/CsEoF+7rZTcAyNWFwaNlkNLboJldSJCfuusXBgs1kXyEDGZccE6QE4t8CARidA=,iv:c2PTedwQRsfVRjSFTbBKEDyw8fsQYhkVoxwqrRQnhsI=,tag:ZRnM5btaNisFjQxSd6OBIw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml
+++ b/k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:cG8=,iv:w28TwnFLXhtPHzrFTTk5vv3HOAkqxwEyLW/u7SS0Ylk=,tag:Ta8T4Nja5jytjyzxKhInlg==,type:str]
-kind: ENC[AES256_GCM,data:Zs9kjH54,iv:kyO+QDuiah05LkGpwLdfM0fRBldmPoXIpKcgBWQ9gd4=,tag:NZipi8eYLM00uduT2Bw3Lg==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:Y+LkDfcYcMKhStysVrw=,iv:OB+2Pe7iOLvWSshsmv9CSgGaDifCFSOd2/EFB6S6mGA=,tag:a+T05GGwTAtCL8kuO5MDww==,type:str]
-    namespace: ENC[AES256_GCM,data:YjEFvPj3jA==,iv:bYgTBD+DCGdwgmtgSRH8Xm9XzJ0yPOw6qjOSRPrXxxo=,tag:CNlwBouJ4EQj68jWr1q70g==,type:str]
+    name: sabnzbd-apikey
+    namespace: sabnzbd
 stringData:
-    api-key: ENC[AES256_GCM,data:aeVQ9wapFQHHNv6f6efdgjvOOK49ZV+tzlqo75XIkwA=,iv:JeLKJ990YOf0ArNTP5u/7br76AjAzvuF+hZVJELmAaM=,tag:fDxx2i60df1Apquy1kqVJw==,type:str]
+    api-key: ENC[AES256_GCM,data:EO8Y706/e4tHzu3vJ2ReEU0Kk6y9nvqj6j8FnoF6fxA=,iv:SHJ05sWeKJ38VDBJnEb/LdAITcyGtB+tYhve/3qrQME=,tag:aNwNWlszJNgSLraRCkrDng==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwL1BwVHlQTFUvY1NrVkMz
-            ZjZjVmE3Q0EvRC9PbldLU1lTZCtXU01oWEVzCnI4Z1NCWFg0d1lYQWcxWEp0amEy
-            ZC9YSm41ZWZKTjhmM3dGNXlGWjM4elEKLS0tIFpZWUJESExINFlva0JsUEwrYWdw
-            ZzdGY2s4UWZRMGN5NWh6YWJqcGFGaDQK/lyLVbCqje5pRSncPudaPfBHikuVwbcl
-            0HMdywSEVKj2xTxE+kIDt/UOx1Sd9TBdS9PEsRpmlJbK9xkLYpBipw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrcDd0YUM2VnlGL2RKZ2xP
+            UzEyTjFteU1qd25xaWJIaHBscHRURUUxblNBCnljbmR4RmdRTHJ6UllHQkd2K0tp
+            b0JPWXE5clA0TGhNUDZLYkkrNzEzZmsKLS0tIFFzejdqdFE1cjQyaVVobXFxR2VW
+            U3BoRHBxUjh3NG9BUms2Q0tBTGRyZnMKaKe/S+pW8ND70CkXhPE5rfqdxhe2flt9
+            R+NHIS9OwP9MZlyVpAe5b/CrgIdh/+h+IFs/duO5G3gxvAcP1lNDzA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-25T00:10:40Z"
-    mac: ENC[AES256_GCM,data:1yqYbt0vuoRScWlTAEOHwGJEgqcxVOL6pRmjD5BM7BQy3gmdhjdvirrroasOlDP+e1QfXhGgo7v3WYPkY+msCH4EVxpl3WCSoMdi9ysznej8MdnLoDyKeDzuD9NzO2KU+Gl57VleUaA7FTY4nRaX4V8Qsql5E85IM0j8TaCEhhc=,iv:R4ffpVK4xncnq8xfy0DBTd2K3LGm2i84PjtxLzZajUk=,tag:iVkcuIVm5pe0DxMNMCxN1A==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:AH0BzGJn8qEFPAJw4rzNFQN3MJ+vsjb+f8MvlDkD4V6+ARuVJGpm1xBC/pxdCXIGZmo5speqDeuvuh6vLRlp077danKHuDZThiYM9GPZGL+n4RewfKh12fQR1+o9iygvUn7vYVvuP/97fDf1VdfxeizCaciBELUqjpiReaFbb+o=,iv:ANRGuejp/9kug639Qpa2gat/lPMTo8wiGVbmDnCzArw=,tag:Dfs02m0qyKyLPAjyV8rldQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/sonarr/sonarr-apikey.sops.yaml
+++ b/k3s/applications/sonarr/sonarr-apikey.sops.yaml
@@ -1,29 +1,29 @@
-#ENC[AES256_GCM,data:OjH933TuMybyKXACn/TKgLh6yu5FHVklXzuTKB67RwaFedeFHUz/Kj8Bnlojw9kOiK23nLFcMAuagNtXhfqWbIE=,iv:hzAXYdoWHpzdH2NejxR9eqwjyrm58eFTgToRqes4YHk=,tag:3nJVZ8HdMmy0Q/ULTth2ZQ==,type:comment]
-#ENC[AES256_GCM,data:SZ0/HWEoXzJQd1zt0BFaa+aR0h0/EybpqNLjWMSkjmxQzbVQN+r/22dtddiJ8xMn/+uZWq121r5Rg3We,iv:9h6VVRBX3hzgUug/4ePZLtdq9gbbeo14SBOqaomjwnM=,tag:xI1bvkO5ZotH3rMg/NnM/g==,type:comment]
-#ENC[AES256_GCM,data:FWsZiRbivAJCNPm/hI47NQtNz/VEHifeSo2a53BRfrfU,iv:j0XgN64vrxmUU3BcqhlsW05/cWa1rAXUi+9UxIuluME=,tag:La9N+6dJOakfv713ZWPS6w==,type:comment]
-#ENC[AES256_GCM,data:jKJADDY8xeYmHrXt1/uxTtiLW6uqzETh,iv:gDpVYbroT0BIXfC93RcztndJrLqm7UDXNo+0tjgHIGQ=,tag:MS57JbQdkosn3lCt0ZLjbA==,type:comment]
-#ENC[AES256_GCM,data:BGuOkqXzA7M1D5DBBmgt9moPeFgzsrdrlukue3nOaZi50gCYf4pQI4tCQWQGmHfzR6YLqKYpSUaJ3Zygkua4j6io/21GO35jYjdtnoHd+dQHrEYHpc/y2A==,iv:NdW6/BxVgXPEbbssyF6m42tVpq5WCgAxbIT6UfPgUjY=,tag:brQ/bmtntWrkXmPRoosF3w==,type:comment]
-#ENC[AES256_GCM,data:cEYZQKl90/5ypNOccVAqnX9doUhRBg1uWtd/sHWu5ZWeIB/e6VjuVp19Z3MWggJ1GpY1kscQX+mxy4dOdgaE7Z85TSIUiBUT+aPjyVJ7vsUuY9c=,iv:KqSEtkBEMTF2tGfVYZXThIccmNY9aJCgOtNoCBoc3rM=,tag:wccsifho4idVKk9p0opP1Q==,type:comment]
-#ENC[AES256_GCM,data:AUybIpGNrW52TCO/cEMFpkA76XBz+WFECW4MKK7q6wGK4IBy+H1r0YzAPFMBJmePWr4PqX4O8s/tiVMzJVuozDdNL6cmwl8LYub4bmn9MElwdQ==,iv:zQNFaglVvvC9OxyVPnjWfQwNj8v6Nz3/WNon2RtFA3Y=,tag:s5rlKQeWJ2waX27v7b1sgg==,type:comment]
-apiVersion: ENC[AES256_GCM,data:AjM=,iv:aCKdu+WtTrntimuUwKQTX88RXhgKsg25tOh0eJNGcSI=,tag:wIQdl3qiU/CUt0uacmfz5Q==,type:str]
-kind: ENC[AES256_GCM,data:VMr4anz5,iv:ImNei7zURkqZPwS9WnoXbkmu2oSKcs6WD93sX9PWcMs=,tag:vhM20Vka3AJZkAxphRR3Xg==,type:str]
+# SOPS-encrypted Secret — DO NOT commit plaintext in production.
+# After first deploy, extract the API key from the Sonarr UI:
+#   Settings -> General -> API Key
+# Then encrypt this file:
+#   sops --encrypt --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     k3s/applications/sonarr/sonarr-apikey.sops.yaml > /tmp/sonarr-apikey.sops.yaml
+#   mv /tmp/sonarr-apikey.sops.yaml k3s/applications/sonarr/sonarr-apikey.sops.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:YAC2Sz6S6MmzBT6x9w==,iv:arqam9Hysmi3j6FHjCPLXsAmifLwbbxTK1BQXWjVfsg=,tag:P2hlyIj9a5vblghfXAIG4g==,type:str]
-    namespace: ENC[AES256_GCM,data:sFxrwXE=,iv:5LmLGnqNbGr6zzmD78WAPhBjEdcwEmSQxH2OkYxoZcM=,tag:ZecGQMhS8pP0GKrwGVxiyQ==,type:str]
+    name: sonarr-apikey
+    namespace: media
 stringData:
-    api-key: ENC[AES256_GCM,data:o2kBc78YEt95+WEFSbxmkx97CoUHUd+/nqXicVu+6mA=,iv:vlH/f6F54RkWibfGsCLoGMth/N9/wNLHu9MkErgHHcc=,tag:HpGdeP8WVkJBChnaE38Q+Q==,type:str]
+    api-key: ENC[AES256_GCM,data:Vd+Vh/Va4MU/KegrJxHVb10uzNNQP7cy7PFwjoq3pNc=,iv:eMZGK0OKUUumWBxxAtJ/KAvVpcpJVRO00WFCFoobEMI=,tag:yU+0vaHpElIhSjx7ethifg==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByUmppeDR2dE56MGVkWWha
-            RG9xRGt4WnFNZk9FL21tWDFNUk1hMmRvNXo0Ck9IMzJldFdrZW5VdlNjT1ZUWENm
-            RkI5RGxvczVPTzc3SisrdFJndW5jUXMKLS0tIEJ1WVVOdUh2aE96ZlhGK0lDSEt1
-            bDdxeXMwWHhhRWk1WEpjd0RXQjYrV1UKbEIzR7opWOBEVxQ/1JfA33AM8e+OP9bI
-            as+uRkcDhcrhEeYjN4mMwUvL+Cu5+8H8y9o+IFquDjoW/SUN+yCXww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIRG1VS1lFVUxuWGdZUmVt
+            MDZsYWNidi9xODlmdVN1WXRadXRGckNPbVJVCnVHWGtMMWFBZ0tmYVZlZlR1R2k2
+            b3Z3cm1oakNjVFRESCsxdFlJb3ZZUWMKLS0tIHZIdVJDS3ZYWUwzNGo1L2FyNzc4
+            Y2NaamxHbDdpZUZnbmhFK05jaUdjL0UKfB0nYjYtldEDzVr6T3jDB7L/20G8ILFe
+            F68MLtJfpUK9jh0IoHIhkwB7kmskxBDypf54zU3wDd6jnN+Lm+k1YQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T18:32:54Z"
-    mac: ENC[AES256_GCM,data:Xk0bVWXZHGAbpJCTyt92sJ8ay5CBfT43sVxBEHhopb50GUpXqwVfYtg3rsKEEDhIASejQLoDir0XlgHOo/2Xis8grzNQvt1VfVWB7QJ29ROwpUldeqsZ1soGYJIsQjBNp1ft8N2o7X6Gk7UsbBIqqN9uiHZuaCr7godtGm6shpk=,iv:k8jTiYdje+s7w2FYeIe+1Vq620O0LpQao2G9YQY+zUg=,tag:+dwaM6o6To/6ijhGLb6NEQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:u64DddS5e8XMUOf1xgSK8UqlSPXLOs2T3vv3g6V5jVvHx+x7KAXBU71NKL6m4jBYMrH+LPgdhxf2zM4NLbKRr2wlES+4nngAFXY51YRnuMedvg2/8CKk+BIyn2DCOp1qbbTCwApc1icbTPgMdCi5+eqkPnnE4lGIdCMxZ1jmtYA=,iv:aAdo82AmatwjY/WOlRjo5O9RaKRQWzJtLmVATAee8Po=,tag:ZIa39gd8BJuAvO3T09ZJGQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
+++ b/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
@@ -1,30 +1,30 @@
-apiVersion: ENC[AES256_GCM,data:ocA=,iv:VtZRDL7ig1yYX/QU0qa32s+u8sHKdYJQxmULqlOoCu8=,tag:XT5l/8XJBkrVe6G+3N/hQQ==,type:str]
-kind: ENC[AES256_GCM,data:CLclFZjX,iv:x+l2Y4zTZadUTEQoO9G6qbfCeXETAH3wGCA1xYJvFgg=,tag:JUC5yx3bcacinCwFH3DrzA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:5YiG3rWEQ4gQxS5vNYY4Vw==,iv:FYX7oaz1mhb1gAwXlVKxp/XOKe+5A87xQ8RnieleSzQ=,tag:ZteY5vZKnLW/EDE6WZWCQQ==,type:str]
-    namespace: ENC[AES256_GCM,data:Ng6hU6z0cGUo,iv:NDIW4IqnUzE9GOm0R9+4LcGxjg2UEWi9rdaXp5vdNsE=,tag:gEFGiYNinaAWsOi+p6ciQg==,type:str]
+    name: authentik-secret
+    namespace: authentik
 stringData:
-    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:hb9VGOsTM/FlP21W0BtAIF3xI3gKxSiN,iv:maS+iPYZRY9vy5Vpns18I+MCCPEQ2q80+F+mS+N7BXc=,tag:9BqKyaqb8ZRxbN9lpM1INg==,type:str]
-    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:tRzvBJxIGscWaTquxWOldGkh50HafY2uz1YVGPfvB2qnTBhNytPNZQ==,iv:5eHLRgNskYsTMUSp914aPedK5pDhn2/QFPgzwPzFaXo=,tag:nbXkU7vD8FLKxW78u0A2Rg==,type:str]
-    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:E8th26/ByQaEfvm/j5GCGILt1GMSybjEDr7rSRMuT1e96t2Sk2YdE5QmsBNOUttiSps=,iv:s4a1aVJ44OJ9Ko2+oFO/Ppbgli3L1CHi+uhWOp+zyEk=,tag:fdHJu9S0Ms5OHYQkHsHqvQ==,type:str]
-    grafana-oidc-client-secret: ENC[AES256_GCM,data:HwpEV4hcJG2wZE6KiunFa+o30syJPqmrE4prtxUmD6s=,iv:bdxY/0KBtm/rN9zTebv8VLaLDR14fht4ltVADS4oySE=,tag:HcHjSySKL7wK2ilRDlTBHw==,type:str]
-    headlamp-oidc-client-secret: ENC[AES256_GCM,data:6MCuM/ThhSKU0ek/cxUyPtkjiNttB8sLUnu2XsHOGTg=,iv:cjHHVYgh/C/QeU5kyLpVCS3MW8HNatmdFiomvThwf5g=,tag:hhnKxtz0ugcSY4xbhisFeg==,type:str]
-    outpost-token: ENC[AES256_GCM,data:Q/ndeNHF8sHYzaX7Lzs0tFX/nI8p1h/DKpHrGhBLHczxEHybgX6Pi8cT2SKJ5cqfQI9mB89tjQpYuWBd,iv:2aCrgv+RtpZ6dYfUvfB358MXQr5XHGly4+01fdbWYX8=,tag:V3NsgZtAVz2Br1vouTdTeA==,type:str]
-    portainer-oidc-client-secret: ENC[AES256_GCM,data:T95yaI5XalaPSjfjl7YiHheMQiRF+/C5Lg6TjF/b3uDDebASX1aRM31chvG4o4gl8KJDJlICbveVjDD53x8Ajw==,iv:Vh15VRJadRJ8XQ9Nbb9ctQ8bl/ROn9QXPlA1wBiFtfc=,tag:DiuuDOFQLAQDNCki+ogmlA==,type:str]
-    postgresql-password: ENC[AES256_GCM,data:qn8ksg4wWi2zS0AOC7p5V9H9PadSlj1aWK1JNe6qUy0=,iv:MwXj0ReZ2ZQykAszi+/FpHiQ5UQyrP0XplQ4/7oBn1k=,tag:FnqNP/BsVEBzorA8oXzyOw==,type:str]
-    redis-password: ENC[AES256_GCM,data:or32QkEIk5um4f46P6Hs/FP20FiZ2LllZ+GEMqKUdH0=,iv:wGvDDAPdbd+3OSl+EJ98la2BPSlk03lFLIziFNMUKlI=,tag:09o/C4PywLwaMA+r2xW34A==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:BLDY/8DpCnc+TeuE7uyJrA+zvZD5tcm4,iv:l4HHCyHvVqCExVawBNZ0DcMYsd5oqVaZiAMToN8E98s=,tag:8Ih4VotQDYtsiNnmNLrMjQ==,type:str]
+    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:l8RQTq++k5S9sXu1Q19E1idjhzLx2NHKc+SI+/f9AY4Y/bVXnxEyrA==,iv:eBwkEkOT9mBOQ6435by4Yw7Gt+GDY4xyh9w/1oU4K4M=,tag:tYZxD6AryOF9IlYz2MjfAQ==,type:str]
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:GXC1KQJe79Ljg25npin6DRU04ykqPt4O6Twzp/5hz1SYxU6wGhHUTED3RQOdFOvbyW8=,iv:0sLQ7JWqG7n686csPmH20Fnda2F/hRfFHUbQgEc3u78=,tag:HqFngn6vTtHCcW1dYNggPA==,type:str]
+    grafana-oidc-client-secret: ENC[AES256_GCM,data:i1esVa941j616BZZaxFp5ha6BM3F0PO5fzTfSM0hv6Y=,iv:1kRPZszXsKfNuKLdTcDX6SPUj+FejtC8+2SSdgwvRxM=,tag:yqFD8o6vV6f8Sf33W4f3Bw==,type:str]
+    headlamp-oidc-client-secret: ENC[AES256_GCM,data:X7Jl3miFqUeGVaTKDAz7tlDtcUeRntNP1rPfXkjO+is=,iv:RMll2EUebnhHxOr9nw6lSmmxciqNzx5x9xfu8VUMmFE=,tag:Em3EqdDQAh/CTCpz8TclNQ==,type:str]
+    outpost-token: ENC[AES256_GCM,data:oPiB1nnYgKoIzHhtpTVA8Oj/2UDVmWg7U8jQ/zy0NQp5N8wHcgcIgQNn0t5mIpBfvB3gFKRdSOHlQPPK,iv:6PZDB9paHFKcbyHnfklJYmYDOctRPDNtReSE6+87rFk=,tag:XqzgEuB9GfiFsPwWIDxtwA==,type:str]
+    portainer-oidc-client-secret: ENC[AES256_GCM,data:bHMDWneq1NS0aXa8YXPMCAcEWT78RYpHiRWmfPRDNBhsPjmVfahqF7Uc/RNFn19dtBtYLKcuNTu42pBIbYHlgA==,iv:77yLmgEneht7bG11DtFpNygNi9tkS0b5TeRX8X3ku2A=,tag:6wsUbEUaz/L/B98QiJ87dA==,type:str]
+    postgresql-password: ENC[AES256_GCM,data:kllmtrVMNJBK+XGFRuSj9LBMeJrgIvZnnppJb9qhqTU=,iv:V+EWPfo+67Wh/eawpoH1vUuml4RPfYohH7NDiUd5x5g=,tag:4+k+cZoljU+b0rD6CgI69g==,type:str]
+    redis-password: ENC[AES256_GCM,data:T708POBgIGyGcT+3NnyCSLcvSnvl4ue70oiNiQKAhPc=,iv:i7TDTP+JtXgPJNER6NVl1ZoyT2uYRPzIJRwrJMZaIb8=,tag:WHTt4jcEl70MZprv3HbVyQ==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRkNhS1drOTVNcGI4eUtw
-            Ni9pUVhnTHZGQWwwTkNHRlhic3g3Z0t3eXdjCjg0YTFRdVZHNEJYRjNsVjRUU0Z6
-            ZTZydmh3NEQ2V1JkVGJySHFhK2krZm8KLS0tIFJkdGJlUVFMczA1aWpONGo2QUs5
-            RzM3M1FrVUVRY0p5dkJyL2YvOURKR0EKm/EzEf+Htkcn9LAq0NeEar++03Xdeqb+
-            lz8vOA/mBqtryH+Rah6zOyChzGDFkJWakkVuR+IGjxJqSNYm8/JSlQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFWnViQm1aNlNMd2oxVUhT
+            T0NLeCtjaVNyMURhb3BNMzhpSEJ6S1pzRFdvCkxWZ3E0aWhZVFdNbUhqZmFZWEJ6
+            WDArVXdGL2t6cTRrOUhzK2dZR2lRZDAKLS0tIGlXdUwzNSswd1dvenVXYXZFckdM
+            aEVRdlE2UW1UVUlaRWNFZ1prZ012cnMKloCavY0cfPMbxAY1bS2rvJUZM18IFmT9
+            AxopG7sFUeRJhOW4abVqiD6Y8wIBITmBT1V8KIniy9C6SflksreJ/g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-25T00:51:23Z"
-    mac: ENC[AES256_GCM,data:mpXHG37hBA0u0Rn6W7yWyWuhDUekdxHSpolKrObIIyuseXR138Q3c/vt+Du0GUdjoipHUkV3HGnKVFMFt+jsdmPHUOpklmbzdouvnWtPG5Ij+9mx1K+t2SMnNf8+yOA7ZkDft9syd+1FVGv4KeV1K4jSRTYe73STlOEM0qfLwmk=,iv:oKm11yXW94q7RMfykUrqVCVCoK0HcRVaTKaKc2gCxMY=,tag:6WHGMzFHOxQfucISmaS3Mg==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:lROl6X9nq7LBMQeRobvcNeb5Nsux7m8+MlhE2W42wr0PmjQkXa2gdNicbfmylgIqYDvd4TmaVZUtTUaLgdh/Mw6Bc0x6cOdmkAmMKoz7bnwAKLkQGF9mI8ijmMFRZcS9ekrvBY+6Jzu2r/35hSH4b70PyDxjbbGuvo1Gh5GsnZM=,iv:joIngVf7kpelNbwjHJrc24H0SfGiUABn5mHeiyxXdaE=,tag:qotW+J3SvtGDxvcgOqCmKQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml
+++ b/k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml
@@ -1,5 +1,7 @@
-# Copy to cloudflare-token.sops.yaml, fill in token, then encrypt:
-# sops -e -i k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml
+# Encrypted SOPS secret. To create from template:
+#   cp cloudflare-token.sops.yaml.example cloudflare-token.sops.yaml
+#   # edit stringData.api-token, then encrypt:
+#   sops --encrypt --in-place cloudflare-token.sops.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml
+++ b/k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml
@@ -1,24 +1,24 @@
-#ENC[AES256_GCM,data:o2xpr/umwU1AU5jgRYh4IrkfI+EDmmeyx+XRUuxC9V9uCo7TvBQ2sz+6qL0Y32XZFbQCvrZZD1/XxNxpaNwoT0I=,iv:Z3P3GsYAJd6bNd6LOzQO6GEN0okhLSkbWzTflm8C4JI=,tag:1NzaQoQ+BwBxoBBmi/E1rA==,type:comment]
-#ENC[AES256_GCM,data:9W0K3IVmEWdBXaRl3dBrtAPf4E744Z24y1Ir2bcUZd3f9atIwherQh/VrWSWCuJ2K/U2bZJu2FNWNK0Ir41tJDdDQA1vOPlWo2PTIoIE,iv:LNH/bSBHaek/rftTK+3Mjc+IDUWoxeNLVse+DYyjzfo=,tag:45qeb0Cg9U2fRWJ+1ckJfA==,type:comment]
-apiVersion: ENC[AES256_GCM,data:ra8=,iv:8tbd9Hp4qyZdeBo0D55zBPDrUJKcJDJjiidu1h4aiz0=,tag:90rVuOrQHgj42YgT2+3Xcw==,type:str]
-kind: ENC[AES256_GCM,data:cgwISUZm,iv:6QuM75YSOOYhh+Htm0FQfTkTdkiVaA6aMlZdZiIzn8E=,tag:7atk1G9aO16fcJvohTIfkw==,type:str]
+# Copy to cloudflare-token.sops.yaml, fill in token, then encrypt:
+# sops -e -i k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:AbYMPWIB4YpfpdJBMF4BsXiO6y4=,iv:/thE4W+UID/W4uYjLOnStRWgTVCr8Hlguc5bGZztFwE=,tag:J0Ijl2h/KZvRelHA6M3DBA==,type:str]
-    namespace: ENC[AES256_GCM,data:wlFs9et4CiOfiCFo,iv:loZs0TTu8hjb5L9b/Ok/biIUMRi9ew71SmflpJxE33o=,tag:tcwipoatWXkzxbNKxYd6sw==,type:str]
+    name: cloudflare-api-token
+    namespace: cert-manager
 stringData:
-    api-token: ENC[AES256_GCM,data:M5c1fiB7PT4GBI92AYlnU3VZJtFjIcz4STByM3dV+hrQbSS5Ko7J7k4baOb/ukYCQ1ZkGQo=,iv:o3LkedIoMM/AnRFsXiraC3HmlXekhE8xhVzt2y5rI20=,tag:J1Q2S2qP5cPV9+8fTQcVGg==,type:str]
+    api-token: ENC[AES256_GCM,data:ZQYmUPnbrX9WsZPYZU8uebcAWAcyWvpJx/o24HqHur4NvryYVhHE6N3BRjJErWpVQqXIsiM=,iv:GiIzM8UFDIGw9PymrS8YLwZvl3Tr1eS2SWlXtmEV4L0=,tag:nHsw2nxqLeBdL/zboVwxRg==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuM21yYy9jWTFIRE5YM3Bp
-            aDgyeGk1anlFVFNLcGk3STlzd2lXQ2FIS3pVCnY3M2xDK2RjbVo4cDJ6N21IYk5Y
-            SkhtcVBRNlFBdWhIdDIyeGIvS0NyUTAKLS0tIEJObEdxdm5MTFUxaDQ0MUprTzdM
-            bFo3Z3N6dmNQTm9CYjd5RzZrUnduQUEKdfTVg0DQEo13ObvYr2lHBsRCu6jH9K9c
-            J577kFMoSRkju+f4VQ1YszUVmMJgg7ptECKmPNOj71rIYweg9iNjhA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0SXR4OGU4MmpDUHg5eXNT
+            RFBlTlNydkRqRzZSUWFqRWhqWkZLWHlqM2c0CkFOLzdGV2pPWmM4bEM3Q1FJdnkr
+            RUhjbzRvYnZhQ1JkQ0hHZCtuamExdW8KLS0tIHdPTnVDYS9maW9Na0lYUHVCYkly
+            WG12K3R2aVRUMEowYmZxOFJ4dkdnSmcKYErp0pdEeR7vYP7XdS6c+TozBvg6BS70
+            SUpFCDOGZJanE0pe7hrMQquFYarCzDQ24zJkTFqhnfTyhOOPhl8WaA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-05T18:15:00Z"
-    mac: ENC[AES256_GCM,data:+q9adbeb/9pLG3HVDj4NQE7HcyKUFTBQnf3pgKeTPqxvaiAlFqsPCBgoEluFICN5cxpALfWFwMEy64KqHxo26pa0HxUbNNxUEA6OynAPn0fJgvQKDS4sogPwebAVm9ONJ3jS2vvI8UIhRnxQD0pI4OVUlhGUUwxbJ26GW3EqK2g=,iv:wTYopm/lF2KotOHDOrEvCrZ8MRA9OdEp82bJ1PlARw8=,tag:jk7B7TXMDPKpVTLkeptnEw==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:LLQBzgYTZ+W9b3wGhO/E4FXLZ+CE31FIGynb458ILm3cAjZahb6Ckeff7K5+sD+wLvq09dCyTn8qtajuX8f4rWbZFVG4IOQ4cdMHwq51jmNE++k/4diKl5SzAqJfW1DiOlwiqH1VRK8X3ITWEu+VRhRBj8ZV+7HGH8eG0Vy7XSk=,iv:FnMCAJ4X1jslXKdM2YdQdv0reCerF3OXW6M1u7XgePs=,tag:Dm95PCg7fkno3P9GKpRWlw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml
+++ b/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml
@@ -1,28 +1,28 @@
-#ENC[AES256_GCM,data:OfbA41pz6AO1THdyDvyWAKQ63dW1jewug0Mwr77UtxbGZTyZqv3k3va173T0YWK3k4NIHavK,iv:wzIGOHMD/8Qk/KQ5NH1pGbL2iY07PBP4LJQwcyyOXO8=,tag:hWRdjU0QpK9xnSPeIVt0NQ==,type:comment]
-#ENC[AES256_GCM,data:SW5MJjrqhNV2CKvTKbAUVUGxOEoXRU3g2F4wm4eF+WoMctiPVZOruyfcrKrO,iv:wV++mdTtKagX1NQfJc+SIYFKfVnP73lRot5F2kZmvrg=,tag:Za40Eoe+gF7QJa9isphpBg==,type:comment]
-#ENC[AES256_GCM,data:L5zkOS3FyfkTGAEP0JZizMTo5pGTMVoAuBksChyBfmetEgXUrqIrQBohq3bX06M63h49XvHbZ3j/7jyookvZ3x+2R+AHIpvE1NTh1B2w,iv:N5WQcbcvAwUVdqY7Rt/f7/jJJJlv8592IRJlAzpkZTk=,tag:BfDPioS0WFnFp73oH67j5Q==,type:comment]
-#ENC[AES256_GCM,data:OMkrmQmwAYq2gqs5GdGCBDjoeVM3Ap2bZTjdKZ9xo+v0lPmUQ7du8YaCJFSw/cK/xSsE,iv:qbEf3JSIzYdJKcv+fCyItJyAcNWX37W7D51Uo0rqhN4=,tag:VzpafJ0S4GxWq1POj9pkGA==,type:comment]
-apiVersion: ENC[AES256_GCM,data:K+A=,iv:2GG4NcSARVrGOhC973+HAmORu/2VnIhlqCuVA//0zXU=,tag:ApR95+VBkw4AYhKaprQJTg==,type:str]
-kind: ENC[AES256_GCM,data:eRmk1VM4,iv:1IXPtU4auy1VptrD8wf1NCa+fgeWamMTIk41U2kdL94=,tag:nTugRA9g0HofOF0c8boLMQ==,type:str]
+# TEMPLATE: Copy this file to smb-credentials.sops.yaml
+# Fill in username and password, then encrypt:
+#   sops --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
+#     --encrypt --in-place smb-credentials.sops.yaml
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:ivc3IDxIpfo=,iv:hJzI0cUMLuGM63GyEOEDr30bEQjCdV5Ny6QJQ6G9ybU=,tag:SBYzTE5MGGm5EWrCnlmNqQ==,type:str]
-    namespace: ENC[AES256_GCM,data:kwlH36DV/Zjrck0=,iv:GHE4GBQKPL4EB6hGyukp859Zk96HJpgKUMk8HO/Hnh4=,tag:5Rs7k4JqbdhLZXBUCU5Uaw==,type:str]
-type: ENC[AES256_GCM,data:rb0ZA5DR,iv:PXxzBnXKClD0VFB04d7sImn0Q73ZHaevl3KgH+sVUZ8=,tag:asAVCSz+qUUegMy8RWgr0A==,type:str]
+    name: smbcreds
+    namespace: kube-system
+type: Opaque
 stringData:
-    username: ENC[AES256_GCM,data:PQiHoUTXeqxJ,iv:i0fmB5RdyYVHLsQEMIAPPLJobfeHz7SJCSeUZbesyVc=,tag:LjceIqnKOWSxJ+tVj2vwCw==,type:str]
-    password: ENC[AES256_GCM,data:VCzGCaJhoCpUrLPp,iv:cbnVMa0ePVBDv8x4i5LeGA1Cr54gjmuJQRlG+s0VpIA=,tag:4VXjrKlsBFzvdfezu4910w==,type:str]
+    username: ENC[AES256_GCM,data:4qPL9z6fdIk3,iv:+icOWjbZQf2yGS/eVK7cCbKz1ZpLV3VdD7xogUuu71Y=,tag:C3lAvXlfbb6K+IqyusDNCw==,type:str]
+    password: ENC[AES256_GCM,data:kH/e8EpW32RyBE7F,iv:2ihJjHHsXgEJ+bmsOqz4JGE22IjJVUv/fbxS+CdtTGA=,tag:3Ao7vHTXt/xPPUOR8SnReA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiQWVvdkkrb2dhNE1xbjFr
-            c3IvNGFlRW9CLy9obEpjT0NDWE9KYjRJdlFzCjdaN01mUm56VWJSTTZBUnZVNWRS
-            U3dwOUpJOCtxbDVIN3JjR1BuQXp2azAKLS0tIFoyQVBMaGNQNDRURGZrVGpnZFJC
-            dFFZeUlpSW8wMVNlYlp2empZV0tXak0KAoDOEuEbhCh4ve/t9r3/EaV37zg0Xeik
-            LTlGNEC1RH6VWexYuNZe5vTKp7mwNEpCBwjFV2430YrDUM7moKA2hg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3clhSenI4b2VJYWFLdGFK
+            Vk8zelA0QmZlRW9raCtSMnVDUTVnaVEwY3hrCmN5YVdnZ1ArdmxOT2VBbW1oQWJG
+            dFVnSlY4MnkzN3lGQlN1anFQRVhXVTQKLS0tIEx2OTdpTGV1d09XOEtadnB3aGVx
+            WExWS0s1OHpDdjQyam1ENlBjY2VWSEkKkQirPr06G7pADN6Z52o8gJOhdFnl4Mwt
+            FDtVQCMAzIKpc6RLo+YKUWUNySbt8ixoTWcMXD3o3qVrRFFsZ6eKuA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T16:20:07Z"
-    mac: ENC[AES256_GCM,data:LgFzXXPw5qvAYP5IkGyOo7fyfz6Vmgf4NbnMUCFIZxOVaHWC6rqmclPv3SpMuAQ5QBbcSnH0+1LXmZ90ATt2TIKl6UOl4Pqs50eNeCM+oQSWaBXIcbheMgb48TiJywe1U88dtdopdzS2s0THtB8O3bgALCwtRdyTVmI8ZfM9l9k=,iv:hS1mBTHA1CDNb5miN0eOLByuHzWxjidZJwomLO5H4w8=,tag:+ZPxuh1UVjpifYXOnUJ4YA==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:/WTR3/6DJcwVHydac6FLy5o1C01DnXju3Zch/Z/6qa8yCbMgg2GZ2x2rEdmhC3BJsc3lu4362MTfQKVYesBkhJzMaCEkQSIUCDxHNQ3FEH3AtSMJeRWA2k4u7/R2/1wUSLutCx/OMzIJ/AhSQZcMn6d/r1Bb2GITuTdqxqURhRU=,iv:nUZN1DyzgetBapmsbG6iKZFT2Fyw3GEABFNbo9X3y8w=,tag:UQ1HNfKKcB51H6nbIlDsCQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml
+++ b/k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml
@@ -1,7 +1,7 @@
-# TEMPLATE: Copy this file to smb-credentials.sops.yaml
-# Fill in username and password, then encrypt:
-#   sops --age age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085 \
-#     --encrypt --in-place smb-credentials.sops.yaml
+# Encrypted SOPS secret. To create from template:
+#   cp smb-credentials.sops.yaml.example smb-credentials.sops.yaml
+#   # edit stringData values, then encrypt:
+#   sops --encrypt --in-place smb-credentials.sops.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k3s/infrastructure/controllers/external-dns/pihole-docker-password.sops.yaml
+++ b/k3s/infrastructure/controllers/external-dns/pihole-docker-password.sops.yaml
@@ -1,22 +1,22 @@
-apiVersion: ENC[AES256_GCM,data:mF8=,iv:ieTPm2yWzdCnDEFcizMIiNv0XOB8Zd4c9hUtDR0KAIE=,tag:yOkNFeG2Exy4HwmG1FItPQ==,type:str]
-kind: ENC[AES256_GCM,data:hRMoGL7P,iv:CY35vm56UZb9AzjuDYieCMoXdYIrssJM8/r0yHth47I=,tag:yYwybzOU5wfqfdDq3zcuSQ==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:DsmLPQYaDWZccCJQtBo1RsbMdO3JIQ==,iv:ZpwcDINlXZkzhYwFHlwiOQzfUBtaE2YLlXo9O/6u+YU=,tag:LowPyxEch9xcqkR+2GPxLA==,type:str]
-    namespace: ENC[AES256_GCM,data:SDr5aTS++aYOXS5J,iv:e3pNUtshh/j5LRqP4e/77Ff70Pz0+3DsSA08WOzf/8k=,tag:UVOfaVU7ZVCZAe2+o/HO/A==,type:str]
+    name: pihole-docker-password
+    namespace: external-dns
 stringData:
-    password: ENC[AES256_GCM,data:BBQBqA0=,iv:g7dK1Ey8AWVJICYQ9LtyNYyHwSt+vp7Bz1J8gTascPA=,tag:QVwTfAAvDtpTNBpkMz8+Dg==,type:str]
+    password: ENC[AES256_GCM,data:1Hgo++k=,iv:XroeDpKemlslEBwVicHPa9F7M9WS7645jsHTmeVLO58=,tag:oENeI12Bb4bYI4TvDkY1ig==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByaVNXYUV6TTc3N1BlTjhW
-            TGgyMnhPOTFKMjhocFNiemtNREtLcXQ5TVN3CjNtRkRqckxqNU4yRjYwKyttZEtR
-            M2dQVUxncVhpbG5ocThaVitaSDRQeWsKLS0tIEFVeW9jV3lUOU5lRjNOYWxrOTdk
-            WFpxL2ZVaTlSVldmRFYwWHNGTlduNjQK/wcQCerjj1ztcoh/vIlow8Ovm/leEZNW
-            mFbPSsu3W1bp7LCyHxjPGWfM0D2uh1dCK/Cn5W4FGYJF6whm7nBTWQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3U3lpT3VzQ3RONGs5eSsw
+            QVEwS2QzejQ4dW9nWXRpc2w0TzNqcU00RzFJCjFtMnFqY09zUmFpVFFCb1hubEw0
+            aFdXb2tpNTBLR29FOFhoNjJjd3NZOVEKLS0tIEFkN2k3VmovdmdyY3hvaDVFd1M3
+            elNjV3BJUUUwQzJaUEg3dVFHYVFaY1UKVpJ5PdIQ6hfVPcDPPQN+pqW4eJ9DZfnz
+            TundtncIBk44rsy36p+zHhUnNjwEHhud/mltu+pA/dR6ToroViebBw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T18:53:47Z"
-    mac: ENC[AES256_GCM,data:++iAlwPgtb7vB9yvINrgm4FSY0DFex+mg7HREVlefQUbb8saCVMNeyFKdvI6W70pSReAxVAMmAiyNtCZzYjtpRPOmKZfxvSX4JDwXtJz8V0XMWJtW4qz7s4IX46dXa/BWVLJAd3nEERKbXeZ+W9n9eYyj7G4z+oad5xSNWtgYHw=,iv:lZNq/rhKRjX7INDrXH2yerbA5E9YWvCSJEr6rHVfS7M=,tag:DIJ8nT21ih2dOQKgPZi9Qg==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-06-02T01:03:04Z"
+    mac: ENC[AES256_GCM,data:gfNrKpMOWSCSreeHIeecmcW4CqgsiT86P1ZLMvWXaYHPPqdQmEIdAw3iNB+rm4J6U4+qfTz/qAgDy5w4YNY3WxuqPU4GGUFuOiNe/Q3oSIlw9DMjqAmFnXoY8NsYedh8tcPVXnKMHDGk8UwgkY8YneSnG5T61GQL3osf2x+yzjM=,iv:LNQSSmvtV95pYNNHspMojhpyDUOR/LLr6ZjTxZoazzI=,tag:43iSHFkooxcmWiU71+rucw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
## Summary

Re-encrypts 15 SOPS secrets that were missed in PR #166. These still had `apiVersion`/`kind` encrypted, which would cause `kustomize build` to fail with `Object 'Kind' is missing` now that `--skip-secrets` has been removed from CI (PR #167).

## Root cause

PR #166 only re-encrypted the 5 monitoring secrets. The remaining secrets in `applications/` and `infrastructure/` were created before `.sops.yaml` had `encrypted_regex: ^(data|stringData)$`.

## Affected files

- `k3s/applications/headlamp/headlamp-oidc-secret.sops.yaml`
- `k3s/applications/recyclarr/recyclarr-secrets.sops.yaml`
- `k3s/applications/prowlarr/prowlarr-apikey.sops.yaml`
- `k3s/applications/radarr/radarr-apikey.sops.yaml`
- `k3s/applications/sabnzbd/nordvpn-credentials.sops.yaml`
- `k3s/applications/sabnzbd/sabnzbd-apikey.sops.yaml`
- `k3s/applications/qbittorrent/nordvpn-credentials.sops.yaml`
- `k3s/applications/qbittorrent/qbittorrent-credentials.sops.yaml`
- `k3s/applications/pihole/pihole-k3s-password.sops.yaml`
- `k3s/applications/pihole/pihole-admin-password.sops.yaml`
- `k3s/applications/sonarr/sonarr-apikey.sops.yaml`
- `k3s/infrastructure/controllers/external-dns/pihole-docker-password.sops.yaml`
- `k3s/infrastructure/configs/smb-storage/smb-credentials.sops.yaml`
- `k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml`
- `k3s/infrastructure/configs/cert-manager/cloudflare-token.sops.yaml`

Addresses Copilot review comments on PR #167.