### PR TITLE
fix(ansible): raise inotify limits in k3s-prereqs sysctl

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -42,6 +42,19 @@ k3s_sysctl_params:
   net.bridge.bridge-nf-call-ip6tables: 1
   net.ipv4.ip_forward: 1
   vm.swappiness: 0
+  # Inotify limits for fsnotify-based controllers (nvidia-device-plugin,
+  # kube-state-metrics, cilium, etc.). The Linux kernel defaults to
+  # max_user_instances=128; containerd-shim on cgroup v2 holds ≥1 inotify
+  # instance per container for memory.events monitoring, plus every fsnotify
+  # watcher adds another. Dense nodes exhaust the default at ~70 pods and the
+  # nvidia-device-plugin (and similar) CrashLoopBackOff with
+  #   "failed to create FS watcher for /var/lib/kubelet/device-plugins/:
+  #    too many open files"
+  # See containerd/containerd#10468 and NVIDIA/gpu-operator#441.
+  # 8192 is the convention from the Crusoe support KB; covers HA clusters
+  # at hundreds of pods without re-tuning.
+  fs.inotify.max_user_watches: 1048576
+  fs.inotify.max_user_instances: 8192
 
 # K3s version installed on all nodes — pin to a specific release.
 # Find the latest: https://github.com/k3s-io/k3s/releases


### PR DESCRIPTION
## Summary

Raise `fs.inotify.max_user_instances` and `max_user_watches` on every K3s node by adding them to `k3s_sysctl_params` in the Ansible inventory. The `k3s-prereqs` role already loops over that dict and applies via `ansible.posix.sysctl` with `state: present`, so this becomes part of `provision-nodes.yml`.

## Why

Containerd-shim on cgroup v2 holds ≥1 inotify instance per container for `memory.events` monitoring. With the Linux default of `max_user_instances=128`, dense nodes (70+ pods) exhaust it and any `fsnotify.NewWatcher()` pod — including the nvidia-device-plugin — fails with:

```
failed to create FS watcher for /var/lib/kubelet/device-plugins/:
too many open files
```

Tonight's k3s 1.36.3 + nvidia driver 595 upgrade pushed the testbed over the cliff: shim activity rose as containers restarted with new CDI specs. Same root cause as:
- [containerd/containerd#10468](https://github.com/containerd/containerd/issues/10468)
- [NVIDIA/gpu-operator#441](https://github.com/NVIDIA/gpu-operator/issues/441)
- [intel/intel-device-plugins-for-kubernetes#2075](https://github.com/intel/intel-device-plugins-for-kubernetes/issues/2075)

## Values

```yaml
fs.inotify.max_user_watches:   1048576
fs.inotify.max_user_instances: 8192
```

8192 is the convention from the Crusoe support KB and covers HA clusters at hundreds of pods without re-tuning.

## Verified end-to-end on the testbed

1. Wrote `/etc/sysctl.d/99-inotify.conf` with the two values, `sudo sysctl --system`
2. Deleted the failing nvidia-device-plugin pod; DaemonSet recreated it
3. Pod came up `2/2 Running`; main container logged `Registered device plugin for nvidia.com/gpu with Kubelet`
4. Node now reports `nvidia.com/gpu: 2` allocatable (was 0 while the pod was crashing)
5. The `provision-nodes.yml` flow that uses this same dict for all future provisioning will apply the same values on every node

## HA cluster

Same change applies via the same role. When you bring up the three Optiplex nodes (192.168.1.40/.41/.42), they get the limits automatically during `provision-nodes.yml` — no extra step needed.

## Diff

```diff
 k3s_sysctl_params:
   net.bridge.bridge-nf-call-iptables: 1
   net.bridge.bridge-nf-call-ip6tables: 1
   net.ipv4.ip_forward: 1
   vm.swappiness: 0
+  # Inotify limits for fsnotify-based controllers (nvidia-device-plugin,
+  # kube-state-metrics, cilium, etc.). The Linux kernel defaults to
+  # max_user_instances=128; containerd-shim on cgroup v2 holds ≥1 inotify
+  # instance per container for memory.events monitoring, plus every fsnotify
+  # watcher adds another. Dense nodes exhaust the default at ~70 pods and the
+  # nvidia-device-plugin (and similar) CrashLoopBackOff with
+  #   "failed to create FS watcher for /var/lib/kubelet/device-plugins/:
+  #    too many open files"
+  # See containerd/containerd#10468 and NVIDIA/gpu-operator#441.
+  # 8192 is the convention from the Crusoe support KB; covers HA clusters
+  # at hundreds of pods without re-tuning.
+  fs.inotify.max_user_watches: 1048576
+  fs.inotify.max_user_instances: 8192
```