### PR TITLE
fix(otel): pin image tag to 0.151.0 to match chart v0.155.0 appVersion

### DIFF
--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
@@ -24,7 +24,9 @@ spec:
 
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
-      tag: "0.155.0"
+      # Chart v0.155.0 ships appVersion 0.151.0 (the collector binary, not the
+      # chart version). Pin the tag explicitly to avoid Chart vs image drift.
+      tag: "0.151.0"
 
     command:
       name: otelcol-k8s


### PR DESCRIPTION
## Summary

Follow-up to #190 and #191. Pins the OTel Collector image tag to `0.151.0` to match chart v0.155.0's `appVersion`. The chart version and the collector binary version are decoupled — tagging the image with the chart version produced `ImagePullBackOff` on the testbed.

## What changed

`k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml`:
- `image.tag: "0.155.0"` → `"0.151.0"`
- 2-line comment explaining the chart-vs-appVersion drift so this doesn't regress

Net diff: `-1 / +3`.

## Symptom (from testbed, after #191 merged)

```
Warning  Failed  pod/opentelemetry-collector-agent-w9x5d
Failed to pull image "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.155.0":
rpc error: code = NotFound desc = failed to pull and unpack image "...:0.155.0":
failed to resolve reference "...:0.155.0": ...: not found
```

Confirmed via `Chart.yaml` of the chart at the matching git tag:
```yaml
version: 0.155.0
appVersion: 0.151.0
```

## Test plan

- [ ] Flux `infra-controllers` reconciles the new value on master
- [ ] `telemetry/opentelemetry-collector` DaemonSet pod reaches `Running` and `Ready` on the testbed node
- [ ] `kubectl logs -n telemetry -l app.kubernetes.io/name=opentelemetry-collector` shows the collector coming up
- [ ] `kubectl get hr -n telemetry opentelemetry-collector` shows `Ready: True`
- [ ] Tempo continues to be `Ready` (no churn from this change)

## Out of scope

Same as #191: uninstalling the broken-image pod. The DaemonSet will replace it once the new tag lands. If it doesn't, `kubectl delete pod -n telemetry -l app.kubernetes.io/name=opentelemetry-collector` is the manual unblock.

## Rest of the work — same bug?

Checked. Only the OTel collector had an explicit `image.tag` override in this PR series. Tempo (`grafana-community/tempo` chart) uses the chart's default tag, which tracks `appVersion` — unaffected.
