### PR TITLE
feat(monitoring): deploy Gatus health dashboard

### DIFF
--- a/k3s/applications/gatus/config.yaml
+++ b/k3s/applications/gatus/config.yaml
@@ -1,0 +1,75 @@
+---
+# Gatus
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus-config
+  namespace: gatus
+data:
+  config.yaml: |
+    metrics: false
+    storage:
+      type: sqlite
+      path: /data/data.db
+    ui:
+      title: "Homelab Health Dashboard"
+      header: "Homelab Status"
+      dashboard-heading: "Homelab Services"
+      dashboard-subheading: "Live health status of homelab services"
+      dark-mode: true
+    endpoints:
+      # auth group
+      - name: authentik
+        group: auth
+        url: https://auth.homelab.properties/-/health/ready/
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[BODY].status == running"
+
+      # dashboards group
+      - name: headlamp
+        group: dashboards
+        url: https://headlamp.homelab.properties/health
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      - name: portainer
+        group: dashboards
+        url: https://portainer.homelab.properties/api/system/status
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      # media group
+      - name: tdarr
+        group: media
+        url: http://tdarr.homelab.properties:8265/api/v1/health
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      # monitoring group
+      - name: grafana
+        group: monitoring
+        url: https://grafana.homelab.properties/api/health
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[BODY].database == ok"
+
+      - name: prometheus
+        group: monitoring
+        url: https://prometheus.homelab.properties/-/healthy
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      # dns group
+      - name: pihole
+        group: dns
+        url: http://pihole.homelab.properties/admin/
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"

--- a/k3s/applications/gatus/helmrelease.yaml
+++ b/k3s/applications/gatus/helmrelease.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+  namespace: gatus
+spec:
+  interval: 1h
+  timeout: 5m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: gatus
+      version: "1.5.0"
+      sourceRef:
+        kind: HelmRepository
+        name: gatus
+        namespace: flux-system
+      interval: 12h
+  values:
+    # Use pre-created ConfigMap (key MUST be config.yaml)
+    externalConfigMap: gatus-config
+
+    # PVC for history persistence (sqlite at /data/data.db)
+    persistence:
+      enabled: true
+      size: 1Gi
+      mountPath: /data
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: local-path
+
+    # Ingress with Traefik + cert-manager + cross-namespace Authentik forwardAuth
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      path: /
+      pathType: Prefix
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        # Reference the Authentik forwardAuth middleware in the monitoring namespace
+        # Traefik cross-namespace middleware reference: <namespace>-<name>@kubernetescrd
+        traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
+      hosts:
+        - gatus.homelab.properties
+      tls:
+        - secretName: gatus-tls
+          hosts:
+            - gatus.homelab.properties
+
+    # Light resources (Gatus is a small Go binary with negligible footprint)
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+    service:
+      type: ClusterIP
+      port: 80
+      portName: http
+      targetPort: 8080

--- a/k3s/applications/gatus/helmrepository.yaml
+++ b/k3s/applications/gatus/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: gatus
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://twin.github.io/helm-charts
+  type: website

--- a/k3s/applications/gatus/kustomization.yaml
+++ b/k3s/applications/gatus/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - config.yaml

--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - qbittorrent/
   - sense-exporter/
   - unpoller/
+  - gatus/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.


### PR DESCRIPTION
## Summary

Deploys [Gatus](https://github.com/TwiN/gatus) as the new user-facing health
dashboard for the cluster, complementing the existing Prometheus + blackbox
probe pipeline. Gatus is the visual/status-page layer; the existing metric-driven
alerts stay untouched.

- Chart: `twin/gatus` `1.5.0` (appVersion `v5.34.0`) — official chart from the
  upstream maintainer
- New namespace `gatus` (created by the HelmRelease)
- 1Gi PVC on `local-path` for sqlite history persistence
- 7 endpoints seeded from the existing blackbox probes (authentik, headlamp,
  portainer, tdarr) plus Grafana, Prometheus, and Pi-hole
- Auth: Traefik forwardAuth via the existing `authentik-forwardauth` middleware
  in the `monitoring` namespace, referenced cross-namespace from the Ingress
  annotation (`monitoring-authentik-forwardauth@kubernetescrd`)

## Files

| File | Change |
|---|---|
| `k3s/applications/gatus/helmrepository.yaml` | new — `HelmRepository` for `https://twin.github.io/helm-charts` |
| `k3s/applications/gatus/helmrelease.yaml` | new — `HelmRelease`, external ConfigMap, PVC, ingress, resources |
| `k3s/applications/gatus/config.yaml` | new — `ConfigMap` with 7 endpoints |
| `k3s/applications/gatus/kustomization.yaml` | new — wires the three resources |
| `k3s/applications/kustomization.yaml` | +1 line — adds `gatus/` to the apps Kustomization |

## Why this complements (not replaces) the existing probes

The current blackbox pipeline (`Prometheus Operator Probe` → `Scrape` →
`Alertmanager`) is great for SRE-grade "fire an alert at 3am" reliability
metrics, but it has no UI for "is the user-facing app working?" Gatus is
visual, public-friendly, and self-contained — the two line up cleanly.

## Validation

- `yamllint -c .yamllint.yaml` — clean
- `helm template gatus /tmp/gatus-chart/gatus` with the values below — renders cleanly
- `docker run --rm twinproduction/gatus:v5.34.0` against the extracted ConfigMap
  content — `Validated 7 endpoints` (the project's hard-earned lesson: helm
  template + binary validation, not just yamllint)
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed

## Deferred (tracked in #238)

- Migrate from Traefik forwardAuth to Gatus native OIDC (requires chart pin
  to v5.35+ and a new Authentik OAuth2 provider; planned for a follow-up)
- Enable `serviceMonitor` so Prometheus scrapes Gatus's `/metrics`
- Endpoint coverage review after one week of uptime

## Heads-up

- Gatus will be the first app to actually use the `authentik-forwardauth`
  middleware — the middleware has been defined but unused until this PR
- Helm chart's `deployment.annotateConfigChecksum: true` (default) will
  restart the pod whenever the ConfigMap changes; this is GitOps-friendly
- The `readOnlyRootFilesystem: true` securityContext is satisfied by the
  PVC mount at `/data` (sqlite at `/data/data.db`)

Refs: closes nothing. Tracks follow-ups in #238.