### PR TITLE
revert(pihole): restore pre-#256 probe config

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -89,21 +89,16 @@ spec:
       size: "1Gi"
       storageClass: "local-path"
 
-    # -- Probes: low initial delay; startupProbe (on spec.patches below)
-    #    carries the startup ceiling so pihole is Ready as soon as FTL is up.
-    #    The chart's `probes` values don't include startupProbe; the patch
-    #    adds it. Real startup is ~5s; old 120s buffer made the Service endpoints
-    #    wait 126s before adding the pod (DNS was actually answering the whole
-    #    time, just not in the Service's endpoint list).
+    # -- Probes: generous initial delay for slow Pi-hole startup
     probes:
       liveness:
         enabled: true
-        initialDelaySeconds: 0
+        initialDelaySeconds: 120
         failureThreshold: 10
         timeoutSeconds: 5
       readiness:
         enabled: true
-        initialDelaySeconds: 0
+        initialDelaySeconds: 120
         failureThreshold: 10
         timeoutSeconds: 5
 
@@ -147,31 +142,3 @@ spec:
     # -- Required for Pi-hole to listen on all interfaces in K3s CNI
     extraEnvVars:
       FTLCONF_dns_listeningMode: "all"
-
-  # Add a startupProbe via Kustomize post-render. The chart template doesn't
-  # expose startupProbe as a value (only liveness/readiness), so this
-  # patches the rendered Deployment after Helm renders. 60s ceiling covers
-  # first-boot gravity DB upgrades while letting DNS become reachable in
-  # ~5-10s on a warm boot (down from 120s + 6s with the old initialDelaySeconds).
-  # Note: this uses spec.postRenderers (not spec.patches) — the latter is a
-  # Kustomization-only field; HelmRelease v2 uses postRenderers for chart output
-  # patching. PR #256 mistakenly used spec.patches and broke the cluster; this
-  # is the corrected form. See https://fluxcd.io/flux/components/helm/helmreleases/
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: pihole
-            patch: |
-              - op: add
-                path: /spec/template/spec/containers/0/startupProbe
-                value:
-                  exec:
-                    command:
-                      - /bin/sh
-                      - -c
-                      - "curl --silent http://localhost/api/info/login | jq 'if (.dns | not) then halt_error(1) end'"
-                  periodSeconds: 5
-                  failureThreshold: 12
-                  timeoutSeconds: 5


### PR DESCRIPTION
## Summary

Reverts `k3s/applications/pihole/helmrelease.yaml` to its pre-#256 state (probes `initialDelaySeconds: 120`, no `spec.postRenderers`). pihole is currently broken in master because of the combined effect of #256 + #257.

## What happened

PRs #256 and #257 added startupProbe patches via Kustomize post-render for three HelmReleases (pihole, portainer, dcgm-exporter) plus dropped the defensive `initialDelaySeconds` from pihole values. In practice the rollout broke pihole:

1. The exporter sidecar (`ekofr/pihole-exporter:v1.2.0`) renders the pod `NotReady` until it converges on pihole's `/admin/api.php` endpoint. With the rollout timeout at 5m and the sidecar's probe period, the Helm upgrade timed out before the pod became ready.
2. Helm controller initiated a rollback, but the HelmRelease remained `Ready=False` with the new probe spec retained.
3. DNS at `192.168.1.201` (pihole's LoadBalancer IP) stopped resolving cluster-wide — every workflow that touches GitHub or any external host failed.

The direct `kubectl patch` (described below) already restored the cluster to working. This PR makes the repo match.

## Direct kubectl patch (applied)

```bash
kubectl patch hr -n pihole pihole --type=json \
  -p='[{"op": "remove", "path": "/spec/postRenderers"}]'
kubectl patch hr -n pihole pihole --type=merge \
  -p='{"spec":{"values":{"probes":{"liveness":{"initialDelaySeconds":120},"readiness":{"initialDelaySeconds":120}}}}}'
kubectl annotate hr -n pihole pihole \
  reconcile.fluxcd.io/requestedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
```

After reconcile, pihole pod is `1/1` Ready and `nslookup google.com 192.168.1.201` returns answers.

## What's reverted

```diff
-    # -- Probes: low initial delay; startupProbe (on spec.patches below)
-    #    carries the startup ceiling so pihole is Ready as soon as FTL is up.
-    #    The chart's `probes` values don't include startupProbe; the patch
-    #    adds it. Real startup is ~5s; old 120s buffer made the Service endpoints
-    #    wait 126s before adding the pod (DNS was actually answering the whole
-    #    time, just not in the Service's endpoint list).
+    # -- Probes: generous initial delay for slow Pi-hole startup
     probes:
       liveness:
         enabled: true
-        initialDelaySeconds: 0
+        initialDelaySeconds: 120
         failureThreshold: 10
         timeoutSeconds: 5
       readiness:
         enabled: true
-        initialDelaySeconds: 0
+        initialDelaySeconds: 120
         failureThreshold: 10
         timeoutSeconds: 5

-  # Add a startupProbe via Kustomize post-render. ...
-  postRenderers:
-    - kustomize:
-        patches: ...
```

## What's NOT touched (intentionally)

| Workload | State | Action |
|---|---|---|
| **portainer** | postRenderers worked, 4s startup, pod healthy | **Keep** — this revert touches only pihole |
| **dcgm-exporter** | postRenderers did NOT apply (target name mismatch in patch) | **Keep** — no-op in cluster; postRenderers block stays in repo, harmlessly inert until a follow-up fixes the target name |
| **tdarr-node** | probes are in-repo (not Helm-managed), 4s startup | **Keep** |

## Follow-ups to file

1. **pihole exporter sidecar readiness** — the `ekofr/pihole-exporter:v1.2.0` readiness probe is the actual blocker that made the rollout time out. The chart-restart loop needs investigation; possibly the exporter needs more `initialDelaySeconds` in its own readiness probe, or pihole's API needs to be ready before the exporter's first probe fires.
2. **dcgm-exporter target name** — one-line fix: change `name: dcgm-exporter` to `name: kube-system-dcgm-exporter` in the postRenderers patch (Helm prefixes the namespace when `targetNamespace` differs from the HelmRelease's namespace).
3. **Re-introducing startupProbe properly** — once the exporter readiness issue is understood, redo the probe fix using a pattern that doesn't break the rollout. Options:
   - Add the startupProbe via a kustomize-sidecar instead of `postRenderers`, so the rollout controller sees a fully-formed Deployment spec from the start.
   - Bump `spec.timeout` on the HelmRelease from 5m to 10m.
   - Pin the exporter's readiness probe independently in the values (the chart probably has a way).

## Diff

```
k3s/applications/pihole/helmrelease.yaml | 39 +++-----------------------------
1 file changed, 3 insertions(+), 36 deletions(-)
```