### PR TITLE
fix(authentik): add grant_types to gatus-provider blueprint

### DIFF
--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -169,6 +169,23 @@ data:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+          # grant_types must include authorization_code for the OIDC
+          # code flow that gatus uses. The model default is an empty list,
+          # so without this the /authorize endpoint returns
+          # "Invalid grant_type for provider" and the redirect lands
+          # at the callback with ?error=invalid_request.
+          # The set below matches the other providers in this configmap
+          # (grafana, headlamp, portainer) which were created via the
+          # Authentik UI before the blueprints existed and so have the
+          # full Authentik default set.
+          grant_types:
+            - authorization_code
+            - hybrid
+            - implicit
+            - client_credentials
+            - password
+            - urn:ietf:params:oauth:grant-type:device_code
+            - refresh_token
       - model: authentik_core.application
         state: present
         identifiers:


### PR DESCRIPTION
## Root cause

The gatus provider was created with `grant_types=[]` because the blueprint from #243 didn't specify the field and the `OAuth2Provider` model default is an empty list. The other three OAuth2 providers in this configmap (`grafana`, `headlamp`, `portainer`) all have the full Authentik default `grant_types` set — they were created via the Authentik UI before the blueprints existed, so when the blueprint was later applied it preserved the existing fields that weren't in `attrs`. The gatus provider has no such history, so its defaults are what the blueprint says.

The `/application/o/authorize/` endpoint returns `Invalid grant_type for provider` when the `grant_type` parameter (`authorization_code` in the OIDC code flow) is not in the provider's `grant_types`. Authentik then redirects to the callback with `?error=invalid_request&error_description=The%20request%20is%20otherwise%20malformed` — exactly what the user sees.

Authentik server logs (the smoking gun):
```
"event": "Invalid grant_type for provider", "grant_type": "authorization_code"
"event": "The request is otherwise malformed", "redirect_uri": "https://gatus.homelab.properties/authorization-code/callback"
```

Postgres comparison confirms the divergence:
```
gatus-provider     | {}                                                                                                  ← empty
grafana-provider   | {authorization_code, hybrid, implicit, client_credentials, password, urn:ietf:params:oauth:grant-type:device_code, refresh_token}
headlamp-provider  | {authorization_code, hybrid, implicit, client_credentials, password, urn:ietf:params:oauth:grant-type:device_code, refresh_token}
portainer-provider | {authorization_code, hybrid, implicit, client_credentials, password, urn:ietf:params:oauth:grant-type:device_code, refresh_token}
```

## Fix

Add `grant_types: [...]` to the `gatus-provider.yaml` block in `k3s/infrastructure/configs/authentik/blueprints-configmap.yaml`, matching the set the other three providers have.

## Validations

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed

## Post-merge chain

1. `infra-configs` reconciles → Authentik worker pod sees the new ConfigMap
2. Worker re-applies the gatus blueprint; the `attrs` block now includes `grant_types`, so the existing gatus provider is updated (not recreated)
3. `grant_types` is populated with the standard set
4. OIDC dance succeeds; `https://gatus.homelab.properties` no longer redirects to the callback with `?error=invalid_request`

## Heads-up

The fix is **persistent** but **not immediate** — the worker needs to re-run the blueprint apply. In the meantime, the OIDC flow is still broken. If you want the immediate unblock, the DB patch from earlier works:

```sql
UPDATE authentik_providers_oauth2_oauth2provider SET grant_types = ARRAY['authorization_code','hybrid','implicit','client_credentials','password','urn:ietf:params:oauth:grant-type:device_code','refresh_token']::text[] WHERE provider_ptr_id = (SELECT id FROM authentik_core_provider WHERE name = 'gatus-provider');
```

That sets the same value Authentik will set after this PR merges. Once the worker re-applies the blueprint, it won't undo the DB-patched value (the blueprint's `attrs` block matches what's already in the DB).

## Related

- #238 — Gatus follow-up issue (auth half closed by #243; remaining items are ServiceMonitor + endpoint coverage review)
- #243 — Initial native OIDC rollout (introduced the gatus blueprint)
- #245 — Added `AUTHENTIK_BLUEPRINTS_DIR` so the worker scans the blueprints (this PR assumes the worker is actually applying blueprints)