### PR TITLE
fix(ansible): use dict subscript not .items in Jinja2 CRD migration template

### DIFF
--- a/k3s/bootstrap/ansible/roles/flux-upgrade/tasks/migrate-crd-versions.yml
+++ b/k3s/bootstrap/ansible/roles/flux-upgrade/tasks/migrate-crd-versions.yml
@@ -53,7 +53,7 @@
   ansible.builtin.set_fact:
     flux_crds_stale: >-
       {%- set ns = namespace(result=[]) -%}
-      {%- for crd in (all_crds_raw.stdout | from_json).items
+      {%- for crd in (all_crds_raw.stdout | from_json)["items"]
           if crd.metadata.name is search('\.toolkit\.fluxcd\.io$') -%}
         {%- set target_versions = flux_target_crd_versions.get(
               crd.metadata.name,
@@ -118,7 +118,7 @@
   when:
     - flux_crds_stale | length > 0
     - item.stdout is defined
-    - (item.stdout | from_json).items | length > 0
+    - (item.stdout | from_json)["items"] | length > 0
   changed_when: true
   delegate_to: localhost
   become: false


### PR DESCRIPTION
## Summary

Replace `.items` attribute access with `["items"]` subscript in two Jinja2 templates in `roles/flux-upgrade/tasks/migrate-crd-versions.yml`. This unblocks `upgrade-flux.yml`, which has never successfully completed against the testbed.

## The bug

```
TASK [flux-upgrade : Identify Flux CRDs with stale stored versions]
fatal: [testbed -> localhost]: FAILED! =>
  msg: |-
    Unexpected templating type error occurred on (...): 
    'builtin_function_or_method' object is not iterable
```

Two locations in `migrate-crd-versions.yml`:

```jinja
{%- for crd in (all_crds_raw.stdout | from_json).items        # line 56 — failing
    if crd.metadata.name is search('\.toolkit\.fluxcd\.io$') -%}
...
- (item.stdout | from_json).items | length > 0                 # line 121 — same bug, never reached
```

**Why it fails:** In Python, `(dict).items` returns a `dict_items` view (iterable). In **Jinja2**, attribute access on a dict returns the unbound method `dict.items`, not the view. The `for` loop tries to iterate the method itself → `TypeError: 'builtin_function_or_method' object is not iterable`.

**Fix:** subscript works in both Python and Jinja2:

```jinja
{%- for crd in (all_crds_raw.stdout | from_json)["items"]
    if crd.metadata.name is search('\.toolkit\.fluxcd\.io$') -%}
...
- (item.stdout | from_json)["items"] | length > 0
```

## Why this slipped through

`migrate-crd-versions.yml` was added in commit `5d0ffb7` (the `flux-bootstrap` → `bootstrap+upgrade` role split) and had **never been executed** before this run. The repo's CI (`yamllint` + `flux-local diff`) doesn't exercise Ansible templates — they pass `migrate-crd-versions.yml` structurally but never execute it. The Jinja2 / Python semantics gap only surfaces at runtime.

Same root cause as the OTel/kps HelmRepository cache-staleness pattern: CI gates validate **structure**, not **semantics**. Add `ansible-playbook --syntax-check` (or a smoke-test task) to the CI gates for any `k3s/bootstrap/ansible/**` change.

## Verification

Ran the patched playbook end-to-end against the testbed (`192.168.1.128`):

```
PLAY RECAP : testbed : ok=16  changed=0  unreachable=0  failed=0  skipped=10
TASK [flux-upgrade : No stale CRD stored versions detected]
  All Flux CRD storedVersions are current — no migration needed.
TASK [flux-upgrade : Display Flux upgrade summary]
  Flux CD upgraded to v2.8.7 and is healthy.
```

The 10 skipped tasks are the CRD-migration sub-tasks that only run when stale versions are detected (none are — all Flux CRDs are at v2.8.7).

## Diff

```diff
- {%- for crd in (all_crds_raw.stdout | from_json).items
+ {%- for crd in (all_crds_raw.stdout | from_json)["items"]
        if crd.metadata.name is search('\.toolkit\.fluxcd\.io$') -%}
...
-    - (item.stdout | from_json).items | length > 0
+    - (item.stdout | from_json)["items"] | length > 0
```