### PR TITLE
fix(gatus): rename ConfigMap to release name to satisfy envFrom

### DIFF
--- a/k3s/applications/gatus/config.yaml
+++ b/k3s/applications/gatus/config.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gatus-config
+  name: gatus
   namespace: gatus
 data:
   config.yaml: |

--- a/k3s/applications/gatus/helmrelease.yaml
+++ b/k3s/applications/gatus/helmrelease.yaml
@@ -24,7 +24,11 @@ spec:
       interval: 12h
   values:
     # Use pre-created ConfigMap (key MUST be config.yaml)
-    externalConfigMap: gatus-config
+    # Chart's _pod.tpl has TWO ConfigMap references: the volume mount uses
+    # .Values.externalConfigMap, but envFrom hardcodes the release name
+    # (`names.fullname`). So the ConfigMap must be named `gatus` — the
+    # release name — to satisfy both.
+    externalConfigMap: gatus
 
     # PVC for history persistence (sqlite at /data/data.db)
     persistence:


### PR DESCRIPTION
## Summary

Unblocks the Gatus pod after #241. With the HelmRepository type fix in
place, the chart installed cleanly but the pod stayed Pending:

```
Warning  Failed  spec.containers{gatus}: Error: configmap "gatus" not found
```

The chart's `_pod.tpl` has **two** ConfigMap references and only one
honors `.Values.externalConfigMap`:

| Location | Reference | Value used |
|---|---|---|
| `volumeMount` / `volumes` (line 101-103) | `externalConfigMap \| default fullname` | `gatus-config` ✓ |
| `envFrom` (line 56-58) | `fullname` (hardcoded) | `gatus` ✗ |

So the volume mount picked up my externalConfigMap=`gatus-config` and
mounted `/config/config.yaml` from the right place, but the pod's
`envFrom` tried to populate the environment from a ConfigMap named after
the release — `gatus` — which didn't exist.

## Fix

- Rename the ConfigMap `metadata.name` from `gatus-config` to `gatus` (the release name)
- Update `externalConfigMap: gatus-config` → `externalConfigMap: gatus` so both references resolve to the same ConfigMap

The key inside the ConfigMap (`config.yaml`) is unchanged, so the volume mount under `/config/config.yaml` still works correctly.

## Timeline of the Gatus rollout

| # | Issue | Fix |
|---|---|---|
| #239 | Namespace not in `platform` (kustomize-controller ref validation failed) | — |
| #240 | Namespace oversight resolved | ✅ merged |
| #241 | `HelmRepository.spec.type: website` rejected by Flux v2 CRD | ✅ merged |
| #242 | `envFrom` ignores `externalConfigMap` (chart bug) | **this PR** |

## Changes

- **Modified**: `k3s/applications/gatus/config.yaml` — `metadata.name: gatus-config` → `gatus`
- **Modified**: `k3s/applications/gatus/helmrelease.yaml` — `externalConfigMap: gatus-config` → `gatus`, with a comment explaining the chart's dual-reference quirk

## Validation

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed
- `helm template` — `envFrom.configMapRef.name: gatus` (confirmed the envFrom references the release name)

## Chart bug worth filing upstream

The `envFrom` reference in `_pod.tpl` line 58 should honor `externalConfigMap` like the volume mount does. This is a [bug in the TwiN/gatus chart](https://github.com/TwiN/helm-charts). Filing a PR upstream is a separate effort (no impact on this repo once #242 merges).

## Post-merge checklist

- [ ] `kubectl get pods -n gatus` shows a Running pod
- [ ] `kubectl get hr -n gatus gatus` flips to `Ready=True`
- [ ] `https://gatus.homelab.properties` returns 200 (after Authentik login)

Refs: continues the work from #239, #240, #241.