### PR TITLE
fix(tdarr): single gpu worker + cpu healthcheck worker

### DIFF
--- a/k3s/applications/tdarr/deployment-node.yaml
+++ b/k3s/applications/tdarr/deployment-node.yaml
@@ -49,9 +49,9 @@ spec:
             - name: transcodecpuWorkers
               value: "0"
             - name: transcodegpuWorkers
-              value: "2"
+              value: "1"
             - name: healthcheckcpuWorkers
-              value: "0"
+              value: "1"
             - name: healthcheckgpuWorkers
               value: "1"
           resources:


### PR DESCRIPTION
## Problem
Tdarr transcode jobs were running at ~2 fps on 4K HEVC Main10 HDR sources despite the RTX 3070 being correctly attached and `hevc_nvenc` selected.

`nvidia-smi pmon` showed the GPU encoder at 46% on one job and idle on the other, with both processes CPU-bound at 200%+.

## Root cause
`nvidia-device-plugin` is configured with time-slicing (`replicas: 2`), which splits CUDA contexts but **not the single NVDEC hardware block**. With two tdarr workers both requesting `nvidia.com/gpu: 1` they each get a CUDA context, but they queue on NVDEC and contend for NVENC. Combined with the plugin's missing `-hwaccel_output_format cuda` flag (frames roundtrip through system RAM), each job dropped to 2-19 fps instead of 30+.

## Fix
Reduce to one GPU worker so each transcode gets the full NVDEC/NVENC engine. Add a CPU healthcheck worker so the scanner isn't blocked on the single GPU worker.

```yaml
transcodegpuWorkers:   2 -> 1
healthcheckcpuWorkers: 0 -> 1
```

## Verified live
|                  | Before       | After         |
| ---------------- | ------------ | ------------- |
| Encoder util     | 46% (1 idle) | 99%           |
| Decoder util     | 7%  (1 idle) | 18%           |
| ffmpeg processes | 2            | 1             |
| Pod CPU          | 3999m        | 1419m         |
| Pod memory       | 3151Mi       | 1477Mi        |

Single GPU worker is now GPU-bound (encoder saturating), which is the correct state.

## Not addressed (out of scope)
The plugin still emits `-hwaccel cuda` without `-hwaccel_output_format cuda`, and uses `rc-lookahead 32` which forces CPU↔GPU frame transfers for 4K HDR Main10. With only one worker now this isn't a bottleneck, but if the worker count is ever raised again the per-job fps will collapse. A follow-up PR to the tdarr flow plugin (drop lookahead to ~8 and add the output_format flag) would unlock higher worker counts on the 3070.

## Notes
- K8s manifest only; CI (`yamllint` + `flux-local diff`) will run on PR open.
- Live cluster already has the env vars set via `kubectl set env` so Flux reconcile won't drift.