### PR TITLE
fix(otel): drop rbac:{} block that fails chart v0.155.0 values schema

### DIFF
--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
@@ -129,12 +129,12 @@ spec:
             exporters: [debug]
 
     # RBAC: the k8scluster and kubeletstats receivers need read access to
-    # pods, nodes, namespaces, services, and replicasets.
+    # pods, nodes, namespaces, services, and replicasets. The chart builds
+    # the ClusterRole + ClusterRoleBinding off the ServiceAccount when
+    # `clusterRole.create: true` is set, so no separate `rbac:` block.
     serviceAccount:
       create: true
     clusterRole:
-      create: true
-    rbac:
       create: true
 
     # hostmetrics needs the host's /proc, /sys, and containerd socket mounted.


### PR DESCRIPTION
## Summary

Follow-up to #190. Drops the `rbac: { create: true }` block from the OTel Collector HelmRelease — the chart v0.155.0 values schema rejects a top-level `rbac:` key, causing the post-merge install to fail on the testbed.

## What changed

`k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml`:
- Removed `rbac: { create: true }`
- Expanded the RBAC comment to explain that `clusterRole.create: true` already provisions the ClusterRole + ClusterRoleBinding off the auto-created ServiceAccount

Net diff: `-3 / +3`.

## Symptom (from testbed)

After #190 merged, Flux started applying the new manifests. Tempo installed successfully. The collector bailed with:

```
Helm install failed for release telemetry/opentelemetry-collector
with chart opentelemetry-collector@0.155.0:
values don't meet the specifications of the schema(s) in the following chart(s):
opentelemetry-collector:
- at '': additional properties 'rbac' not allowed
```

## Test plan

- [ ] Flux `infra-controllers` reconciles the new value on master
- [ ] `telemetry/opentelemetry-collector` reaches Ready on the testbed node
- [ ] `kubectl logs -n telemetry -l app.kubernetes.io/name=opentelemetry-collector` shows kubeletstats/k8scluster/hostmetrics series in the debug exporter
- [ ] Tempo's `/ready` still 200, no OTel collector traces yet (no app-side OTLP shippers)

## Out of scope

Uninstalling the failed `opentelemetry-collector` release. If Flux can't re-install over the failed state after this merges, the manual unblock is:

```sh
kubectl delete hr opentelemetry-collector -n telemetry
# wait for Flux to recreate it
```
