### PR TITLE
feat(gatus): native OIDC auth against Authentik

### DIFF
--- a/k3s/applications/gatus/config.yaml
+++ b/k3s/applications/gatus/config.yaml
@@ -11,6 +11,16 @@ data:
     storage:
       type: sqlite
       path: /data/data.db
+    security:
+      oidc:
+        issuer-url: https://auth.homelab.properties/application/o/gatus/
+        redirect-url: https://gatus.homelab.properties/authorization-code/callback
+        client-id: ${OIDC_CLIENT_ID}
+        client-secret: ${OIDC_CLIENT_SECRET}
+        scopes:
+          - openid
+          - email
+          - profile
     ui:
       title: "Homelab Health Dashboard"
       header: "Homelab Status"

--- a/k3s/applications/gatus/gatus-oidc-secret.sops.yaml
+++ b/k3s/applications/gatus/gatus-oidc-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gatus-oidc-secret
+    namespace: gatus
+stringData:
+    OIDC_CLIENT_ID: ENC[AES256_GCM,data:CPBG7ow=,iv:ZkNkEL2srYqLnmLv+xJtk31yzch1sLzgApoigr410ic=,tag:+0EbZAolrltQpFJrgFqm0A==,type:str]
+    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:jAvH1Eb2YH/QvPS1IaDm9VWoD+MVLBcnlq4y4AbqUJkzj0jIxViuXHCUJYf2nJDhuItYGuB7wgtWUiCOxiy2,iv:dPOD3qShzDCd6ApL/gSIjZ6G6HPEMf1qiW77Faqlaxg=,tag:LCbo1uutFsHrkGGf0bB7uQ==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpZTI1Ri8vOERKS1E2S1V3
+            T2IvSFJoWG4xM0F1ZWl1RnBFRkl2YUlEcFNnCnY0cEwxcTdyRlhFSzRjVlYwaUsr
+            L0Jkc0NVNmgwemp4K09HNnlZcUl3Wk0KLS0tIFF1T3REZlY4bzF0aWM5dFk4MERS
+            MENiMS8vMldxYTcwdWpDempaLyt4aTAKfZaH3bOcVj7HaNnJ91YLFHzkzYwNhn1+
+            C4yXx+Jxeu2XpyN8npFi3dIJo9UuS+NNx8RNbDmzA1Hc4yFR2K908g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-08-07T01:32:27Z"
+    mac: ENC[AES256_GCM,data:0J9Ht8tLKeA6tvNWBinnzMgc4uHMVjpRBeIMoEy42qVOlY8cNYfjByBtsz0fbYwy3eQobXJRcKd4Xh91gmZL56hXqDI1ZD4rOMPvz+pneEKttUSTEmdKlQnCfsL3M4YVNmcURgbPIuZSxSdJbrxwzXA7W0fvyxbyLGyptzwY+eQ=,iv:UhT18mjpKGdZhqVqHiXl4yccRzSzpTJVVP0VXvch7Ic=,tag:tDvmghMHMcqOyz06sL63fw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/k3s/applications/gatus/helmrelease.yaml
+++ b/k3s/applications/gatus/helmrelease.yaml
@@ -30,6 +30,19 @@ spec:
     # release name — to satisfy both.
     externalConfigMap: gatus
 
+    # Pin image tag explicitly. Chart appVersion is v5.34.0, but v5.34+
+    # has native OIDC support; v5.36.0 is the latest Gatus at chart time.
+    # Per AGENTS.md: chart version != image tag, pin explicitly.
+    image:
+      tag: v5.36.0
+
+    # Inject OIDC credentials from the SOPS-encrypted secret. The values
+    # are then referenced in config.yaml as ${OIDC_CLIENT_ID} and
+    # ${OIDC_CLIENT_SECRET} — Gatus's env-var substitution in the config.
+    extraEnvFrom:
+      - secretRef:
+          name: gatus-oidc-secret
+
     # PVC for history persistence (sqlite at /data/data.db)
     persistence:
       enabled: true
@@ -39,7 +52,9 @@ spec:
         - ReadWriteOnce
       storageClassName: local-path
 
-    # Ingress with Traefik + cert-manager + cross-namespace Authentik forwardAuth
+    # Ingress with Traefik + cert-manager. Auth is now Gatus-native OIDC
+    # (via the security.oidc block in config.yaml), so no Traefik
+    # forwardAuth middleware is needed.
     ingress:
       enabled: true
       ingressClassName: traefik
@@ -48,9 +63,6 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         traefik.ingress.kubernetes.io/router.entrypoints: websecure
-        # Reference the Authentik forwardAuth middleware in the monitoring namespace
-        # Traefik cross-namespace middleware reference: <namespace>-<name>@kubernetescrd
-        traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
       hosts:
         - gatus.homelab.properties
       tls:

--- a/k3s/applications/gatus/kustomization.yaml
+++ b/k3s/applications/gatus/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - config.yaml
+  - gatus-oidc-secret.sops.yaml

--- a/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
+++ b/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
@@ -4,27 +4,28 @@ metadata:
     name: authentik-secret
     namespace: authentik
 stringData:
-    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:BLDY/8DpCnc+TeuE7uyJrA+zvZD5tcm4,iv:l4HHCyHvVqCExVawBNZ0DcMYsd5oqVaZiAMToN8E98s=,tag:8Ih4VotQDYtsiNnmNLrMjQ==,type:str]
-    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:l8RQTq++k5S9sXu1Q19E1idjhzLx2NHKc+SI+/f9AY4Y/bVXnxEyrA==,iv:eBwkEkOT9mBOQ6435by4Yw7Gt+GDY4xyh9w/1oU4K4M=,tag:tYZxD6AryOF9IlYz2MjfAQ==,type:str]
-    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:GXC1KQJe79Ljg25npin6DRU04ykqPt4O6Twzp/5hz1SYxU6wGhHUTED3RQOdFOvbyW8=,iv:0sLQ7JWqG7n686csPmH20Fnda2F/hRfFHUbQgEc3u78=,tag:HqFngn6vTtHCcW1dYNggPA==,type:str]
-    grafana-oidc-client-secret: ENC[AES256_GCM,data:i1esVa941j616BZZaxFp5ha6BM3F0PO5fzTfSM0hv6Y=,iv:1kRPZszXsKfNuKLdTcDX6SPUj+FejtC8+2SSdgwvRxM=,tag:yqFD8o6vV6f8Sf33W4f3Bw==,type:str]
-    headlamp-oidc-client-secret: ENC[AES256_GCM,data:X7Jl3miFqUeGVaTKDAz7tlDtcUeRntNP1rPfXkjO+is=,iv:RMll2EUebnhHxOr9nw6lSmmxciqNzx5x9xfu8VUMmFE=,tag:Em3EqdDQAh/CTCpz8TclNQ==,type:str]
-    outpost-token: ENC[AES256_GCM,data:oPiB1nnYgKoIzHhtpTVA8Oj/2UDVmWg7U8jQ/zy0NQp5N8wHcgcIgQNn0t5mIpBfvB3gFKRdSOHlQPPK,iv:6PZDB9paHFKcbyHnfklJYmYDOctRPDNtReSE6+87rFk=,tag:XqzgEuB9GfiFsPwWIDxtwA==,type:str]
-    portainer-oidc-client-secret: ENC[AES256_GCM,data:bHMDWneq1NS0aXa8YXPMCAcEWT78RYpHiRWmfPRDNBhsPjmVfahqF7Uc/RNFn19dtBtYLKcuNTu42pBIbYHlgA==,iv:77yLmgEneht7bG11DtFpNygNi9tkS0b5TeRX8X3ku2A=,tag:6wsUbEUaz/L/B98QiJ87dA==,type:str]
-    postgresql-password: ENC[AES256_GCM,data:kllmtrVMNJBK+XGFRuSj9LBMeJrgIvZnnppJb9qhqTU=,iv:V+EWPfo+67Wh/eawpoH1vUuml4RPfYohH7NDiUd5x5g=,tag:4+k+cZoljU+b0rD6CgI69g==,type:str]
-    redis-password: ENC[AES256_GCM,data:T708POBgIGyGcT+3NnyCSLcvSnvl4ue70oiNiQKAhPc=,iv:i7TDTP+JtXgPJNER6NVl1ZoyT2uYRPzIJRwrJMZaIb8=,tag:WHTt4jcEl70MZprv3HbVyQ==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:+2zNR9thdGqzlXNlMP4sze1RxtUet9yp,iv:oYUrSbg2eM64HuphDraflZc8Zqa6YKIXW5odtRevtD4=,tag:Cqjup4lmNbTkavFYuYFmpg==,type:str]
+    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:CeJ8+UK4bM79WCkMfez/sDK9gnr1OT9B+RPN+l7jYVaInOgwU/eMOA==,iv:WBPRd7mkD+sWKG5FTxP0fdCeiTGs4ZpRzow5fk/J/Cg=,tag:c2gH36Y8rJfmLbNFRDYUPw==,type:str]
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:IrpDGTHpRl7yX6gxw5oaKfcRx53NOkeaTJHpZs1pjMGFPl1x0+V2PYcV9vUtHYmhqts=,iv:VRinO8nTIFSLke4MLgV1flpasnxd9mpb3zfEnJ5dr/E=,tag:AM3PCmHXt2xQ1q7Cpv0K6A==,type:str]
+    grafana-oidc-client-secret: ENC[AES256_GCM,data:pKCLAom7CZfSCC2TNZYsL+K9IyDm+EQfIL4f8t5W6j8=,iv:PUV9G6TuBaoNWjqJSv/lPPSvYFOMwKst34GfjwKmUOA=,tag:s9SgVWrh8WzK6T0uBQNMMw==,type:str]
+    headlamp-oidc-client-secret: ENC[AES256_GCM,data:7g4wFCQH2yWzT86SvcmKYsbsMkWV1wFWAsspbLQkMRA=,iv:sUkFVHYDCz2Ydn0hqoQ8Gp0VVPgrPpA5h6pu1ek1IgA=,tag:kYEUpJyG3b5q/jIyls06VA==,type:str]
+    outpost-token: ENC[AES256_GCM,data:JtTHAkgrSvrCKR6ZeouNUJqVWlyqMzwYpTbJlW4f/DUQMKt+YT49Uj3EdCsVcfYeTb25AcfRBz578VwJ,iv:M6zLcpPbcLckcWjqej4x605HEnaQAsoScTDAQ391fHM=,tag:0kDx2fy9Xc4VE+A3eY9scQ==,type:str]
+    portainer-oidc-client-secret: ENC[AES256_GCM,data:jN3po/eCYxKrnF7FN2/fIZ7NUs6nAoOOAW7HC+/PYv2cCkVyPpzPstuFVFt4PedD/QAYs062Rx6LuJMC521WbA==,iv:dtcr+qXU5wp8dWEpsUcPALahOYPAphohHE/CCHS1Sw8=,tag:cBGVJrnCPvxoulG8iuBdRA==,type:str]
+    gatus-oidc-client-secret: ENC[AES256_GCM,data:l0GD1+u2ZZsp9W+4d6XSri4xwtCQiyNh9OTU8pOdid1et7twc1grZVhxT4sJAjeIz5fjB/rO/fZEjlz3oSiW,iv:eMBliiIIO6K0gt8oKmPE6gC2SNMjMHbME8HmnpYi1rA=,tag:Oe07KPGWOh3YSISXat3RDg==,type:str]
+    postgresql-password: ENC[AES256_GCM,data:IPNLtvh0FnV/YdsCVMVLE/N43jsLCZ0kmxpP3uK+DNY=,iv:8hIf62jJNLJalt4naTFqoIh4Ajm0a65FJZgSW/6BZkU=,tag:W4/JPUsKplqOYzJV1YiD1Q==,type:str]
+    redis-password: ENC[AES256_GCM,data:zDimQ6Y9qj1tY7BUQZuH3lB+72kEq/SJTPXgGsBwm9w=,iv:9CjZ0y9UjH+ZRWFcjmKeCGjUJoDGVrvjkH25Ee5Bxj0=,tag:UfuMDXlePZXnWD6m416BeQ==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFWnViQm1aNlNMd2oxVUhT
-            T0NLeCtjaVNyMURhb3BNMzhpSEJ6S1pzRFdvCkxWZ3E0aWhZVFdNbUhqZmFZWEJ6
-            WDArVXdGL2t6cTRrOUhzK2dZR2lRZDAKLS0tIGlXdUwzNSswd1dvenVXYXZFckdM
-            aEVRdlE2UW1UVUlaRWNFZ1prZ012cnMKloCavY0cfPMbxAY1bS2rvJUZM18IFmT9
-            AxopG7sFUeRJhOW4abVqiD6Y8wIBITmBT1V8KIniy9C6SflksreJ/g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPVi85Zm5IU1Y1NkxJL3hE
+            NVBYaklGa2gxamRXb21KYkx5K3pmNmVGMWlVCklpY3FWQjcrMGdyaEQ1aklzVldO
+            d0ZwMUkxSDBsOUJsYnJxRk1sRWowa3MKLS0tIDhwL2tMUVlmaVM1TzdQV1YycmZ5
+            QmRHNlA5ZisvQVZic1BuZEd3ejZWRmMKcI/udsiu17DuluFvvxF/xtKLxjLJIHOV
+            WzAghp7ZyU9YvKhoGExBndGoDiuJM35jjLY7XQAACENxWihagIa8Ug==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-02T01:03:04Z"
-    mac: ENC[AES256_GCM,data:lROl6X9nq7LBMQeRobvcNeb5Nsux7m8+MlhE2W42wr0PmjQkXa2gdNicbfmylgIqYDvd4TmaVZUtTUaLgdh/Mw6Bc0x6cOdmkAmMKoz7bnwAKLkQGF9mI8ijmMFRZcS9ekrvBY+6Jzu2r/35hSH4b70PyDxjbbGuvo1Gh5GsnZM=,iv:joIngVf7kpelNbwjHJrc24H0SfGiUABn5mHeiyxXdaE=,tag:qotW+J3SvtGDxvcgOqCmKQ==,type:str]
+    lastmodified: "2026-08-07T01:33:59Z"
+    mac: ENC[AES256_GCM,data:i+k2CI7VHWJeNfEDzaYwBOhTyEx1ZzxlC3abMz+e+GTqI5OqVFbSxRBs9t4xVsDExD+Tl73nlLtYITxKHWxmV86vGgafN3ngUWQpRWN01sl275JsJ5eZ8NqEom8ZjNgcETC7IKdrCBPE/Zi7JsPyyseBY6r6ALSKcpX1Mq1ZyU8=,iv:Vj3zo0Rjo0NObqdUGEVMR6As1fCq9CW6USyYF6SKYDE=,tag:guNFDQekud1VvpeFxHaukg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -145,6 +145,38 @@ data:
           config:
             authentik_host: https://auth.homelab.properties
             authentik_host_insecure: false
+  gatus-provider.yaml: |
+    version: 1
+    metadata:
+      name: "Gatus OIDC Provider"
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        state: present
+        identifiers:
+          name: gatus-provider
+        attrs:
+          name: gatus-provider
+          client_type: confidential
+          client_id: gatus
+          client_secret: !Env AUTHENTIK_ENV__GATUS_OIDC_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          redirect_uris:
+            - matching_mode: strict
+              url: "https://gatus.homelab.properties/authorization-code/callback"
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: gatus
+        attrs:
+          name: Gatus
+          slug: gatus
+          provider: !Find [authentik_providers_oauth2.oauth2provider, [name, gatus-provider]]
   portainer-oidc.yaml: |
     version: 1
     metadata:

--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -62,6 +62,10 @@ spec:
       targetPath: authentik.env.PORTAINER_OIDC_CLIENT_SECRET
     - kind: Secret
       name: authentik-secret
+      valuesKey: gatus-oidc-client-secret
+      targetPath: authentik.env.GATUS_OIDC_CLIENT_SECRET
+    - kind: Secret
+      name: authentik-secret
       valuesKey: postgresql-password
       targetPath: authentik.postgresql.password
     - kind: Secret


### PR DESCRIPTION
## Summary

Replaces the v1 Traefik forwardAuth (which required an Authentik Proxy Provider and Application that were never created) with **Gatus's own native OIDC support**, available in Gatus v5.35+. Matches the Grafana pattern already in production.

This is the work deferred from #238 and the follow-up to the post-merge troubleshooting in #239/#240/#241/#242 where the forwardAuth deployment surfaced as a "no app for hostname" rejection from Authentik.

## Bundle scope (Path A)

The four pieces are tightly coupled and have to apply together for the OAuth dance to resolve, so they ship in one PR.

### 1. Authentik side

- **`k3s/infrastructure/configs/authentik/blueprints-configmap.yaml`** — new `gatus-provider.yaml` block defining an oauth2provider named `gatus-provider` (client_id=`gatus`, scopes=`openid`/`email`/`profile`, redirect_uri matching Gatus's `/authorization-code/callback`) and an `Application` with `slug=gatus`. Mirrors the existing `headlamp-provider.yaml` and `portainer-oidc.yaml` blocks.
- **`k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml`** — new `gatus-oidc-client-secret` key. Value is a random 64-char string generated locally, encrypted in place with the homelab age key.
- **`k3s/infrastructure/configs/authentik/helmrelease.yaml`** — new `valuesFrom` mapping that key to `authentik.env.GATUS_OIDC_CLIENT_SECRET` so the `!Env AUTHENTIK_ENV__GATUS_OIDC_CLIENT_SECRET` tag in the blueprint expands correctly.

### 2. Gatus side

- **New `k3s/applications/gatus/gatus-oidc-secret.sops.yaml`** in the `gatus` namespace with `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` (same value as the Authentik-side key).
- **`k3s/applications/gatus/config.yaml`** — `security.oidc` block with `issuer-url`, `redirect-url`, `scopes`, and `client-id`/`client-secret` read from env vars via Gatus's `${VAR}` substitution.
- **`k3s/applications/gatus/helmrelease.yaml`** — `image.tag` pinned to `v5.36.0` (chart's appVersion is v5.34.0, which predates native OIDC; per AGENTS.md chart-vs-appVersion rule), `extraEnvFrom` wires the OIDC secret into the pod, and the `traefik.ingress.kubernetes.io/router.middlewares` annotation is dropped.
- **`k3s/applications/gatus/kustomization.yaml`** — picks up the new SOPS secret.

### 3. Truths preserved

- The `monitoring-authentik-forwardauth` middleware stays in `monitoring/` for future apps that need Traefik-level auth — gatus just stops using it.
- All four prior PRs in the gatus chain (#239–#242) remain the source of truth for the HelmRelease, ConfigMap, namespace, and HelmRepository wiring.

## Validations

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed
- `gatus` binary v5.36.0 against the extracted ConfigMap with `OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET` set:
  - `Validated 7 endpoints` ✓
  - `Total endpoint keys to preserve: 7` ✓
  - Startup proceeded to OIDC discovery fetch — the 404 panic from Authentik is expected because the `gatus` Application doesn't exist in Authentik until this PR's manifests are reconciled there.

## Post-merge order

1. `infra-configs` reconciles `authentik-secret` + `blueprints-configmap` → Authentik pod applies the new `gatus-provider` + `gatus` Application
2. `apps` reconciles `gatus-oidc-secret` + `gatus` HelmRelease
3. Gatus pod starts, OIDC discovery URL returns 200, login flow becomes available at `https://gatus.homelab.properties`

## Future work (still tracked in #238)

- Endpoint coverage review after one week of uptime
- No further auth work — the native OIDC path is now in place

Closes the auth half of #238.