### PR TITLE
chore(ansible): bump Flux CLI default 2.8.7 → 2.9.4

### DIFF
--- a/k3s/bootstrap/ansible/roles/flux-bootstrap/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-bootstrap/defaults/main.yml
@@ -4,12 +4,12 @@
 
 # ─── Flux CLI ────────────────────────────────────────────────────────────────
 # Pinned version — check https://github.com/fluxcd/flux2/releases for updates.
-flux_cli_version: "2.8.7"
+flux_cli_version: "2.9.4"
 
 # Optional SHA256 checksum for the flux CLI archive (without the 'sha256:' prefix).
 # Find at: https://github.com/fluxcd/flux2/releases/download/v{{ flux_cli_version }}/flux_{{ flux_cli_version }}_checksums.txt
 # Leave empty to skip verification (not recommended for production).
-flux_cli_checksum: "493a8df42bf89f8481f03afb44b6f4801a76ec0f0b9233042487d0cb5c6cf4e3"
+flux_cli_checksum: "c2c397a52930f52d2005c01d276116b059d062de379386d58e98115380a766a2"
 
 # Directory where the flux binary is installed on the Ansible controller.
 flux_install_dir: "{{ lookup('env', 'HOME') }}/.local/bin"

--- a/k3s/bootstrap/ansible/roles/flux-upgrade/defaults/main.yml
+++ b/k3s/bootstrap/ansible/roles/flux-upgrade/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Flux CLI version to install/upgrade to
-flux_cli_version: "2.8.7"
-flux_cli_checksum: "493a8df42bf89f8481f03afb44b6f4801a76ec0f0b9233042487d0cb5c6cf4e3"
+flux_cli_version: "2.9.4"
+flux_cli_checksum: "c2c397a52930f52d2005c01d276116b059d062de379386d58e98115380a766a2"
 flux_install_dir: "{{ lookup('env', 'HOME') }}/.local/bin"
 
 # Kubeconfig for the target cluster


### PR DESCRIPTION
## Summary

Bump the pinned Flux CLI version from **2.8.7 → 2.9.4** in both Ansible roles, keeping them in sync.

## Verified upgrade

End-to-end against the testbed:
- `upgrade-flux.yml` ran clean (`ok=16 changed=0 failed=0 skipped=10`)
- `migrate-crd-versions` from #252 reported *"All Flux CRD storedVersions are current — no migration needed"* for the 2.8.7 → 2.9.4 transition
- Final task: *"Flux CD upgraded to v2.9.4 and is healthy."*

## Files (2)

| File | Change |
|---|---|
| `roles/flux-upgrade/defaults/main.yml` | `flux_cli_version` + `flux_cli_checksum` |
| `roles/flux-bootstrap/defaults/main.yml` | same two values |

SHA256: `c2c397a52930f52d2005c01d276116b059d062de379386d58e98115380a766a2` (from `flux_2.9.4_linux_amd64.tar.gz`).

## Why both files

`flux-bootstrap` is one-shot, but its defaults should track the same target version so a future re-bootstrap doesn't silently pin to the old release. The original `flux-bootstrap` → `bootstrap+upgrade` split (commit `5d0ffb7`) had both pinned at 2.8.7; bumping only `flux-upgrade` would have re-introduced that drift.

## Note on `flux_cli_checksum`

The `get_url` task at `roles/flux-upgrade/tasks/main.yml:101` uses `checksum: "sha256:{{ flux_cli_checksum }}"`. If `flux_cli_version` and `flux_cli_checksum` don't change together, either the download fails (wrong checksum) or the wrong archive gets installed. Both lines are coupled.