### PR TITLE
fix(otel): rename k8scluster receiver, fix env var, fix detector name

### DIFF
--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -51,9 +51,9 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 ### opentelemetry-collector
 - **Chart**: `open-telemetry/opentelemetry-collector` v0.155.0 (contrib "kube" image) | namespace: `telemetry`
 - **Mode**: `daemonset` — one pod per node (single on the testbed, scales to N on HA cluster)
-- **Receivers**: `k8scluster`, `kubeletstats`, `hostmetrics` (cluster telemetry), plus `otlp` (grpc :4317, http :4318) for app-side opt-ins
+- **Receivers**: `k8s_cluster`, `kubeletstats`, `hostmetrics` (cluster telemetry), plus `otlp` (grpc :4317, http :4318) for app-side opt-ins
 - **Exporters**: `otlp` → `tempo.telemetry.svc.cluster.local:4317`; `debug` (stdout) for metrics/logs
-- **Processors**: `memory_limiter`, `batch`, `resourcedetection`
+- **Processors**: `memory_limiter`, `batch`, `resourcedetection` (detectors: `env`, `k8s`)
 - **Extensions**: `health_check`, `k8s_observer`
 - **Host mounts**: `/proc`, `/sys`, `/var/run/containerd` (required by hostmetrics + containerd scraper)
 - **RBAC**: created automatically by the chart (ClusterRole with read on pods/nodes/services/etc.)

--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
@@ -17,9 +17,10 @@ spec:
         namespace: flux-system
       interval: 12h
   values:
-    # Contrib "kube" distribution. Provides kubeletstats, k8scluster, hostmetrics
-    # on top of the core receivers. K8S_NODE_NAME is supplied via downward API
-    # by the chart's DaemonSet template.
+    # Contrib "kube" distribution. Provides kubeletstats, k8s_cluster,
+    # hostmetrics on top of the core receivers. Node identity is supplied
+    # via downward API as OTEL_K8S_NODE_NAME (chart convention, not the
+    # bare K8S_NODE_NAME).
     mode: daemonset
 
     image:
@@ -34,18 +35,24 @@ spec:
     config:
       receivers:
         # Cluster-wide condition/allocatable metrics from the K8s API.
-        k8scluster:
+        # The receiver type is `k8s_cluster` (with underscore) — the bare
+        # word `k8scluster` is not registered and the collector refuses
+        # to start with it in the config.
+        k8s_cluster:
           auth_type: serviceAccount
           collection_interval: 30s
           node_conditions_to_report: [Ready, MemoryPressure, DiskPressure]
           allocatable_types_to_report: [cpu, memory, ephemeral-storage, pods]
         # Per-node kubelet metrics (CPU, memory, network, fs at the pod level).
+        # The chart's DaemonSet template sets OTEL_K8S_NODE_NAME via the
+        # downward API — that's the env var the receiver resolves to find
+        # the local kubelet.
         kubeletstats:
           auth_type: serviceAccount
-          endpoint: "${env:K8S_NODE_NAME}:10250"
+          endpoint: "${env:OTEL_K8S_NODE_NAME}:10250"
           insecure_skip_verify: true
           collection_interval: 30s
-          node: "${env:K8S_NODE_NAME}"
+          node: "${env:OTEL_K8S_NODE_NAME}"
           k8s_api_config:
             auth_type: serviceAccount
           metrics:
@@ -94,8 +101,10 @@ spec:
         batch:
           send_batch_size: 1024
           timeout: 5s
+        # The K8s detector in the resourcedetection processor is registered
+        # as `k8s` (short name), distinct from the k8s_cluster receiver.
         resourcedetection:
-          detectors: [env, k8scluster]
+          detectors: [env, k8s]
 
       exporters:
         # Forward received traces to the in-cluster Tempo monolithic.
@@ -122,7 +131,7 @@ spec:
             processors: [memory_limiter, batch, resourcedetection]
             exporters: [otlp]
           metrics:
-            receivers: [otlp, k8scluster, kubeletstats, hostmetrics]
+            receivers: [otlp, k8s_cluster, kubeletstats, hostmetrics]
             processors: [memory_limiter, batch, resourcedetection]
             exporters: [debug]
           logs:
@@ -130,7 +139,7 @@ spec:
             processors: [memory_limiter, batch, resourcedetection]
             exporters: [debug]
 
-    # RBAC: the k8scluster and kubeletstats receivers need read access to
+    # RBAC: the k8s_cluster and kubeletstats receivers need read access to
     # pods, nodes, namespaces, services, and replicasets. The chart builds
     # the ClusterRole + ClusterRoleBinding off the ServiceAccount when
     # `clusterRole.create: true` is set, so no separate `rbac:` block.


### PR DESCRIPTION
## Summary

Follow-up to #190, #191, #192. Fixes three config errors in the OTel Collector that prevented the process from starting — the image-pull fix in #192 was necessary but not sufficient. Without this, the pod pulled fine, started, and then died on a config validation error, crash-looping the liveness probe.

## What changed

`k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml`:
- Renamed `k8scluster` receiver → `k8s_cluster` (with underscore; matches the registered type)
- Changed `endpoint: "${env:K8S_NODE_NAME}:10250"` and `node: "${env:K8S_NODE_NAME}"` → use `OTEL_K8S_NODE_NAME` (the env var the chart's DaemonSet template actually sets via downward API)
- Renamed the resourcedetection `k8scluster` detector → `k8s` (the registered short name)
- Updated comments to explain each choice and the bug history so this doesn't regress

`k3s/infrastructure/AGENTS.md`:
- Updated the OTel collector description block to reflect the correct receiver/detector names

Net diff: `+20 / -11` across the two files.

## Symptom (from testbed, after #192 merged)

Image pulled fine, container started, but process exited 1 before binding the health_check port. Liveness probe then failed every restart. Pod entered `CrashLoopBackOff`.

Collector log:
```
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

'receivers' unknown type: "k8scluster" for id: "k8scluster"
(valid values: [otlp fluent_forward jaeger k8s_cluster k8s_events otelarrow prometheus file_log http_check journald kubeletstats fluentforward k8s_objects filelog host_metrics hostmetrics httpcheck k8sobjects receiver_creator zipkin])
```

Warning in same log (would have surfaced next):
```
warn envprovider@v1.57.0/provider.go:61 Configuration references unset environment variable {"name": "K8S_NODE_NAME"}
```

Confirmed chart sets `OTEL_K8S_NODE_NAME` via downward API (verified on the running pod's spec).

## Why this happened

I conflated the OTel **repo** directory name (`receiver/k8sclusterreceiver/`) with the **config type key** (`k8s_cluster`). The valid types list is in the collector's own log output, but I didn't run the config end-to-end before claiming the work was verified. yamllint and `kustomize build` pass cleanly on syntactically-valid but semantically-wrong YAML.

## Test plan

- [ ] Flux `infra-controllers` reconciles the new value on master
- [ ] OTel collector pod exits `CrashLoopBackOff` and reaches `Ready 1/1`
- [ ] Liveness probe on port 13133 succeeds (`kubectl describe pod` shows no `Unhealthy` events)
- [ ] Collector log shows `Everything is ready. Begin running and processing data.` (no config error, no env var warning)
- [ ] `kubectl logs ... | grep -E "k8s_cluster|kubeletstats|hostmetrics"` shows the receivers spinning up
- [ ] `kubectl logs ... | grep -E "Started.*Tempo|writing to"` shows traces being exported to Tempo

## Out of scope

Adding a CI check that actually renders the OTel config against a real `otelcol-k8s:0.151.0` binary. Worth doing but a separate piece of work.
