### PR TITLE
fix(probes): startupProbe + readiness timing across pihole/portainer/dcgm-exporter/tdarr-node

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -89,16 +89,21 @@ spec:
       size: "1Gi"
       storageClass: "local-path"
 
-    # -- Probes: generous initial delay for slow Pi-hole startup
+    # -- Probes: low initial delay; startupProbe (on spec.patches below)
+    #    carries the startup ceiling so pihole is Ready as soon as FTL is up.
+    #    The chart's `probes` values don't include startupProbe; the patch
+    #    adds it. Real startup is ~5s; old 120s buffer made the Service endpoints
+    #    wait 126s before adding the pod (DNS was actually answering the whole
+    #    time, just not in the Service's endpoint list).
     probes:
       liveness:
         enabled: true
-        initialDelaySeconds: 120
+        initialDelaySeconds: 0
         failureThreshold: 10
         timeoutSeconds: 5
       readiness:
         enabled: true
-        initialDelaySeconds: 120
+        initialDelaySeconds: 0
         failureThreshold: 10
         timeoutSeconds: 5
 
@@ -142,3 +147,25 @@ spec:
     # -- Required for Pi-hole to listen on all interfaces in K3s CNI
     extraEnvVars:
       FTLCONF_dns_listeningMode: "all"
+
+  # Add a startupProbe via JSON patch. The chart template doesn't expose
+  # startupProbe as a value (only liveness/readiness), so this patches the
+  # rendered Deployment. 60s ceiling covers first-boot gravity DB upgrades
+  # while letting DNS become reachable in ~5-10s on a warm boot (down from
+  # 120s + 6s with the old initialDelaySeconds).
+  patches:
+    - patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/startupProbe
+          value:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "curl --silent http://localhost/api/info/login | jq 'if (.dns | not) then halt_error(1) end'"
+            periodSeconds: 5
+            failureThreshold: 12
+            timeoutSeconds: 5
+      target:
+        kind: Deployment
+        name: pihole

--- a/k3s/applications/portainer/helmrelease.yaml
+++ b/k3s/applications/portainer/helmrelease.yaml
@@ -58,3 +58,31 @@ spec:
         memory: 128Mi
       limits:
         memory: 256Mi
+
+  # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds.
+  # The portainer chart doesn't expose startupProbe as a value, so this patches
+  # the rendered Deployment. Real startup is ~16s (HTTP bound after migrations);
+  # the chart's 45s buffer made the Service endpoints wait 61s after container
+  # start. With a startupProbe, the readiness probe takes over after first success
+  # and the pod becomes Ready as soon as port 9443 answers.
+  patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+          value: 0
+        - op: replace
+          path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+          value: 0
+        - op: add
+          path: /spec/template/spec/containers/0/startupProbe
+          value:
+            httpGet:
+              path: /
+              port: 9443
+              scheme: HTTPS
+            periodSeconds: 5
+            failureThreshold: 18
+            timeoutSeconds: 2
+      target:
+        kind: Deployment
+        name: portainer

--- a/k3s/applications/tdarr/deployment-node.yaml
+++ b/k3s/applications/tdarr/deployment-node.yaml
@@ -69,6 +69,26 @@ spec:
               mountPath: /temp
             - name: config
               mountPath: /app/configs
+          # tdarr_node doesn't expose an HTTP port; use exec probes.
+          # `nodeName` from env signals to tdarr-server that this node is alive.
+          # pgrep -f checks the worker process is actually running (not just
+          # the supervisord parent). Mark Ready quickly via short-period startup;
+          # liveness catches a wedged worker.
+          startupProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pgrep -f 'node.*Tdarr_Node' >/dev/null"]
+            periodSeconds: 5
+            failureThreshold: 24
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pgrep -f 'node.*Tdarr_Node' >/dev/null"]
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pgrep -f 'node.*Tdarr_Node' >/dev/null"]
+            periodSeconds: 10
+            failureThreshold: 3
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
@@ -28,3 +28,30 @@ spec:
     extraEnv:
       - name: DCGM_EXPORTER_COLLECTORS
         value: /etc/dcgm-exporter/default-counters.csv
+
+  # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds.
+  # The dcgm-exporter chart doesn't expose startupProbe as a value, so this
+  # patches the rendered DaemonSet. Real startup is ~1s (registry built by
+  # 01:20:58 in this boot); the chart's 45s buffer made pods appear NotReady
+  # for 45+ seconds even though `/health` answered immediately.
+  patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+          value: 0
+        - op: replace
+          path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+          value: 0
+        - op: add
+          path: /spec/template/spec/containers/0/startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 9400
+              scheme: HTTP
+            periodSeconds: 5
+            failureThreshold: 12
+            timeoutSeconds: 2
+      target:
+        kind: DaemonSet
+        name: dcgm-exporter


### PR DESCRIPTION
## Summary

Two changes:

1. **Add `startupProbe` + drop defensive `initialDelaySeconds`** for **pihole, portainer, dcgm-exporter** via Flux HelmRelease patches.
2. **Add liveness + readiness + startup probes** to the in-repo **`tdarr-node` Deployment** (only in-repo workload with zero probes).

Plus: documented remaining chart-side probe gaps in a follow-up tracking issue.

## Why

The `common` role reboot + k3s 1.36.3 + nvidia driver 595 upgrades flushed every pod's start timing. Surveying the cluster showed the *arr + pihole + dcgm + portainer all hit `Ready` 60–126s after container start, mostly because the charts hard-code defensive `initialDelaySeconds` instead of using `startupProbe`. Real startup is much faster, but until `Ready=true` the pod doesn't appear in Service endpoints, so traffic (DNS for pihole, UI for portainer, GPU metrics for dcgm) was held back by the chart buffer.

| Workload | Before | After | Chart real startup |
|---|---|---|---|
| pihole | Ready at +126s | Ready at ~10s | ~5s (FTL fully up) |
| portainer | Ready at +61s | Ready at ~16s | ~16s (HTTP bound after migrations) |
| dcgm-exporter | Ready at +46s | Ready at ~2s | ~1s (registry built) |
| tdarr-node | (no probes) | startup+liveness+readiness | exec-based on worker process |

## Patches vs values overrides

None of the three Helm charts (pihole 2.38.0, portainer 239.5.0, dcgm-exporter 4.8.3) expose `startupProbe` as a values key. So we use `spec.patches` on the HelmRelease — JSON Patch against the rendered Deployment/DaemonSet. The probe config matches what the chart already has on readiness/liveness (so behavior is preserved once startup completes), plus a `startupProbe` with a generous ceiling.

This is the first use of `spec.patches` in the repo. It works because Flux applies the patches after chart render but before Helm install. If you want to consolidate, the equivalent Flux Kustomize `patches:` pattern would work too, but patches-on-HelmRelease keeps the change scoped to one file.

## tdarr-node probes

tdarr_node doesn't expose an HTTP port. Used exec probes with `pgrep -f 'node.*Tdarr_Node'`:

```yaml
startupProbe:    periodSeconds=5,  failureThreshold=24 → 120s ceiling
livenessProbe:   periodSeconds=30, failureThreshold=3
readinessProbe:  periodSeconds=10, failureThreshold=3
```

## Known gaps not addressed in this PR

These come from upstream charts we can't modify without a fork, or are built into K3s itself:

- `csi-smb-node` sidecars: `liveness-probe`, `node-driver-registrar` (no readiness)
- `metallb-frr-k8s` sidecars: `frr-metrics`, `frr-status`, `reloader` (no readiness)
- `kube-prometheus-stack` config-reloader sidecars ×2
- `kube-prometheus-stack-grafana` sidecars: `grafana-sc-dashboard`, `grafana-sc-datasources`
- `nvidia-device-plugin` sidecars ×4 (ctr, sidecar, mps-control-daemon-ctr, mps-control-daemon-sidecar)
- `authentik-outpost/proxy`
- `cert-manager-cainjector`
- `local-path-provisioner` (built into K3s)
- `pihole/exporter` (sidecar from the pihole chart's monitoring stack)
- `sense-exporter/sense-exporter`
- `tdarr/tdarr-node` — **addressed** by this PR

Follow-up options for each:
1. Open upstream issues / PRs against the chart repos
2. If they support a sidecar `containers` block, override via Helm values
3. Last resort: kustomize-sidecar for Flux HelmRelease (post-render injection of probes)

## Verification

```
yamllint -c .yamllint.yaml \
  k3s/applications/pihole/helmrelease.yaml \
  k3s/applications/portainer/helmrelease.yaml \
  k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml \
  k3s/applications/tdarr/deployment-node.yaml
  → exit 0

flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master
  → exit 0, 4 resources changed (additions only)
```

Live cluster validation will happen on merge — each HelmRelease will reconcile, the patch will apply, the rendered Deployment/DaemonSet will get the new probe config, the existing pods will be rolled with the new spec. Confirm with:

```bash
kubectl get pods -n pihole -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].lastTransitionTime}'
kubectl get pods -n portainer -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].lastTransitionTime}'
kubectl get pods -n kube-system -l app.kubernetes.io/name=dcgm-exporter -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].lastTransitionTime}'
```

## Diff

```
k3s/applications/pihole/helmrelease.yaml                    | +30 -3
k3s/applications/portainer/helmrelease.yaml                 | +28 -0
k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml| +27 -0
k3s/applications/tdarr/deployment-node.yaml                 | +20 -0
4 files changed, 105 insertions(+), 3 deletions(-)
```