### PR TITLE
fix(otel): drop invalid k8s_api resourcedetection detector override

### DIFF
--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -51,10 +51,10 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 ### opentelemetry-collector
 - **Chart**: `open-telemetry/opentelemetry-collector` v0.155.0 (contrib "kube" image, appVersion 0.151.0) | namespace: `telemetry`
 - **Mode**: `daemonset` — one pod per node (single on the testbed, scales to N on HA cluster)
-- **Presets enabled**: `clusterMetrics`, `hostMetrics`, `kubeletMetrics`, `resourceDetection` — the chart generates correct receiver/ClusterRole/host-mount config for these, including `k8s_leader_elector` for the daemonset k8s_cluster receiver
-- **Custom receivers layered on top**: `otlp` (grpc :4317, http :4318) for app-side opt-ins; `k8s_cluster.distribution: kubernetes` (required by Validate() but the chart doesn't set it); `kubeletstats.metrics` enabling the four node-utilization gauges
+- **Presets enabled**: `clusterMetrics`, `hostMetrics`, `kubeletMetrics`, `resourceDetection` — the chart generates correct receiver/ClusterRole/host-mount config for these, including `k8s_leader_elector` for the daemonset k8s_cluster receiver. The chart also auto-adds the `resourcedetection/env` processor to the traces pipeline when the resourceDetection preset is enabled.
+- **Custom receivers layered on top**: `otlp` (grpc :4317, http :4318) for app-side opt-ins; `k8s_cluster.node_conditions_to_report` / `allocatable_types_to_report` extensions; `kubeletstats.node: "${env:K8S_NODE_NAME}"` (required by Validate() when node-utilization metrics are enabled; the preset doesn't set it) and `kubeletstats.metrics` enabling the four node-utilization gauges
 - **Exporters**: `otlp` → `tempo.telemetry.svc.cluster.local:4317`; `debug` (stdout) for metrics/logs
-- **Processors**: `memory_limiter`, `batch`, `resourcedetection` (detectors: `env`, `k8s_api`)
+- **Processors**: `memory_limiter`, `batch` (custom); `resourcedetection/env` (chart preset, auto-added to traces pipeline; detectors: `env`, `k8snode` — `k8snode` is the only registered K8s detector in v0.151.0; the `k8s_api` rename is a future-version change)
 - **Extensions**: `health_check` (chart default) — no k8s_observer/receiver_creator; we don't do annotation-based discovery
 - **Host mounts**: provided by the `hostMetrics` preset (hostfs → /, propagated HostToContainer)
 

--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
@@ -46,25 +46,28 @@ spec:
         enabled: true
         # This preset also sets the K8S_NODE_NAME / K8S_NODE_IP env vars
         # via downward API, which the kubeletstats receiver and the
-        # k8s_api resource detector both consume.
+        # resourcedetection k8snode detector both consume.
       resourceDetection:
         enabled: true
         env:
           enabled: true
-        # The chart's default uses the deprecated `k8snode` detector
-        # name. Disable it and add `k8s_api` (the non-deprecated name)
-        # via the custom config below.
+        # k8snode is the ONLY registered K8s detector in the v0.151.0
+        # collector binary (verified against factory.go at the matching
+        # git tag). The `k8s_api` rename is a future-version change.
+        # Leave the chart's default (k8snode.enabled: true). The chart's
+        # _config.tpl automatically adds the `resourcedetection/env`
+        # processor to the traces pipeline when this preset is enabled,
+        # so we don't reference it here either.
 
     # Custom config layered on top of the preset config. Helm merges this
     # into the chart-generated config; you can't remove preset entries,
     # but you can extend them.
     config:
       receivers:
-        # k8s_cluster from the preset doesn't set `distribution`; the
-        # receiver's Validate() requires it to be "kubernetes" or
-        # "openshift", so add it here.
+        # k8s_cluster from the preset already has Distribution: "kubernetes"
+        # as the factory default — no need to override.
+        # Extend the preset's k8s_cluster condition/allocatable reporting.
         k8s_cluster:
-          distribution: kubernetes
           node_conditions_to_report: [Ready, MemoryPressure, DiskPressure]
           allocatable_types_to_report: [cpu, memory, ephemeral-storage, pods]
         # Extend the preset's kubeletstats with the four "node utilization"
@@ -93,14 +96,6 @@ spec:
             http:
               endpoint: 0.0.0.0:4318
 
-      processors:
-        # The chart's resourceDetection preset adds a `resourcedetection`
-        # processor with the deprecated `k8snode` detector. Reconfigure
-        # it to use the non-deprecated `k8s_api` name (which reads
-        # K8S_NODE_NAME by default — set by the kubeletMetrics preset).
-        resourcedetection:
-          detectors: [env, k8s_api]
-
       exporters:
         # Forward received traces to the in-cluster Tempo monolithic.
         otlp:
@@ -114,11 +109,13 @@ spec:
       service:
         # Add a traces pipeline. The metrics/logs pipelines come from the
         # chart defaults + preset augments (we don't override them, so
-        # nothing gets dropped).
+        # nothing gets dropped). The resourcedetection/env processor is
+        # added to this pipeline automatically by the resourceDetection
+        # preset, so we don't reference it here.
         pipelines:
           traces:
             receivers: [otlp]
-            processors: [memory_limiter, batch, resourcedetection]
+            processors: [memory_limiter, batch]
             exporters: [otlp]
 
     serviceAccount:


### PR DESCRIPTION
## Summary

Follow-up to #195. The collector is still crash-looping on the testbed because the `processors.resourcedetection` block in #194 used `k8s_api` as a detector name, and **that name does not exist in the v0.151.0 collector binary**. The README on `main` that I cited for the rename describes a future release; the actual `factory.go` at the `v0.151.0` tag registers only `k8snode`. The chart's preset uses `k8snode` correctly.

## What changed

`k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml`:
- **Deleted** the entire `processors.resourcedetection` block (the broken `k8s_api` detector)
- **Deleted** the `resourcedetection` entry from the traces pipeline processor list (chart auto-wires `resourcedetection/env` via `_config.tpl` lines 555-556)
- **Deleted** `receivers.k8s_cluster.distribution: kubernetes` (the factory's default is already `"kubernetes"` per `receiver/k8sclusterreceiver/factory.go`)
- **Kept** `kubeletstats.node: "${env:K8S_NODE_NAME}"` from #195 (still required by `Validate()` when the node-utilization metrics are enabled)
- **Kept** the kubeletMetrics preset (still sets the `K8S_NODE_NAME` and `K8S_NODE_IP` env vars via downward API)
- Updated the comment block on the `resourceDetection` preset to document why `k8snode` is correct for v0.151.0

`k3s/infrastructure/AGENTS.md`:
- Updated the OTel collector description to match the actual config and call out that `k8snode` is the only registered K8s detector in v0.151.0

Net diff: `+18 / -21`.

## Why I'm doing this right this time (verified against actual v0.151.0 sources)

| What the README on main says | What `factory.go` at `v0.151.0` actually does | Action |
|-------------------------------|-----------------------------------------------|--------|
| `k8s_api` is the non-deprecated rename of `k8snode` | The `NewProviderFactory` map registers `k8snode.TypeStr` and nothing named `k8s_api` | Delete the `k8s_api` reference; let the chart preset use `k8snode` |
| `k8s_cluster.distribution` must be set explicitly | `defaultDistribution = distributionKubernetes` in the factory | Drop the override |
| `k8s_node` for resourcedetection needs to be in the pipeline manually | Chart `_config.tpl` lines 555-556 auto-prepend it when the preset is enabled | Remove the manual pipeline ref |

I read the actual sources, not the README, this time. Sorry for the chain.

## Test plan

- [ ] Flux `infra-controllers` reconciles the new value on master
- [ ] OTel collector pod exits `CrashLoopBackOff` and reaches `Ready 1/1`
- [ ] Liveness probe on port 13133 succeeds (no `Unhealthy` events)
- [ ] Collector log shows `Everything is ready. Begin running and processing data.`
- [ ] Collector log does NOT show `invalid detector key`
- [ ] Collector log does NOT show `node setting is required`
- [ ] Tempo continues to be `Ready` (no churn from this change)

## Out of scope (filed for a separate PR)

Adding CI that runs the rendered Helm config through a real `otelcol-k8s:0.151.0 validate` command before merge. Would have caught all six bugs in this chain at the first PR.
