### PR TITLE
chore: gitignore *.sops.yaml.tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ applications/cdk8s/imports/
 .omo/
 # TS build artifacts
 applications/cdk8s/dist/out-tsc/
+
+# SOPS encryption temp files (created by sops CLI during in-place re-encryption)
+*.sops.yaml.tmp


### PR DESCRIPTION
Add `*.sops.yaml.tmp` to .gitignore to prevent accidental commits of SOPS in-place encryption temp files.

Discovered during PR #168 (`fix/re-encrypt-remaining-sops-secrets`) where sops CLI creates `.sops.yaml.tmp` siblings when re-encrypting files in place. They were accidentally staged and committed, then cleaned up in the same PR.

Adding this guardrail so the cleanup step isn't needed in future SOPS re-encryption PRs.