### PR TITLE
feat(k3s): deploy unpoller metrics exporter

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -76,7 +76,7 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths 2>&1 | tee /tmp/flux-diff-output.txt
+          flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master 2>&1 | tee /tmp/flux-diff-output.txt
 
       - name: kubeconformist (placeholder)
         # actionlint:ignore[if-cond]

--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - sabnzbd/
   - qbittorrent/
   - sense-exporter/
+  - unpoller/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/unpoller/deployment.yaml
+++ b/k3s/applications/unpoller/deployment.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unpoller
+  namespace: unpoller
+  labels:
+    app.kubernetes.io/name: unpoller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unpoller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unpoller
+    spec:
+      serviceAccountName: unpoller
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      containers:
+        - name: unpoller
+          image: ghcr.io/unpoller/unpoller:v3.2.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9130
+              protocol: TCP
+          env:
+            - name: UP_UNIFI_DEFAULT_URL
+              value: "https://192.168.1.1"
+            - name: UP_UNIFI_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: unpoller-credentials
+                  key: UP_UNIFI_DEFAULT_USER
+            - name: UP_UNIFI_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: unpoller-credentials
+                  key: UP_UNIFI_DEFAULT_PASS
+            - name: UP_UNIFI_DEFAULT_SITE_0
+              value: "all"
+            - name: UP_UNIFI_DEFAULT_VERIFY_SSL
+              value: "false"
+            - name: UP_PROMETHEUS_HTTP_LISTEN
+              value: "0.0.0.0:9130"
+            - name: UP_UNIFI_DEFAULT_SAVE_SITES
+              value: "true"
+          startupProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 10
+            failureThreshold: 30
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"

--- a/k3s/applications/unpoller/kustomization.yaml
+++ b/k3s/applications/unpoller/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - deployment.yaml
+  - unpoller-secret.sops.yaml
+  - service.yaml
+  - servicemonitor.yaml

--- a/k3s/applications/unpoller/service.yaml
+++ b/k3s/applications/unpoller/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: unpoller
+  namespace: unpoller
+  labels:
+    app.kubernetes.io/name: unpoller
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: unpoller
+  ports:
+    - name: metrics
+      port: 9130
+      targetPort: metrics
+      protocol: TCP

--- a/k3s/applications/unpoller/serviceaccount.yaml
+++ b/k3s/applications/unpoller/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unpoller
+  namespace: unpoller
+automountServiceAccountToken: false

--- a/k3s/applications/unpoller/servicemonitor.yaml
+++ b/k3s/applications/unpoller/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: unpoller
+  namespace: unpoller
+  labels:
+    app.kubernetes.io/name: unpoller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unpoller
+  namespaceSelector:
+    matchNames:
+      - unpoller
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/k3s/applications/unpoller/unpoller-secret.sops.yaml
+++ b/k3s/applications/unpoller/unpoller-secret.sops.yaml
@@ -4,8 +4,8 @@ metadata:
     name: unpoller-credentials
     namespace: unpoller
 stringData:
-    UP_UNIFI_DEFAULT_USER: ENC[AES256_GCM,data:fFniFHVx4ReOg+JHpeUwf8S5NpMXtxWBJQ==,iv:g0tBl5M7waxkxtkzjzuP6hNPMzyGTBAxhxQS2rvmImA=,tag:EvVKJNpW1xf1f+giG/tnUg==,type:str]
-    UP_UNIFI_DEFAULT_PASS: ENC[AES256_GCM,data:ZGgKRZe18Ph9KsbfstN7e6a8alw667RONw==,iv:9l89W8blPHQRrVOMdzFKzRaGJLkrrfBQMiFcaNVHwWc=,tag:UrIO/eQUpjnJMBREdHtqHA==,type:str]
+    UP_UNIFI_DEFAULT_USER: ENC[AES256_GCM,data:Y0d9pTmXMo1ZVXfv,iv:/++pmhkx677qzE6elgXiv6Fy1MiAKY65yXv91kr8mrw=,tag:24gybbE6PpxUGCIYwXwUcQ==,type:str]
+    UP_UNIFI_DEFAULT_PASS: ENC[AES256_GCM,data:l+vIhS9RHq+RHP+b,iv:0qiyJ1FBQM01hXtlYuGRDhPBSkPINqZMvkQ/REy03CI=,tag:L7fH0ry/tbL59W7T/uSILg==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
@@ -17,7 +17,7 @@ sops:
             OGd3cThoTFQ2L1ZieGo4emlNL1F6L0UKChggvNKx2JRD4Q8MYjYa8mf/sxVwR3Xg
             bhrFstzoKGMbL+m0p05ow0A0x+STMrG0rQX3wwLEnh+kb21yb5VhhQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-03T21:28:21Z"
-    mac: ENC[AES256_GCM,data:JmXheffP52rHN3vKmuG4x8wNyDJQ17VljM8hBtcW3Rue8kLVDesbPa3s9FXVaA/HXgfFZHMSDHuhDrOJ/30zyM0DAYE8rmAdAOoKp1aEoLcg4rZxbL9FN5UE+M6EPndTZe52CUE9YaeRy7XkFemx0LpUQatNV/1AOZeBY76HXM4=,iv:o9mr3YSrNW+wmwuK5Mx8D5plHVAtfn9BRVPrmCUQ1RU=,tag:58lHHPBbt3DXHL3EZwQLUA==,type:str]
+    lastmodified: "2026-06-03T21:45:32Z"
+    mac: ENC[AES256_GCM,data:/wcw+uXxCBSoGhz3MRQtJW7lv7NSH1FehDMPHIyQcl8ppfBnO4LJPB2vQOhl9/rEVNzSzCNl5XFM3AwoBfzVNmJW3ftZTiRIm7LATYPQQykJxGEh9A8BTn5ngZlnYdSZIcoUXB2p36WVsjimMbpY8BS7mQISVTM1S8OEXDYlHek=,iv:U7yI7gK9vuhCF0+yHHkc5sS4h31mJ9RwGOU26xoPRmg=,tag:3heMwBmjehJwXEkswuWa+A==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/applications/unpoller/unpoller-secret.sops.yaml
+++ b/k3s/applications/unpoller/unpoller-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: unpoller-credentials
+    namespace: unpoller
+stringData:
+    UP_UNIFI_DEFAULT_USER: ENC[AES256_GCM,data:fFniFHVx4ReOg+JHpeUwf8S5NpMXtxWBJQ==,iv:g0tBl5M7waxkxtkzjzuP6hNPMzyGTBAxhxQS2rvmImA=,tag:EvVKJNpW1xf1f+giG/tnUg==,type:str]
+    UP_UNIFI_DEFAULT_PASS: ENC[AES256_GCM,data:ZGgKRZe18Ph9KsbfstN7e6a8alw667RONw==,iv:9l89W8blPHQRrVOMdzFKzRaGJLkrrfBQMiFcaNVHwWc=,tag:UrIO/eQUpjnJMBREdHtqHA==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVOHhOcmRkVkd1Z210Zk05
+            Qlkwc2syc3ozSXQvZ0c3SHpsSUcvaWo0RkFNClNaV3VhajEyOVFUb3pVTjZjdllk
+            d3E0ZEhhMmc2Snp1NkdSS3YrcGpjN0kKLS0tIElvWU81bjU1b1VnTDFYYW9BR0pQ
+            OGd3cThoTFQ2L1ZieGo4emlNL1F6L0UKChggvNKx2JRD4Q8MYjYa8mf/sxVwR3Xg
+            bhrFstzoKGMbL+m0p05ow0A0x+STMrG0rQX3wwLEnh+kb21yb5VhhQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-03T21:28:21Z"
+    mac: ENC[AES256_GCM,data:JmXheffP52rHN3vKmuG4x8wNyDJQ17VljM8hBtcW3Rue8kLVDesbPa3s9FXVaA/HXgfFZHMSDHuhDrOJ/30zyM0DAYE8rmAdAOoKp1aEoLcg4rZxbL9FN5UE+M6EPndTZe52CUE9YaeRy7XkFemx0LpUQatNV/1AOZeBY76HXM4=,iv:o9mr3YSrNW+wmwuK5Mx8D5plHVAtfn9BRVPrmCUQ1RU=,tag:58lHHPBbt3DXHL3EZwQLUA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - sabnzbd.yaml
   - qbittorrent.yaml
   - sense-exporter.yaml
+  - unpoller.yaml

--- a/k3s/platform/namespaces/unpoller.yaml
+++ b/k3s/platform/namespaces/unpoller.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unpoller
+  labels:
+    app.kubernetes.io/name: unpoller


### PR DESCRIPTION
## Summary

Deploys unpoller v3.2.0 as a Flux-managed K3s application that scrapes UniFi network metrics from the UDM SE at https://192.168.1.1 and exposes them to the existing kube-prometheus-stack via a ServiceMonitor.

- Adds platform namespace \`unpoller\` under \`k3s/platform/namespaces/\`.
- Adds raw workload manifests (ServiceAccount, Deployment, Service, ServiceMonitor) under \`k3s/applications/unpoller/\`.
- Uses a SOPS-encrypted placeholder Secret for UDM credentials; real values must be set post-merge.
- Wires the new app into \`k3s/applications/kustomization.yaml\` and the namespace into \`k3s/platform/namespaces/kustomization.yaml\`.
- Single replica, hardened security context (runAsUser/Group 65532, readOnlyRootFilesystem, drop ALL caps, no SA token mount).
- Official v3 single-controller env vars: \`UP_UNIFI_DEFAULT_URL\`, \`UP_UNIFI_DEFAULT_USER\`, \`UP_UNIFI_DEFAULT_PASS\`, \`UP_UNIFI_DEFAULT_SITE_0=all\`, \`UP_UNIFI_DEFAULT_VERIFY_SSL=false\`, \`UP_PROMETHEUS_HTTP_LISTEN=0.0.0.0:9130\`, \`UP_UNIFI_DEFAULT_SAVE_SITES=true\`.
- Grafana dashboard work intentionally moved to jander99/homelab-dashboards#13.

## Validation evidence

- \`kustomize build k3s/platform/\` succeeds and renders Namespace \`unpoller\`.
- \`kustomize build k3s/applications/unpoller/\` succeeds and renders ServiceAccount, Secret, Service, Deployment, and ServiceMonitor for unpoller.
- \`kustomize build k3s/applications/\` succeeds and includes the unpoller workload.
- \`flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths\` → **exit 0** (5 passed).
- \`flux-local diff ks ...\` shows only the expected unpoller additions (Namespace, ServiceAccount, Secret, Service, Deployment, ServiceMonitor).
- \`sops -d k3s/applications/unpoller/unpoller-secret.sops.yaml\` → exit 0; contains only \`UP_UNIFI_DEFAULT_USER\` and \`UP_UNIFI_DEFAULT_PASS\` keys (placeholder values, no real credentials).

## Post-merge runtime verification (REQUIRED)

Live cluster/Prometheus verification is **out of scope for this PR** because Flux only applies \`master\` and the merged Secret contains placeholder credentials that cannot authenticate. After merge, run:

\`\`\`bash
flux get kustomizations -A | grep -E 'apps|platform'
flux reconcile kustomization apps --with-source
flux reconcile kustomization platform --with-source
kubectl get namespace unpoller -o wide
kubectl get deployment,svc,servicemonitor,pods -n unpoller -o wide
kubectl rollout status deployment/unpoller -n unpoller --timeout=5m
kubectl -n unpoller port-forward svc/unpoller 9130:9130 &
sleep 2
curl -fsS http://127.0.0.1:9130/metrics | head -20
\`\`\`

Then replace the placeholder credentials with real UDM read-only values via \`sops k3s/applications/unpoller/unpoller-secret.sops.yaml\` (requires \`SOPS_AGE_KEY_FILE=~/.kube/k3s-homelab-age.agekey\`). After that, \`unifi_*\` metric families will populate in Prometheus.

## References

- jander99/homelab#154
- jander99/homelab-dashboards#13