### PR TITLE
fix(gatus): drop invalid HelmRepository spec.type

### DIFF
--- a/k3s/applications/gatus/helmrepository.yaml
+++ b/k3s/applications/gatus/helmrepository.yaml
@@ -7,4 +7,3 @@ metadata:
 spec:
   interval: 12h
   url: https://twin.github.io/helm-charts
-  type: website


### PR DESCRIPTION
## Summary

Unblocks the Gatus deployment after #240. The `apps` Kustomization was
waiting on `infra-configs` with this dry-run failure:

```
HelmRepository/flux-system/gatus dry-run failed (Invalid):
spec.type: Unsupported value: "website": supported values: "default", "oci"
```

Flux v2's `HelmRepository` CRD only accepts `default` (HTTP index URLs) and
`oci` (OCI registries). The `type: website` value in the original Helm
release came from an older Helm repo convention that doesn't exist in the
current Flux schema. The existing `headlamp` repo (also a plain HTTP Helm
repo) just leaves `spec.type` unset — that defaults to `default`, which is
the right type for `https://twin.github.io/helm-charts`.

## Timeline of the Gatus rollout

| # | Issue | Fix |
|---|---|---|
| #239 | Namespace not in `platform` (kustomize-controller ref validation failed) | — |
| #240 | Added `k3s/platform/namespaces/gatus.yaml`, dropped `createNamespace: true` | ✅ merged |
| #241 | `HelmRepository.spec.type: website` rejected by Flux v2 CRD | **this PR** |

## Changes

- **Modified**: `k3s/applications/gatus/helmrepository.yaml` — removed the `type: website` line

## Validation

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed
- `kubectl apply --dry-run=server -f k3s/applications/gatus/helmrepository.yaml` against the running cluster — `helmrepository.source.toolkit.fluxcd.io/gatus created (server dry run)`

## CI gap that's worth filing later

The repo's CI (`flux-local test` + `flux-local diff ks`) validates Kustomize
build structure but does **not** exercise the running Flux CRD schema. A
schema-invalid `spec.type` value passes both checks but Flux rejects it at
apply time. A CI step that runs `kubectl apply --dry-run=server` on every
manifest in `k3s/applications/` and `k3s/infrastructure/` would have caught
this pre-merge. Filing separately so it's not in scope creep here.

## Post-merge checklist

- [ ] `kubectl get helmrepository -n flux-system gatus` flips to `Ready=True`
- [ ] `kubectl get ks -n flux-system apps` flips to `Ready=True`
- [ ] `kubectl get hr -n gatus gatus` flips to `ReleaseInstalled=True`
- [ ] `kubectl get pods -n gatus` shows the running pod
- [ ] `https://gatus.homelab.properties` returns 200 (after Authentik login)

Refs: continues the work from #239 and #240.