### PR TITLE
ci: add yamllint, drop continue-on-error on flux diff, add pre-commit

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -1,12 +1,25 @@
 name: Flux Validate
 
 on:
+
   pull_request:
+
     paths:
+
       - "k3s/**"
+
       - "applications/cdk8s/**"
+
       - "package.json"
+
       - "yarn.lock"
+
+      - ".github/workflows/**"
+
+      - ".yamllint.yaml"
+
+      - ".pre-commit-config.yaml"
+
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -17,6 +17,7 @@ env:
   FLUX_LOCAL_VERSION: "8.2.0"
   KUSTOMIZE_VERSION: "v5.7.1"
   FLUX_VERSION: "2.8.7"
+  YAMLLINT_VERSION: "1.38.0"
 
 jobs:
   flux-validate:
@@ -50,6 +51,9 @@ jobs:
       - name: Install flux-local
         run: pip install flux-local==${{ env.FLUX_LOCAL_VERSION }}
 
+      - name: Install yamllint
+        run: pip install yamllint==${{ env.YAMLLINT_VERSION }}
+
       - name: Configure SOPS age key
         env:
           SOPS_AGE_KEY_CONTENT: ${{ secrets.SOPS_AGE_KEY }}
@@ -62,6 +66,20 @@ jobs:
             echo "No SOPS_AGE_KEY secret set; encrypted kustomizations will be skipped"
           fi
 
+      - name: Lint YAML
+        # Catches indentation, trailing-space, duplicate-key, and other
+        # YAML bugs that the kustomize-build step would only report
+        # opaquely. Scoped to k3s/** and .github/workflows/** to avoid
+        # noise from docker/** (existing trailing-space issues tracked
+        # separately).
+        run: |
+          yamllint -c .yamllint.yaml \
+            k3s/applications/ \
+            k3s/infrastructure/ \
+            k3s/platform/ \
+            k3s/clusters/homelab/ \
+            .github/workflows/
+
       - name: flux-local test
         id: flux_test
         run: |
@@ -72,8 +90,11 @@ jobs:
 
       - name: flux-local diff
         id: flux_diff
+        # NOTE: no `continue-on-error: true` here. A diff failure is a
+        # real signal that the kustomize build is broken (see PR #188
+        # for the indentation bug this caught). The `if: always()`
+        # still lets the post-comment step run regardless.
         if: always()
-        continue-on-error: true
         run: |
           set -o pipefail
           flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master 2>&1 | tee /tmp/flux-diff-output.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+---
+# Pre-commit hooks for homelab.
+#
+# Install once:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Run on demand:
+#   pre-commit run --all-files
+#
+# The yamllint hook matches the CI check in flux-validate.yaml so the
+# same indentation / trailing-space / duplicate-key rules fire on
+# `git commit` instead of waiting for a PR. Catches the class of bug
+# from PR #188 (env list with inconsistent indent) at commit time.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        # SOPS-encrypted files have padding trailing whitespace on
+        # purpose; the data block is fixed-width base64.
+        exclude: '\.sops\.ya?ml$'
+      - id: end-of-file-fixer
+        exclude: '\.sops\.ya?ml$'
+      - id: check-merge-conflict
+      - id: check-yaml
+        # yamllint (below) does the real validation; this one just
+        # parses. Disable its key-duplicates and indentation rules so
+        # it doesn't double-fail on the same thing.
+        args: ['--allow-multiple-documents']
+        exclude: '\.sops\.ya?ml$'
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+        exclude: '\.sops\.ya?ml$'
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        # Use the project-level config; if absent yamllint uses its
+        # built-in default (which would fail the existing repo on
+        # line-length, document-start, and truthy).
+        args: ['-c', '.yamllint.yaml']
+        # Mirror the CI scope so devs and CI agree on what gets linted.
+        files: '^(k3s/|\.github/workflows/)'
+        exclude: '\.sops\.ya?ml$'

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,66 @@
+---
+# yamllint configuration for homelab.
+#
+# The indentation rule is the most important one — it's the rule that
+# would have caught the bug in PR #188 where two `value:` lines under
+# an env list lost 2 spaces of leading indent and broke kustomize build.
+#
+# Line-length, document-start, and truthy are disabled because:
+#   - K8s/Helm YAML frequently has long labels and matchExpressions
+#   - K8s manifests in this repo don't consistently use `---`
+#   - GitHub Actions triggers (`on: pull_request:`, `on: workflow_dispatch:`)
+#     have null values that yamllint flags as truthy by design
+#
+# Extend yamllint's `default` ruleset and override only what we need.
+extends: default
+
+# Files yamllint should not touch. These are out of scope for our linter:
+#   - gotk-components.yaml / gotk-sync.yaml : Flux-generated, untouched by hand
+#   - *.sops.yaml                            : SOPS-encrypted, base64 content
+#   - k3s/bootstrap/ansible/                 : Ansible playbooks, not K8s YAML
+#   - node_modules/                          : frontend deps (future-proofing)
+ignore: |
+  **/gotk-components.yaml
+  **/gotk-sync.yaml
+  **/*.sops.yaml
+  k3s/bootstrap/ansible/**
+  node_modules/
+
+rules:
+  # Hard-disable rules that don't fit this repo
+  line-length: disable
+  document-start: disable
+  truthy: disable
+  octal-values: disable
+
+  # Stricter empty-lines: 2 max consecutive (was 2 already, but be explicit)
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+
+  # Indentation is the headline rule. Enforce consistent 2-space
+  # indentation for sequences and block mappings. This is what catches
+  # the "dropped 2 spaces under an env list" class of bug.
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+    check-multi-line-strings: false
+
+  # Don't tolerate trailing spaces anywhere
+  trailing-spaces: enable
+
+  # A new line at end of file is conventional and matches POSIX
+  new-line-at-end-of-file: enable
+
+  # Catch duplicate keys (silent overrides)
+  key-duplicates: enable
+
+  # Braces and brackets: warn-only, since some of the existing
+  # workflow files use them with internal whitespace
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1


### PR DESCRIPTION
Follow-up to #188. The flux-local diff step in the Flux Validate workflow had two issues that hid the real bug:

1. `continue-on-error: true` masked a real failure signal. If the kustomize build is broken (like the indentation bug in #188), the diff step is what catches it. A diff failure should fail the check, not be silently green.
2. The diff step's error message was opaque. yamllint would have reported the exact line and column of the indentation bug instead of a kustomize build error pointing to a deeply nested field.

## Changes

- **`.yamllint.yaml`** — strict 2-space indentation, trailing-space, duplicate-key, and new-line-at-end-of-file rules. Ignores Flux-generated `gotk-*.yaml`, SOPS-encrypted `*.sops.yaml`, and Ansible playbooks (different conventions).
- **Flux Validate workflow** — adds `Install yamllint` and `Lint YAML` steps, scoped to `k3s/**` and `.github/workflows/**` (the hand-written K8s YAMLs). Removes `continue-on-error: true` from the flux-local diff step with a comment explaining why.
- **`.pre-commit-config.yaml`** — mirrors the same yamllint rules so the catch happens at `git commit` time too, plus basic hygiene hooks (trailing-whitespace, end-of-file-fixer, mixed-line-ending).

## Verification

- `yamllint -c .yamllint.yaml k3s/applications/ k3s/infrastructure/ k3s/platform/ k3s/clusters/homelab/ .github/workflows/` → exit 0
- `yamllint -c .yamllint.yaml .yamllint.yaml .pre-commit-config.yaml .github/workflows/flux-validate.yaml` → exit 0 (the config files themselves pass the rules)

Refs #188