### PR TITLE
fix(gatus): pihole endpoint uses /admin/login (no .php) on https

### DIFF
--- a/k3s/applications/gatus/config.yaml
+++ b/k3s/applications/gatus/config.yaml
@@ -87,10 +87,7 @@ data:
       # dns group
       - name: pihole
         group: dns
-        # /admin/ alone returns 404 on the pihole web service — the
-        # actual admin interface is at /admin/login.php. The unauthenticated
-        # login page returns 200, which is what we want for "is pihole up".
-        url: http://pihole.homelab.properties/admin/login.php
+        url: https://pihole.homelab.properties/admin/login
         interval: 60s
         conditions:
           - "[STATUS] == 200"


### PR DESCRIPTION
## Root cause

The gatus pihole endpoint had two problems stacked:

1. **Wrong protocol**: `http://pihole.homelab.properties/admin/` — but the pihole Ingress only listens on Traefik's `websecure` entrypoint (HTTPS). HTTP requests get an immediate 404 from Traefik without a matching route. The 7ms failure duration in the gatus logs is consistent with that.

2. **Wrong path**: `/admin/` returns 302 to `/admin/login` (no .php), which is the actual login page. `/admin/login.php` (the PR #247 choice) returns 404 internally too — the pihole web service serves the login page at `/admin/login` (no .php).
   - Verified: `https://pihole.homelab.properties/admin/login` → 200
   - Verified: `https://pihole.homelab.properties/admin/login.php` → 404
   - Verified: `https://pihole.homelab.properties/admin/` → 302 → `/admin/login`

The pihole-dns service having a different metallb IP (`192.168.1.201`) is unrelated — that's the DNS service on port 53, not the web interface. The web is on `192.168.1.200` (Traefik) via the Ingress, same as everything else.

## Fix

`url: http://pihole.homelab.properties/admin/` → `url: https://pihole.homelab.properties/admin/login`

## Validations

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed
- Live curl: `https://pihole.homelab.properties/admin/login` returns 200 in ~26ms

## Side note (separate concern, not in this PR)

`k3s/infrastructure/configs/monitoring/probe-pihole.yaml` has the same `http://pihole.homelab.properties/admin/` URL — same blind spot. The blackbox exporter likely also reports pihole as down on the Prometheus side. Filing a follow-up for that separately.