### PR TITLE
fix(authentik): enable blueprint discovery on the worker

### DIFF
--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -127,6 +127,18 @@ spec:
               - auth.homelab.properties
 
     worker:
+      # Tell the worker where to discover custom blueprints. The
+      # ConfigMap is already mounted at /blueprints/custom (see volumes
+      # below); without this env var, the worker doesn't scan the
+      # directory and the blueprints sit inert. The existing providers
+      # (grafana / headlamp / portainer) were applied via the Authentik
+      # UI/API before this discovery loop existed; their blueprint files
+      # in the ConfigMap are the git-tracked export of that state.
+      # The gatus-provider.yaml added in #243 needs this scanning to
+      # actually land as live providers + applications.
+      env:
+        - name: AUTHENTIK_BLUEPRINTS_DIR
+          value: /blueprints/custom
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

Completes the gatus-native OIDC rollout that's been blocked since #243 merged. The HelmRelease rendering was correct, the OIDC config schema was correct, the env vars were being injected — but the Authentik worker **never picked up the gatus-provider.yaml blueprint** because `AUTHENTIK_BLUEPRINTS_DIR` was unset, so the mount at `/blueprints/custom/` was decorative.

Why the existing providers (grafana / headlamp / portainer) are still live: their YAML files in the configmap are the **git-tracked export** of state that was originally created via the Authentik UI/API. The blueprints are now the source-of-truth for new providers (gatus, future apps), with the worker as the apply mechanism.

## Fix

One line in `k3s/infrastructure/configs/authentik/helmrelease.yaml`:

```yaml
worker:
  env:
    - name: AUTHENTIK_BLUEPRINTS_DIR
      value: /blueprints/custom
```

The ConfigMap is already mounted at `/blueprints/custom/` (see volume + volumeMounts right below it). The worker just wasn't told to scan it.

## Validations

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed
- `helm template authentik /tmp/authentik-chart/authentik` with the new values — `AUTHENTIK_BLUEPRINTS_DIR` shows up in the worker container env block, volumeMounts and ConfigMap mount still render correctly

## The existing blueprints are the blueprint example

The `k3s/infrastructure/configs/authentik/blueprints-configmap.yaml` now serves as the canonical template for future OIDC client additions. The pattern for a new app is:

1. Add a `<app>-provider.yaml` key to the ConfigMap with `model: authentik_providers_oauth2.oauth2provider` + `model: authentik_core.application` entries (use `gatus-provider.yaml` as the minimal example)
2. If the provider needs a client secret, add a `valuesFrom` row to `authentik/helmrelease.yaml` mapping the secret to `authentik.env.<APP>_OIDC_CLIENT_SECRET`
3. Reference the secret from `AUTHENTIK_ENV__<APP>_OIDC_CLIENT_SECRET` in the blueprint via `!Env`

The existing `gatus-provider.yaml` from #243 already covers all of this for gatus, so the next person inherits a working reference.

## Post-merge chain

1. `infra-configs` reconciles → Authentik worker pod rolls with the new env var
2. Worker scans `/blueprints/custom/`, picks up `gatus-provider.yaml`
3. Idempotent apply: existing grafana/headlamp/portainer providers are skipped (already in DB), `gatus-provider` + `gatus` Application are created
4. OIDC discovery URL at `https://auth.homelab.properties/application/o/gatus/.well-known/openid-configuration` starts returning 200 JSON
5. gatus pods (currently in CrashLoopBackOff on OIDC discovery 404) recover
6. `https://gatus.homelab.properties` redirects to the Authentik login flow

## Cumulative chain (full gatus thread)

| # | PR | Fix |
|---|---|---|
| #239 | Initial deploy | Namespace + ConfigMap + HelmRelease + ServiceMonitor wiring |
| #240 | Namespace in platform layer | `k3s/platform/namespaces/gatus.yaml` |
| #241 | HelmRepository.type | Removed invalid `type: website` |
| #242 | ConfigMap name | Renamed to release name (`gatus`) |
| #243 | Native OIDC | Authentik blueprint + Gatus OIDC config + secret + image pin |
| #244 | envFrom field | `extraEnvFrom` → `envFrom` |
| **#245** | **Blueprint discovery** | **`AUTHENTIK_BLUEPRINTS_DIR` on worker** |

Refs: closes the loop on #238's auth half. No further gatus work pending.