### PR TITLE
fix(gatus): use envFrom (not extraEnvFrom) for OIDC secret injection

### DIFF
--- a/k3s/applications/gatus/helmrelease.yaml
+++ b/k3s/applications/gatus/helmrelease.yaml
@@ -39,7 +39,13 @@ spec:
     # Inject OIDC credentials from the SOPS-encrypted secret. The values
     # are then referenced in config.yaml as ${OIDC_CLIENT_ID} and
     # ${OIDC_CLIENT_SECRET} — Gatus's env-var substitution in the config.
-    extraEnvFrom:
+    # The chart's _pod.tpl appends `.Values.envFrom` to its own
+    # built-in envFrom (which references the configMap and (when
+    # .Values.secrets is set) the release-name secret). Field name is
+    # `envFrom`, not `extraEnvFrom` — the chart silently ignores
+    # unknown keys, so #243 left the OIDC env vars unset and the pods
+    # panicked with "invalid security configuration" on every start.
+    envFrom:
       - secretRef:
           name: gatus-oidc-secret
 


### PR DESCRIPTION
## Summary

Unblocks the gatus pods after #243. Both pods (`gatus-585dfcb5d6-9s6fx` v5.34.0 and `gatus-67846b5f48-cmw66` v5.36.0) were in CrashLoopBackOff with the same panic:

```
panic: error parsing config: invalid security configuration
```

## Root cause

PR #243 introduced `extraEnvFrom` to inject the OIDC credentials from the `gatus-oidc-secret` secret into the pod. The chart's `_pod.tpl` only consumes `.Values.envFrom` — `extraEnvFrom` is not a value the chart reads:

```yaml
envFrom:
  - configMapRef:
      name: {{ include "names.fullname" . }}    # built-in
  {{- if .Values.envFrom }}
  {{- toYaml .Values.envFrom | nindent 6 }}      # the only extension point
  {{- end }}
```

Unknown keys are silently ignored, so the OIDC credentials never reached the pod. With `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` both empty, `security.oidc.ValidateAndSetDefaults()` produced the panic. Both pods (old and new) hit the same panic because the *config* is what changed, not the image — the v5.34.0 pod was carrying the new config until the new ReplicaSet rolled it out.

## Fix

Rename `extraEnvFrom` → `envFrom` in the HelmRelease. The chart's `_pod.tpl` appends `.Values.envFrom` to the built-in list, so the rendered pod spec will now have:

```yaml
envFrom:
  - configMapRef:
      name: gatus                  # chart's built-in (release name)
  - secretRef:
      name: gatus-oidc-secret     # our injection
```

## Validation

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test` — 5/5 passed
- `helm template` — confirmed `secretRef.name: gatus-oidc-secret` is now in the rendered manifest
- `gatus v5.36.0` binary against the config with env vars set — proceeds past config validation; only the expected OIDC discovery 404 from Authentik remains (which is the next milestone)

## CI gap (filed for #238 follow-up)

This is exactly the failure mode the AGENTS.md "verification gotchas" warns about. The right validation step is `helm template` + manifest inspection — I did that in #243 but missed checking whether the secretRef actually rendered. Adding a CI step that greps `helm template` output for `secretRef` when a PR touches `k3s/applications/<app>/` is a follow-up; not in scope here.

## Follow-up I also want to flag

The Authentik worker log shows `clear_failed_blueprints` running at 01:44:20, which suggests the `gatus-provider.yaml` blueprint failed to apply earlier. If the OIDC discovery URL still returns 404 after this PR merges (the worker picks up the ConfigMap on its own schedule), the failure needs investigation — could be a Blueprint schema mismatch or a missing precondition. Filing separately.

Refs: continues the work from #239, #240, #241, #242, #243.