### PR TITLE
fix(renovate-validate): update renovate to v40 for managerFilePatterns support

### DIFF
--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  RENOVATE_VERSION: "39.264.1"
+  RENOVATE_VERSION: "40.5.0"
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The renovate-validate workflow was using renovate v39.264.1, but the `renovate/migrate-config` branch (PR #183) uses the new `managerFilePatterns` option in the `flux` and `kubernetes` sections. This option was introduced in renovate v40 and is not recognized by v39, causing the validation to fail.

## Fix

Update `RENOVATE_VERSION` from `39.264.1` to `40.5.0` (latest stable v40) in `.github/workflows/renovate-validate.yaml`.

The v40+ validator:
- Accepts both old `fileMatch` and new `managerFilePatterns` 
- Correctly validates the migrated config on `renovate/migrate-config` branch

Tested locally:
- Master config (old `fileMatch`) → validates with v40 ✓
- PR config (new `managerFilePatterns`) → validates with v40 ✓