### PR TITLE
chore(ansible): bump k3s_version v1.36.0+k3s1 → v1.36.3+k3s1

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -45,7 +45,7 @@ k3s_sysctl_params:
 
 # K3s version installed on all nodes — pin to a specific release.
 # Find the latest: https://github.com/k3s-io/k3s/releases
-k3s_version: "v1.36.0+k3s1"
+k3s_version: "v1.36.3+k3s1"
 
 # K3s built-in components to disable — these are replaced by external controllers.
 # servicelb (klipper-lb) must be disabled when MetalLB is installed to prevent


### PR DESCRIPTION
## Summary

Bump `k3s_version` from `v1.36.0+k3s1` → `v1.36.3+k3s1` in the Ansible inventory. Patch-level bump within the same minor.

## To apply on the cluster

After merge:

```bash
# From k3s/bootstrap/ansible/
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml
```

The `k3s-server` role at `tasks/main.yml:122-145` already detects version mismatch — if `/usr/local/bin/k3s --version` doesn't match `k3s_version`, it re-runs the installer with `INSTALL_K3S_VERSION={{ k3s_version }}`. No reboot needed for patch bumps; only the `k3s` service restarts.

For the (future) HA cluster, run **one node at a time** to preserve etcd quorum:

```bash
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml --limit k3s-mini-01 -v
# wait for settle
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml --limit k3s-mini-02 -v
# wait
ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml --limit k3s-mini-03 -v
```

## Heads-up

- `secrets-encryption: true` is set. Patch releases don't change the on-disk encryption format, so this is fine. A major-version jump would need a decrypt/re-encrypt cycle.
- After upgrade, `kubectl` on the controller may briefly complain about API version mismatch. Re-run `kubectl get nodes` after a few seconds — the cluster auto-negotiates.
- This PR only bumps the pin; the actual binary upgrade happens on the cluster via the playbook above.