### PR TITLE
fix(flux): lower opentelemetry-collector HelmRepository interval 24h→1h

### DIFF
--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrepository.yaml
@@ -5,5 +5,11 @@ metadata:
   name: open-telemetry
   namespace: flux-system
 spec:
-  interval: 24h
+  # OTel helm chart cuts 1-2 releases/week; a 24h interval was too long and
+  # caused Renovate bumps to land before the index caught up to a freshly
+  # published chart version (HelmChart reconcile failed with "no chart
+  # version matching 'X.Y.Z' found" until the next interval tick). 1h keeps
+  # the cache aligned with Renovate's Monday-morning schedule without much
+  # extra load — the index is small (~1.3 MB).
+  interval: 1h
   url: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
## Summary

Lower the `open-telemetry` HelmRepository interval from `24h` to `1h` so Renovate chart bumps don't land before the index cache catches up.

## Context

PR #232 bumped the OTel chart to 0.169.0. The OTel helm-charts `index.yaml` was republished *after* source-controller's last fetch (2026-08-07T17:33 UTC) but before #232 merged (2026-08-08T00:15 UTC). The next HelmRepository refresh wasn't due for ~17 more hours, so HelmChart reconcile stalled:

```
no 'opentelemetry-collector' chart with version matching '0.169.0' found
```

The chart was actually present in the public index — this is purely a Flux cache-staleness problem. Lowering the interval to 1h keeps the cache aligned with Renovate's Monday-morning schedule.

## Change

Single-file edit to `k3s/infrastructure/controllers/opentelemetry-collector/helmrepository.yaml`:

- `interval: 24h` → `interval: 1h`
- Added a comment explaining the reasoning (so the next person who sees "1h, why?" doesn't revert it).

## Why not lower the others?

- `cert-manager` and `metallb` HelmRepositories are slow-moving (~quarterly patch cadence). 24h is fine.
- `tempo` is similar.
- OTel is the outlier — ~1-2 chart releases per week.

## Verification

- `yamllint -c .yamllint.yaml k3s/infrastructure/controllers/opentelemetry-collector/` → exit 0, no warnings on the edited file (pre-existing `comments-indentation` warning on `helmrelease.yaml:54` is unrelated).
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` → exit 0, diff shows exactly one line changed.

## Immediate cluster remediation (separate from this PR)

Until this lands, the live cluster's `telemetry/opentelemetry-collector` HelmRelease is stuck in `False`. To unstick it *now* without waiting for the merge:

```bash
flux reconcile source helmrepository open-telemetry
# or:
kubectl annotate helmrepository -n flux-system open-telemetry \
  reconcile.fluxcd.io/requestedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
```

That refreshes the index in seconds and the HelmChart materializes.