### PR TITLE
fix(gatus): tune three endpoint conditions to match actual responses

### DIFF
--- a/k3s/applications/gatus/config.yaml
+++ b/k3s/applications/gatus/config.yaml
@@ -33,9 +33,12 @@ data:
         group: auth
         url: https://auth.homelab.properties/-/health/ready/
         interval: 60s
+        # The body of /-/health/ready/ is HTML (the login page redirect,
+        # not a JSON health status), so the [BODY].status check fails —
+        # the body isn't a JSON document. The existing blackbox probe
+        # uses the same URL and just checks 2xx/3xx. Drop the body check.
         conditions:
           - "[STATUS] == 200"
-          - "[BODY].status == running"
 
       # dashboards group
       - name: headlamp
@@ -55,10 +58,15 @@ data:
       # media group
       - name: tdarr
         group: media
-        url: http://tdarr.homelab.properties:8265/api/v1/health
+        # The actual API server is on port 8266 — port 8265 is the webui
+        # and doesn't expose /api/v1/health (returns 404). The existing
+        # blackbox probe uses 8266 too. Tdarr redirects unauthenticated
+        # requests to login, so accepting sub-400 status codes is the
+        # right check (matches the blackbox probe's http_2xx module).
+        url: http://tdarr.homelab.properties:8266/api/v1/health
         interval: 60s
         conditions:
-          - "[STATUS] == 200"
+          - "[STATUS] < 400"
 
       # monitoring group
       - name: grafana
@@ -79,7 +87,10 @@ data:
       # dns group
       - name: pihole
         group: dns
-        url: http://pihole.homelab.properties/admin/
+        # /admin/ alone returns 404 on the pihole web service — the
+        # actual admin interface is at /admin/login.php. The unauthenticated
+        # login page returns 200, which is what we want for "is pihole up".
+        url: http://pihole.homelab.properties/admin/login.php
         interval: 60s
         conditions:
           - "[STATUS] == 200"


### PR DESCRIPTION
## Three endpoints were reporting down because the gatus conditions didn't match the actual response shape, not because the services were down.

| Endpoint | Was | Problem | Fix |
|---|---|---|---|
| authentik | `https://auth.homelab.properties/-/health/ready/` | Returns 200 with HTML body (login page redirect), not JSON. `[BODY].status == running` fails. | Drop the body check. The existing blackbox probe uses the same URL with `http_2xx` (no body inspection). |
| tdarr | `http://tdarr.homelab.properties:8265/api/v1/health` | Port 8265 is the webui — `/api/v1/health` returns 404 there. The actual API server is on 8266. | Switch to port 8266. Use `[STATUS] < 400` to accept the 302 redirect (matches the existing blackbox probe's `http_2xx`). |
| pihole | `http://pihole.homelab.properties/admin/` | The bare `/admin/` path returns 404 on the pihole web service. | Use `/admin/login.php` (the actual admin interface URL). The unauthenticated login page returns 200. |

## Validations

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed

## Post-merge

1. `apps` Kustomization reconciles → ConfigMap updated
2. Gatus pod rolls (ConfigMap change triggers the rollout via the `checksum/config` annotation)
3. New conditions applied within ~1 minute
4. The three endpoints flip from down to up

## Related

- #238 — gatus follow-up issues (auth half closed by #243; remaining items are ServiceMonitor + endpoint coverage review)
- The OIDC grant_types fix in #246 completed the auth half of the gatus news; this PR polishes the monitored-endpoints half