### PR TITLE
fix(flux): use spec.postRenderers (not spec.patches) for HelmRelease probe injection

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -148,24 +148,30 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: "all"
 
-  # Add a startupProbe via JSON patch. The chart template doesn't expose
-  # startupProbe as a value (only liveness/readiness), so this patches the
-  # rendered Deployment. 60s ceiling covers first-boot gravity DB upgrades
-  # while letting DNS become reachable in ~5-10s on a warm boot (down from
-  # 120s + 6s with the old initialDelaySeconds).
-  patches:
-    - patch: |
-        - op: add
-          path: /spec/template/spec/containers/0/startupProbe
-          value:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - "curl --silent http://localhost/api/info/login | jq 'if (.dns | not) then halt_error(1) end'"
-            periodSeconds: 5
-            failureThreshold: 12
-            timeoutSeconds: 5
-      target:
-        kind: Deployment
-        name: pihole
+  # Add a startupProbe via Kustomize post-render. The chart template doesn't
+  # expose startupProbe as a value (only liveness/readiness), so this
+  # patches the rendered Deployment after Helm renders. 60s ceiling covers
+  # first-boot gravity DB upgrades while letting DNS become reachable in
+  # ~5-10s on a warm boot (down from 120s + 6s with the old initialDelaySeconds).
+  # Note: this uses spec.postRenderers (not spec.patches) — the latter is a
+  # Kustomization-only field; HelmRelease v2 uses postRenderers for chart output
+  # patching. PR #256 mistakenly used spec.patches and broke the cluster; this
+  # is the corrected form. See https://fluxcd.io/flux/components/helm/helmreleases/
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: pihole
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/startupProbe
+                value:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - "curl --silent http://localhost/api/info/login | jq 'if (.dns | not) then halt_error(1) end'"
+                  periodSeconds: 5
+                  failureThreshold: 12
+                  timeoutSeconds: 5

--- a/k3s/applications/portainer/helmrelease.yaml
+++ b/k3s/applications/portainer/helmrelease.yaml
@@ -59,30 +59,31 @@ spec:
       limits:
         memory: 256Mi
 
-  # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds.
-  # The portainer chart doesn't expose startupProbe as a value, so this patches
-  # the rendered Deployment. Real startup is ~16s (HTTP bound after migrations);
-  # the chart's 45s buffer made the Service endpoints wait 61s after container
-  # start. With a startupProbe, the readiness probe takes over after first success
-  # and the pod becomes Ready as soon as port 9443 answers.
-  patches:
-    - patch: |
-        - op: replace
-          path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
-          value: 0
-        - op: replace
-          path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
-          value: 0
-        - op: add
-          path: /spec/template/spec/containers/0/startupProbe
-          value:
-            httpGet:
-              path: /
-              port: 9443
-              scheme: HTTPS
-            periodSeconds: 5
-            failureThreshold: 18
-            timeoutSeconds: 2
-      target:
-        kind: Deployment
-        name: portainer
+  # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds
+  # via Kustomize post-render. The portainer chart doesn't expose startupProbe
+  # as a value. Real startup is ~16s; the chart's 45s buffer made the Service
+  # endpoints wait 61s after container start. With a startupProbe, the readiness
+  # probe takes over after first success.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: portainer
+            patch: |
+              - op: replace
+                path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+                value: 0
+              - op: replace
+                path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+                value: 0
+              - op: add
+                path: /spec/template/spec/containers/0/startupProbe
+                value:
+                  httpGet:
+                    path: /
+                    port: 9443
+                    scheme: HTTPS
+                  periodSeconds: 5
+                  failureThreshold: 18
+                  timeoutSeconds: 2

--- a/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
@@ -29,29 +29,31 @@ spec:
       - name: DCGM_EXPORTER_COLLECTORS
         value: /etc/dcgm-exporter/default-counters.csv
 
-  # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds.
-  # The dcgm-exporter chart doesn't expose startupProbe as a value, so this
-  # patches the rendered DaemonSet. Real startup is ~1s (registry built by
-  # 01:20:58 in this boot); the chart's 45s buffer made pods appear NotReady
-  # for 45+ seconds even though `/health` answered immediately.
-  patches:
-    - patch: |
-        - op: replace
-          path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
-          value: 0
-        - op: replace
-          path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
-          value: 0
-        - op: add
-          path: /spec/template/spec/containers/0/startupProbe
-          value:
-            httpGet:
-              path: /health
-              port: 9400
-              scheme: HTTP
-            periodSeconds: 5
-            failureThreshold: 12
-            timeoutSeconds: 2
-      target:
-        kind: DaemonSet
-        name: dcgm-exporter
+  # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds
+  # via Kustomize post-render. The dcgm-exporter chart doesn't expose
+  # startupProbe as a value. Real startup is ~1s; the chart's 45s buffer made
+  # pods appear NotReady for 45+ seconds even though `/health` answered
+  # immediately.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: DaemonSet
+              name: dcgm-exporter
+            patch: |
+              - op: replace
+                path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+                value: 0
+              - op: replace
+                path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+                value: 0
+              - op: add
+                path: /spec/template/spec/containers/0/startupProbe
+                value:
+                  httpGet:
+                    path: /health
+                    port: 9400
+                    scheme: HTTP
+                  periodSeconds: 5
+                  failureThreshold: 12
+                  timeoutSeconds: 2


### PR DESCRIPTION
## Summary

Replaces `spec.patches:` with `spec.postRenderers[].kustomize.patches:` in three HelmRelease files. Same JSON 6902 patch body, different wrapper — the correct field for the Flux v2 HelmRelease API.

## Background

PR #256 added a `patches:` block under `spec` in three HelmReleases (pihole, portainer, dcgm-exporter). That field doesn't exist on the Flux v2 HelmRelease API — it's a Kustomization-only field. HelmRelease v2 expects chart-output patching under `spec.postRenderers[].kustomize.patches` (Kustomize post-render applied to rendered manifests before Helm install).

The broken schema caused the cluster chain to stall:

```
infra-contController: ReconciliationFailed
  "HelmRelease/flux-system/dcgm-exporter dry-run failed:
   failed to create typed patch object (...; helm.toolkit.fluxcd.io/v2, Kind=HelmRelease):
   .spec.patches: field not declared in schema"

infra-configs: DependencyNotReady
apps: DependencyNotReady
```

`infra-controllers` → `infra-configs` → `apps` all stuck on `DependencyNotReady`. The probe-config changes from #256 never applied. `tdarr-node` also didn't reconcile (the `apps` Kustomization was blocked).

## Fix

Same JSON Patch, wrapped in `postRenderers`:

```yaml
spec:
  postRenderers:
    - kustomize:
        patches:
          - target:
              kind: Deployment      # or DaemonSet for dcgm-exporter
              name: pihole
            patch: |
              - op: add
                path: /spec/template/spec/containers/0/startupProbe
                value: { ... }
```

Three files changed:
- `k3s/applications/pihole/helmrelease.yaml`
- `k3s/applications/portainer/helmrelease.yaml`
- `k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml`

The pihole chart values block from #256 (lowered `initialDelaySeconds` to 0) is preserved — only the patches-as-Kustomization mistake was wrong.

## Why I picked `postRenderers` over other options

| Approach | Why not |
|---|---|
| `spec.patches` (Kustomization-only) | **Wrong field — caused the breakage** |
| Open upstream issues against each chart | Doesn't fix the cluster right now |
| Fork each chart | Massive blast radius for a probe tweak |
| Replace with `chartHookSelector`-style override | Charts don't expose hooks for this |

`postRenderers.kustomize.patches` is the documented Flux v2 mechanism for exactly this case. It's the first use of postRenderers in this repo, but it's a stable Flux feature (v2.0+).

## Verification

```
yamllint -c .yamllint.yaml \
  k3s/applications/pihole/helmrelease.yaml \
  k3s/applications/portainer/helmrelease.yaml \
  k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
  → exit 0

flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master
  → exit 0, 3 HelmReleases show postRenderers block
```

Cluster validation will happen on merge — the dry-run error should clear and the chain should reconcile within ~1m:
- `infra-controllers` → True
- `infra-configs` → True
- `apps` → True
- dcgm-exporter / pihole / portainer HelmReleases upgrade with startupProbe
- tdarr-node Deployment rolls with new probes

Then check timing:
```bash
kubectl get pods -n pihole -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].lastTransitionTime}'
# expect ~10s after pod start (vs 126s before)
```

## Diff

```
k3s/applications/pihole/helmrelease.yaml                     | 48 ++++++++++---------
k3s/applications/portainer/helmrelease.yaml                  | 55 +++++++++++-----------
k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml | 54 +++++++++++----------
3 files changed, 83 insertions(+), 74 deletions(-)
```