### PR TITLE
fix(tdarr): single gpu transcode worker, drop cpu healthcheck

### DIFF
--- a/k3s/applications/tdarr/deployment-node.yaml
+++ b/k3s/applications/tdarr/deployment-node.yaml
@@ -51,7 +51,7 @@ spec:
             - name: transcodegpuWorkers
               value: "1"
             - name: healthcheckcpuWorkers
-              value: "1"
+              value: "0"
             - name: healthcheckgpuWorkers
               value: "1"
           resources:


### PR DESCRIPTION
Set tdarr-node worker config to 1 GPU transcode + 1 GPU healthcheck, zero CPU workers.

After the earlier fix to rc-lookahead/spatial_aq in the flow plugin, transcode throughput is now GPU-bound, so the CPU worker slots are no longer needed and were causing the healthcheck scan to be slow.

Changes:
- transcodegpuWorkers: 2 -> 1 (already proven by PR #203, but lost in a subsequent renovate merge)
- transcodecpuWorkers: 0 (unchanged)
- healthcheckcpuWorkers: 0 (was set to 1 in PR #203, reverting to 0 per current preference)
- healthcheckgpuWorkers: 1 (unchanged)

Requires node pod restart to take effect.