### PR TITLE
feat(otel): add OpenTelemetry Collector + Tempo to k3s testbed

### DIFF
--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -13,8 +13,10 @@ Flux-managed infrastructure layer split into two reconciliation stages:
 ```
 infrastructure/
 ├── controllers/
-│   ├── cert-manager/   # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
-│   └── metallb/        # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
+│   ├── cert-manager/           # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
+│   ├── metallb/                # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
+│   ├── opentelemetry-collector/# helmrelease.yaml, helmrepository.yaml, kustomization.yaml
+│   └── tempo/                  # helmrelease.yaml, helmrepository.yaml, kustomization.yaml
 └── configs/
     ├── cert-manager/   # cloudflare-token.sops.yaml, clusterissuer-{prod,staging}.yaml, kustomization.yaml
     ├── metallb/        # ipaddresspool.yaml, l2advertisement.yaml, kustomization.yaml
@@ -46,6 +48,24 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 - **K3s scrapers disabled**: kubeEtcd, kubeScheduler, kubeControllerManager, kubeProxy (K3s uses SQLite; control plane binds to 127.0.0.1)
 - **PodMonitor discovery**: `podMonitorSelectorNilUsesHelmValues: false` + `serviceMonitorSelectorNilUsesHelmValues: false`
 
+### opentelemetry-collector
+- **Chart**: `open-telemetry/opentelemetry-collector` v0.155.0 (contrib "kube" image) | namespace: `telemetry`
+- **Mode**: `daemonset` — one pod per node (single on the testbed, scales to N on HA cluster)
+- **Receivers**: `k8scluster`, `kubeletstats`, `hostmetrics` (cluster telemetry), plus `otlp` (grpc :4317, http :4318) for app-side opt-ins
+- **Exporters**: `otlp` → `tempo.telemetry.svc.cluster.local:4317`; `debug` (stdout) for metrics/logs
+- **Processors**: `memory_limiter`, `batch`, `resourcedetection`
+- **Extensions**: `health_check`, `k8s_observer`
+- **Host mounts**: `/proc`, `/sys`, `/var/run/containerd` (required by hostmetrics + containerd scraper)
+- **RBAC**: created automatically by the chart (ClusterRole with read on pods/nodes/services/etc.)
+
+### tempo
+- **Chart**: `grafana-community/tempo` v2.2.0 (single-binary / monolithic) | namespace: `telemetry`
+- **Storage**: `local` backend, 5Gi PVC on `local-path`, WAL at `/var/tempo/wal`
+- **Receivers**: `otlp` (grpc :4317, http :4318) — defaults, no override needed
+- **Retention**: 168h (7 days)
+- **No ingress** — Grafana dials `http://tempo.telemetry.svc.cluster.local:3200` in-cluster
+- **Datasource**: `grafanadatasource-tempo.yaml` in `configs/monitoring/` (sidecar-discovered via `grafana_datasource: "1"` label); uid `tempo`, serviceMap back-linked to `prometheus`
+
 ### Headlamp (reference — lives in `k3s/applications/headlamp/`)
 - Uses `cert-manager.io/cluster-issuer: letsencrypt-prod` in Traefik ingress
 - URL: `headlamp.homelab.properties`
@@ -58,6 +78,7 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 | Task | File |
 |------|------|
 | Add a new controller chart | `controllers/<name>/helmrelease.yaml` + `helmrepository.yaml` + `kustomization.yaml` |
+| Add a Grafana datasource | `configs/monitoring/grafanadatasource-<name>.yaml` (must have `grafana_datasource: "1"` label) |
 | Add a ClusterIssuer | `configs/cert-manager/` |
 | Change IP address pool | `configs/metallb/ipaddresspool.yaml` |
 | Edit Cloudflare token secret | `configs/cert-manager/cloudflare-token.sops.yaml` via `sops` CLI |

--- a/k3s/infrastructure/configs/monitoring/grafanadatasource-tempo.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafanadatasource-tempo.yaml
@@ -1,0 +1,31 @@
+---
+# Grafana datasource for Tempo (traces). Picked up by the kube-prometheus-stack
+# Grafana sidecar via the `grafana_datasource: "1"` label.
+# Cluster-internal URL only — Grafana dials Tempo via the in-cluster service DNS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-tempo
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    deleteDatasources:
+      - name: Tempo
+        orgId: 1
+    datasources:
+      - name: Tempo
+        uid: tempo
+        type: tempo
+        access: proxy
+        url: http://tempo.telemetry.svc.cluster.local:3200
+        isDefault: false
+        editable: false
+        jsonData:
+          httpMethod: GET
+          serviceMap:
+            datasourceUid: prometheus
+          nodeGraph:
+            enabled: true

--- a/k3s/infrastructure/configs/monitoring/kustomization.yaml
+++ b/k3s/infrastructure/configs/monitoring/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - prometheusrule-flux.yaml
   - prometheusrule-cert-manager.yaml
   - podmonitor-cert-manager.yaml
+  - grafanadatasource-tempo.yaml

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - csi-driver-smb
   - dcgm-exporter
   - external-dns
+  - opentelemetry-collector
+  - tempo

--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
@@ -1,0 +1,167 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opentelemetry-collector
+  namespace: telemetry
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      version: "0.155.0"
+      sourceRef:
+        kind: HelmRepository
+        name: open-telemetry
+        namespace: flux-system
+      interval: 12h
+  values:
+    # Contrib "kube" distribution. Provides kubeletstats, k8scluster, hostmetrics
+    # on top of the core receivers. K8S_NODE_NAME is supplied via downward API
+    # by the chart's DaemonSet template.
+    mode: daemonset
+
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
+      tag: "0.155.0"
+
+    command:
+      name: otelcol-k8s
+
+    config:
+      receivers:
+        # Cluster-wide condition/allocatable metrics from the K8s API.
+        k8scluster:
+          auth_type: serviceAccount
+          collection_interval: 30s
+          node_conditions_to_report: [Ready, MemoryPressure, DiskPressure]
+          allocatable_types_to_report: [cpu, memory, ephemeral-storage, pods]
+        # Per-node kubelet metrics (CPU, memory, network, fs at the pod level).
+        kubeletstats:
+          auth_type: serviceAccount
+          endpoint: "${env:K8S_NODE_NAME}:10250"
+          insecure_skip_verify: true
+          collection_interval: 30s
+          node: "${env:K8S_NODE_NAME}"
+          k8s_api_config:
+            auth_type: serviceAccount
+          metrics:
+            k8s.container.cpu.node.utilization:
+              enabled: true
+            k8s.pod.cpu.node.utilization:
+              enabled: true
+            k8s.container.memory.node.utilization:
+              enabled: true
+            k8s.pod.memory.node.utilization:
+              enabled: true
+        # Host-level metrics — needs /proc and /sys mounted (see extraVolumes).
+        hostmetrics:
+          collection_interval: 30s
+          scrapers:
+            cpu: {}
+            memory: {}
+            disk: {}
+            filesystem:
+              mount_points:
+                - mount_path: /
+                  fs_type: ext4
+                - mount_path: /var/lib/containerd
+              exclude_mount_points:
+                - mount_path: /proc*
+                - mount_path: /sys*
+                - mount_path: /dev/*
+                - mount_path: /var/lib/kubelet/*
+            load: {}
+            paging: {}
+            network: {}
+            processes: {}
+        # OTLP receiver — apps can ship traces/metrics/logs to us on 4317/4318.
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+
+      processors:
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 20
+        batch:
+          send_batch_size: 1024
+          timeout: 5s
+        resourcedetection:
+          detectors: [env, k8scluster]
+
+      exporters:
+        # Forward received traces to the in-cluster Tempo monolithic.
+        otlp:
+          endpoint: tempo.telemetry.svc.cluster.local:4317
+          tls:
+            insecure: true
+        # Local debug exporter for metrics/logs (stdout) — cheap to leave on
+        # for visibility until a metrics pipeline is wired into Prometheus.
+        debug: {}
+
+      extensions:
+        health_check: {}
+        k8s_observer:
+          auth_type: serviceAccount
+          observe_pods: true
+          observe_nodes: true
+
+      service:
+        extensions: [health_check, k8s_observer]
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [memory_limiter, batch, resourcedetection]
+            exporters: [otlp]
+          metrics:
+            receivers: [otlp, k8scluster, kubeletstats, hostmetrics]
+            processors: [memory_limiter, batch, resourcedetection]
+            exporters: [debug]
+          logs:
+            receivers: [otlp]
+            processors: [memory_limiter, batch, resourcedetection]
+            exporters: [debug]
+
+    # RBAC: the k8scluster and kubeletstats receivers need read access to
+    # pods, nodes, namespaces, services, and replicasets.
+    serviceAccount:
+      create: true
+    clusterRole:
+      create: true
+    rbac:
+      create: true
+
+    # hostmetrics needs the host's /proc, /sys, and containerd socket mounted.
+    extraVolumes:
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-containerd
+        hostPath:
+          path: /var/run/containerd
+    extraVolumeMounts:
+      - name: host-proc
+        mountPath: /hostfs/proc
+        readOnly: true
+      - name: host-sys
+        mountPath: /hostfs/sys
+        readOnly: true
+      - name: host-containerd
+        mountPath: /var/run/containerd
+        readOnly: true
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: open-telemetry
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/k3s/infrastructure/controllers/opentelemetry-collector/kustomization.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/tempo/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/tempo/helmrelease.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tempo
+  namespace: telemetry
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: tempo
+      version: "2.2.0"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-community
+        namespace: flux-system
+      interval: 12h
+  values:
+    # Single-binary (monolithic) mode is the chart's only deployment topology.
+    # Reasonable for a testbed; scales to ~hundreds of spans/sec.
+    tempo:
+      reportingEnabled: false
+      retention: 168h  # 7 days
+      # OTLP receivers are enabled by the chart's default values
+      # (grpc :4317, http :4318). Retention/ingester/querier are tuned below.
+      ingester:
+        trace_idle_period: 10s
+        max_block_duration: 5m
+        complete_block_timeout: 10m
+      querier:
+        max_concurrent_queries: 20
+      # Resources tuned for a single-node testbed. CPU limits stay unset
+      # (Go GC throttling is a footgun on this class of workload).
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+
+    # 5Gi is enough for ~7 days of cluster-telemetry traces on a testbed.
+    # local-path matches the rest of the cluster (kube-prometheus-stack).
+    persistence:
+      enabled: true
+      enableStatefulSetAutoDeletePVC: false
+      storageClassName: local-path
+      accessModes:
+        - ReadWriteOnce
+      size: 5Gi
+
+    # No ingress on Tempo — queries flow through Grafana, which dials
+    # http://tempo.telemetry.svc.cluster.local:3200 in-cluster.
+
+    service:
+      type: ClusterIP
+      targetPort: 3200
+
+    serviceAccount:
+      create: true

--- a/k3s/infrastructure/controllers/tempo/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/tempo/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana-community
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://grafana-community.github.io/helm-charts

--- a/k3s/infrastructure/controllers/tempo/kustomization.yaml
+++ b/k3s/infrastructure/controllers/tempo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - qbittorrent.yaml
   - sense-exporter.yaml
   - unpoller.yaml
+  - telemetry.yaml

--- a/k3s/platform/namespaces/telemetry.yaml
+++ b/k3s/platform/namespaces/telemetry.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telemetry


### PR DESCRIPTION
## Summary

Deploys a cluster-telemetry-only OpenTelemetry pipeline on the Flux-managed k3s testbed. The pattern mirrors cert-manager/metallb/monitoring so the manifests copy verbatim to the eventual 3-node HA cluster.

## What's added

**Charts (both in `infrastructure/controllers/`):**
- `open-telemetry/opentelemetry-collector` v0.155.0 (contrib `kube` image) - DaemonSet
- `grafana-community/tempo` v2.2.0 (single-binary / monolithic)

**OpenTelemetry Collector** (namespace: `telemetry`):
- Receivers: `k8scluster`, `kubeletstats`, `hostmetrics`, `otlp` (gRPC :4317 + HTTP :4318)
- Exporters: `otlp` -> in-cluster Tempo; `debug` (stdout) for metrics/logs
- Processors: `memory_limiter`, `batch`, `resourcedetection`
- Host mounts: `/proc`, `/sys`, `/var/run/containerd` (hostmetrics)
- ClusterRole + RBAC auto-created by chart for K8s API reads

**Tempo** (namespace: `telemetry`):
- Storage: local backend, 5Gi PVC on `local-path`, 168h retention
- OTLP gRPC :4317, HTTP :4318 (chart defaults)
- No ingress - Grafana dials `http://tempo.telemetry.svc.cluster.local:3200` in-cluster

**Grafana datasource** (`infrastructure/configs/monitoring/grafanadatasource-tempo.yaml`):
- ConfigMap with `grafana_datasource: "1"` label - picked up by kube-prometheus-stack sidecar
- `uid=tempo`, serviceMap back-linked to `prometheus`, nodeGraph enabled

## Layering (per AGENTS.md anti-patterns)

- `telemetry` namespace added to `k3s/platform/namespaces/` (not `configs/`)
- Both controllers registered in `k3s/infrastructure/controllers/kustomization.yaml`
- Datasource lives in `configs/monitoring/` alongside existing PodMonitor/PrometheusRule files

## Out of scope (deliberately)

- Application-level instrumentation (auto-instrumentation operator)
- Sampling/tail-based processors (single-node testbed, low trace volume)
- Ingress on Tempo (Grafana-only access pattern)
- Loki wiring in the Grafana datasource (Loki not yet deployed)

## Test plan

- [ ] Flux `infra-controllers` reconciles and installs the `telemetry` namespace + both HelmReleases
- [ ] `tempo` pod reaches Ready, OTLP `/ready` returns 200 on :3200
- [ ] `opentelemetry-collector` DaemonSet pod reaches Ready on the testbed node
- [ ] `kubectl logs -n telemetry -l app.kubernetes.io/name=tempo` shows blocks being written
- [ ] `kubectl logs -n telemetry -l app.kubernetes.io/name=opentelemetry-collector` shows cluster metrics in the debug exporter
- [ ] Grafana -> Connections -> Data sources shows Tempo with a green check on Save & Test
- [ ] Grafana Explore -> Tempo -> Search shows recent traces from the collector's self-telemetry
