### PR TITLE
fix(k3s): disable unpoller InfluxDB output

### DIFF
--- a/k3s/applications/unpoller/deployment.yaml
+++ b/k3s/applications/unpoller/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: "0.0.0.0:9130"
             - name: UP_UNIFI_DEFAULT_SAVE_SITES
               value: "true"
+            - name: UP_INFLUXDB_DISABLE
+              value: "true"
           startupProbe:
             tcpSocket:
               port: metrics


### PR DESCRIPTION
## Summary
- disable unpoller InfluxDB output with `UP_INFLUXDB_DISABLE=true`
- prevents repeated writes to local InfluxDB at 127.0.0.1:8086 when only Prometheus output is used

## Validation
- `kubectl kustomize k3s/applications/unpoller` renders successfully and includes `UP_INFLUXDB_DISABLE=true`
- `kubectl kustomize k3s/applications` renders successfully
- `kubectl kustomize k3s/platform` renders successfully
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` passed: 5 passed
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master --output-file /tmp/opencode/flux-diff-output.txt` shows only the unpoller Deployment env addition

## Notes
- Official/source-backed config maps `UP_INFLUXDB_DISABLE` to `influxdb.disable`; setting it to `true` disables only the InfluxDB output plugin.
- Prometheus metrics output remains enabled.