### PR TITLE
feat(k3s): add Loki + Grafana Alloy for K3s log aggregation

### DIFF
--- a/k3s/infrastructure/AGENTS.md
+++ b/k3s/infrastructure/AGENTS.md
@@ -66,6 +66,27 @@ Flux Kustomization `infra-configs` has `dependsOn: [infra-controllers]`. This gu
 - **No ingress** — Grafana dials `http://tempo.telemetry.svc.cluster.local:3200` in-cluster
 - **Datasource**: `grafanadatasource-tempo.yaml` in `configs/monitoring/` (sidecar-discovered via `grafana_datasource: "1"` label); uid `tempo`, serviceMap back-linked to `prometheus`
 
+### loki
+- **Chart**: `grafana-community/loki` v18.7.5 (appVersion 3.7.6) | namespace: `telemetry`
+- **Mode**: `Monolithic` (`SingleBinary` was renamed as of chart 12.0.0; legacy key still accepted but deprecated). 1 replica only.
+- **Storage**: filesystem on `local-path` PVC, 20Gi. `minio.enabled: false` — the built-in MinIO subchart is deprecated/removed 2026-10-31.
+- **Schema**: TSDB v13 / `from: 2024-04-01` / `object_store: filesystem` (required by chart v6.x+).
+- **Retention**: 168h (7 days), `compactor.retention_enabled: true`, `working_directory: /data/loki/compactor`. Matches Tempo.
+- **Gateway**: NGINX fronting the single binary on port 80. Cluster-internal entry point: `http://loki-gateway.telemetry.svc.cluster.local:80`. This is the only service Alloy + Grafana should dial.
+- **Canary**: enabled (chart's validate.yaml requires it). 1 replica, no extra storage.
+- **No memcached** caches — single-node scale doesn't need them.
+- **ServiceMonitor**: enabled so kube-prometheus-stack Prometheus scrapes `loki` metrics.
+- **HelmRepository**: `loki` (Flux-scoped `flux-system` namespace). URL `https://grafana-community.github.io/helm-charts` — same index as Tempo.
+- **Datasource**: `grafanadatasource-loki.yaml` in `configs/monitoring/` (uid `loki`).
+
+### alloy
+- **Chart**: `grafana/alloy` v1.11.1 (appVersion v1.18.1) | namespace: `telemetry`
+- **Mode**: DaemonSet. One pod per node, scans only pods scheduled on its own node via the kube API.
+- **Log source**: `loki.source.kubernetes` (kube-API, no host mounts, no privileged mode). `loki.source.kubernetes` is `public-preview` stability in the upstream — `stabilityLevel: public-preview` is set explicitly.
+- **Pipeline**: `discovery.kubernetes` → `discovery.relabel` (low-cardinality labels: `cluster`, `namespace`, `pod`, `container`, `job`) → `loki.source.kubernetes` → `loki.process` (adds `cluster=homelab`) → `loki.write` → `http://loki-gateway.telemetry.svc.cluster.local:80`.
+- **RBAC**: chart-managed ClusterRole (`rbac.create: true`). Cluster-wide `get/list/watch` on `pods`, `pods/log`, `namespaces`, plus discovery endpoints.
+- **HelmRepository**: `alloy` (separate from `loki`/`tempo`). URL `https://grafana.github.io/helm-charts`.
+
 ### Headlamp (reference — lives in `k3s/applications/headlamp/`)
 - Uses `cert-manager.io/cluster-issuer: letsencrypt-prod` in Traefik ingress
 - URL: `headlamp.homelab.properties`

--- a/k3s/infrastructure/configs/monitoring/grafanadatasource-loki.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafanadatasource-loki.yaml
@@ -1,0 +1,28 @@
+---
+# Grafana datasource for Loki (logs). Picked up by the kube-prometheus-stack
+# Grafana sidecar via the `grafana_datasource: "1"` label.
+# Cluster-internal URL only — Grafana dials Loki via the gateway service.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-loki
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    deleteDatasources:
+      - name: Loki
+        orgId: 1
+    datasources:
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://loki-gateway.telemetry.svc.cluster.local:80
+        isDefault: false
+        editable: true
+        jsonData:
+          maxLines: 1000
+          httpMethod: GET

--- a/k3s/infrastructure/configs/monitoring/kustomization.yaml
+++ b/k3s/infrastructure/configs/monitoring/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - prometheusrule-cert-manager.yaml
   - podmonitor-cert-manager.yaml
   - grafanadatasource-tempo.yaml
+  - grafanadatasource-loki.yaml

--- a/k3s/infrastructure/controllers/alloy/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/alloy/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: telemetry
+spec:
+  interval: 1h
+  timeout: 5m
+  chart:
+    spec:
+      chart: alloy
+      version: "1.11.1"
+      sourceRef:
+        kind: HelmRepository
+        name: alloy
+        namespace: flux-system
+      interval: 12h
+  values:
+    # DaemonSet: one pod per node. On the single-node testbed that's 1.
+    controller:
+      type: daemonset
+
+    # In-cluster configMap — the chart renders the contents into a ConfigMap
+    # and mounts it. The config below is the entire pipeline: discover pods,
+    # relabel into Loki labels, tail via the kube API, write to Loki.
+    alloy:
+      # public-preview: required to enable loki.source.kubernetes, which is
+      # not yet at generally-available stability per the upstream docs.
+      # We accept this because the kube-API model is the only path that
+      # doesn't require host mounts / privileged mode.
+      stabilityLevel: public-preview
+
+      # Pin the image explicitly so chart version vs binary version drift
+      # can't bite us on chart bumps (matches Chart.appVersion 1.11.1 -> v1.18.1).
+      image:
+        tag: v1.18.1
+
+      # The config body is the entire Alloy pipeline.
+      configMap:
+        create: true
+        content: |
+          discovery.kubernetes "pods" {
+            role = "pod"
+          }
+
+          discovery.relabel "pod_logs" {
+            targets = discovery.kubernetes.pods.targets
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              action = "replace"
+              target_label = "namespace"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              action = "replace"
+              target_label = "pod"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              action = "replace"
+              target_label = "container"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+              action = "replace"
+              target_label = "job"
+              separator = "/"
+              replacement = "$1"
+            }
+          }
+
+          loki.source.kubernetes "pod_logs" {
+            targets    = discovery.relabel.pod_logs.output
+            forward_to = [loki.process.pod_logs.receiver]
+          }
+
+          loki.process "pod_logs" {
+            stage.static_labels {
+              values = {
+                cluster = "homelab",
+              }
+            }
+            forward_to = [loki.write.loki.receiver]
+          }
+
+          loki.write "loki" {
+            endpoint {
+              url = "http://loki-gateway.telemetry.svc.cluster.local:80/loki/api/v1/push"
+            }
+          }
+
+      # CPU limits unset (Go runtime). Memory is bounded.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+      # Mount paths are off — kube-API mode doesn't need /var/log or /var/lib.
+      mounts:
+        varlog: false
+        dockercontainers: false
+
+    # Chart-managed ClusterRole for k8s API access (pods, pods/log, etc.).
+    # This is the cluster-wide permissions alloy needs to discover pods and
+    # tail their logs via the API. No host mounts, no privileged mode.
+    rbac:
+      create: true
+
+    serviceAccount:
+      create: true

--- a/k3s/infrastructure/controllers/alloy/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/alloy/helmrepository.yaml
@@ -1,0 +1,13 @@
+---
+# Grafana Helm repository that serves the Alloy chart.
+# (Different chart publisher than Tempo/Loki — separate HelmRepository.)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: alloy
+  namespace: flux-system
+spec:
+  # Same 1h cadence as the other HelmRepositories — keeps the index warm
+  # against Renovate's weekly schedule.
+  interval: 1h
+  url: https://grafana.github.io/helm-charts

--- a/k3s/infrastructure/controllers/alloy/kustomization.yaml
+++ b/k3s/infrastructure/controllers/alloy/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - external-dns
   - opentelemetry-collector
   - tempo
+  - loki
+  - alloy

--- a/k3s/infrastructure/controllers/loki/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: telemetry
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: loki
+      version: "18.7.5"
+      sourceRef:
+        kind: HelmRepository
+        name: loki
+        namespace: flux-system
+      interval: 12h
+  values:
+    # Single binary (Monolithic) mode. `SingleBinary` is deprecated as of
+    # community chart 12.0.0 — use `Monolithic` explicitly. 1 replica on a
+    # single-node testbed is correct; multi-replica requires object storage.
+    deploymentMode: Monolithic
+
+    loki:
+      commonConfig:
+        replication_factor: 1
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+      storage:
+        type: filesystem
+      limits_config:
+        allow_structured_metadata: true
+        retention_period: 168h  # 7 days, matches Tempo
+      compactor:
+        retention_enabled: true
+        working_directory: /data/loki/compactor
+
+    singleBinary:
+      replicas: 1
+      persistence:
+        size: 20Gi
+        storageClassName: local-path
+        accessModes:
+          - ReadWriteOnce
+
+    # Zero out the other deployment modes — Monolithic runs everything in
+    # singleBinary; the mode-specific components are unusable on this chart.
+    backend:
+      replicas: 0
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    ingester:
+      replicas: 0
+    querier:
+      replicas: 0
+    queryFrontend:
+      replicas: 0
+    queryScheduler:
+      replicas: 0
+    distributor:
+      replicas: 0
+    indexGateway:
+      replicas: 0
+
+    # Built-in MinIO subchart is deprecated and removed 2026-10-31. Disable
+    # entirely; filesystem storage doesn't need it.
+    minio:
+      enabled: false
+
+    # Gateway is the cluster-internal entry point: Alloy + Grafana both dial
+    # http://loki-gateway.telemetry.svc.cluster.local:80. One nginx pod is
+    # plenty for this scale.
+    gateway:
+      enabled: true
+      replicas: 1
+
+    # Allow kube-prometheus-stack Prometheus to scrape Loki's metrics.
+    serviceMonitor:
+      enabled: true
+
+    # Memcached caches are optional for a single-node testbed; skip them.
+    memcached:
+      enabled: false
+
+    # Canary is required by the chart's validate.yaml hook. Keep it minimal.
+    lokiCanary:
+      enabled: true
+      replicas: 1
+
+    # CPU limits intentionally unset (Go GC throttling is a footgun on this
+    # workload class). Memory is bounded, CPU is left to the kernel.
+    defaults:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 1Gi

--- a/k3s/infrastructure/controllers/loki/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrepository.yaml
@@ -1,0 +1,14 @@
+---
+# Grafana Community Helm repository that serves the Loki chart.
+# (Same URL as the tempo HelmRepository — namespacing per controller keeps
+# the existing tempo release untouched while isolating this one.)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: loki
+  namespace: flux-system
+spec:
+  # Loki chart cuts 1-2 releases/week; 1h keeps the cache aligned with Renovate
+  # bumps without much extra load (the index is small).
+  interval: 1h
+  url: https://grafana-community.github.io/helm-charts

--- a/k3s/infrastructure/controllers/loki/kustomization.yaml
+++ b/k3s/infrastructure/controllers/loki/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary

Phase 1 of log aggregation for the K3s testbed: **Loki** (Monolithic) + **Grafana Alloy** (DaemonSet) + a Loki Grafana datasource. Pod logs only — Synology is a follow-up phase.

## What changes

- `k3s/infrastructure/controllers/loki/` — new HelmRepository + HelmRelease (Loki v18.7.5, appVersion 3.7.6)
- `k3s/infrastructure/controllers/alloy/` — new HelmRepository + HelmRelease (Alloy v1.11.1, appVersion v1.18.1)
- `k3s/infrastructure/controllers/kustomization.yaml` — add `loki` and `alloy`
- `k3s/infrastructure/configs/monitoring/grafanadatasource-loki.yaml` — new ConfigMap (uid `loki`)
- `k3s/infrastructure/configs/monitoring/kustomization.yaml` — add the datasource
- `k3s/infrastructure/AGENTS.md` — Loki + Alloy sections

## Decisions

- **Monolithic, single replica, 20Gi PVC, 168h retention** — matches Tempo's testbed scale. `local-path` storage. MinIO disabled (subchart deprecated, removed 2026-10-31).
- **Alloy DaemonSet via kube-API** (`loki.source.kubernetes`) — no host mounts, no privileged mode. `stabilityLevel: public-preview` set explicitly because `loki.source.kubernetes` is not yet GA upstream.
- **Cluster-internal gateway only** — `http://loki-gateway.telemetry.svc.cluster.local:80` is the only endpoint. No ingress on Loki for now.
- **Low-cardinality labels**: `cluster`, `namespace`, `pod`, `container`, `job`. Pod UID/image digest/etc. are deliberately not indexed.
- **No auth on Loki** — single tenant, in-cluster only. Auth deferred to the Synology phase.

## Files

```
k3s/infrastructure/controllers/loki/
├── helmrelease.yaml     (loki: chart, PVC, gateway, canary, retention)
├── helmrepository.yaml  (grafana-community repo, 1h interval)
└── kustomization.yaml

k3s/infrastructure/controllers/alloy/
├── helmrelease.yaml     (DaemonSet, kube-API config, RBAC)
├── helmrepository.yaml  (grafana repo, 1h interval)
└── kustomization.yaml

k3s/infrastructure/configs/monitoring/
├── grafanadatasource-loki.yaml  (Loki datasource, uid `loki`)
└── kustomization.yaml           (+ grafanadatasource-loki.yaml)
```

## Validation

- `yamllint -c .yamllint.yaml` — clean for new files (pre-existing OTel warning untouched)
- `flux-local test --path k3s/clusters/homelab` — 5/5 passed
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — confirmed only additive changes (Loki + Alloy + datasource)
- `helm template` against the upstream charts at the pinned versions — both render without errors

## Verification on the cluster

After merge, on the testbed:

```bash
kubectl get pods -n telemetry -l app.kubernetes.io/name=loki
kubectl get pods -n telemetry -l app.kubernetes.io/name=alloy
kubectl logs -n telemetry -l app.kubernetes.io/name=alloy --tail=200
# In Grafana: Explore > Loki > {namespace="telemetry"} should return logs
```

## Out of scope (deferred)

- **Synology ingestion** — separate phase. Adds Alloy on the Synology host and a LAN-reachable, authenticated Loki endpoint.
- **Loki auth/NetworkPolicies** — only when multi-tenant or cross-network.
- **S3/object-store backend** — only needed for HA or multi-replica.
- **OTel Collector logs pipeline** — only if apps emit OTLP logs natively.

Companion PR for the dashboard JSON will follow in `jander99/homelab-dashboards`.