### PR TITLE
fix(gatus): provision gatus namespace in platform layer

### DIFF
--- a/k3s/applications/gatus/helmrelease.yaml
+++ b/k3s/applications/gatus/helmrelease.yaml
@@ -8,7 +8,6 @@ spec:
   interval: 1h
   timeout: 5m
   install:
-    createNamespace: true
     remediation:
       retries: 3
   upgrade:

--- a/k3s/platform/namespaces/gatus.yaml
+++ b/k3s/platform/namespaces/gatus.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatus

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - sense-exporter.yaml
   - unpoller.yaml
   - telemetry.yaml
+  - gatus.yaml


### PR DESCRIPTION
## Summary

Fixes the post-merge #239 deployment failure. The `apps` Flux Kustomization
was looping with:

```
ConfigMap/gatus/gatus-config not found: namespaces 'gatus' not found
```

The root cause: the kustomize-controller validates referenced resources
before applying, and the gatus `ConfigMap` (which the HelmRelease's
`externalConfigMap: gatus-config` value points to) lives in the `gatus`
namespace. The namespace didn't exist yet because the previous PR relied
on `install.createNamespace: true` to create it — but that flag runs
*inside* the Helm install, which never gets reached because the
Kustomize validation fails first.

Every other app's namespace lives in `k3s/platform/namespaces/`, and the
`platform` Flux Kustomization creates them before the `apps` Kustomization
runs. PR #239 mirrored that pattern for the HelmRelease but skipped the
namespace manifest — fixing the oversight.

## Changes

- **New**: `k3s/platform/namespaces/gatus.yaml`
- **Modified**: `k3s/platform/namespaces/kustomization.yaml` — added `- gatus.yaml` to the resources list
- **Modified**: `k3s/applications/gatus/helmrelease.yaml` — dropped `install.createNamespace: true` (the platform layer now owns namespace lifecycle, consistent with all other apps)

## Validation

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed

## Post-merge verification checklist

- [ ] `kubectl get ns gatus` returns `Active`
- [ ] `kubectl get hr -n gatus gatus` flips to `ReleaseInstalled=True`
- [ ] `kubectl get pods -n gatus` shows a running pod
- [ ] `https://gatus.homelab.properties` returns 200 (after Authentik login)

## Follow-ups

The deferred items in #238 are unaffected by this fix.

Refs: supersedes #239 only partially (the namespace oversight); does not change the helmrelease config outside the `createNamespace` line.