### PR TITLE
fix(loki): set compactor.delete_request_store=filesystem

### DIFF
--- a/k3s/infrastructure/controllers/loki/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrelease.yaml
@@ -42,6 +42,10 @@ spec:
       compactor:
         retention_enabled: true
         working_directory: /data/loki/compactor
+        # delete_request_store is required whenever retention_enabled is true
+        # (Loki's Validate() refuses to start otherwise). Filesystem storage
+        # reuses the same PVC as the chunks — no extra wiring needed.
+        delete_request_store: filesystem
 
     singleBinary:
       replicas: 1


### PR DESCRIPTION
## Summary

Follow-up to #260. After merge, the Loki pod started but immediately entered CrashLoopBackOff with:

```
CONFIG ERROR: invalid compactor config: compactor.delete-request-store
should be configured when retention is enabled
```

Loki 3.7.x's `Validate()` refuses to start when `retention_enabled: true` and `delete_request_store` is unset. The chart passes `loki.compactor` straight through to the runtime config, so this is a one-line fix.

## What changes

- `k3s/infrastructure/controllers/loki/helmrelease.yaml` — add `delete_request_store: filesystem` to the `loki.compactor` block.

## Why filesystem

For a single-node testbed with filesystem storage, the compactor's delete-request store can reuse the same filesystem-backed `common.storage.filesystem` config the chunks use. No extra storage class, no extra PVC, no extra volume.

## Validation

- `yamllint -c .yamllint.yaml` — clean
- `flux-local test` — 5/5 passed
- `flux-local diff ks` — confirms only the new `delete_request_store: filesystem` line is added
- `helm template` — verified the rendered runtime config now contains:
  ```yaml
  compactor:
    delete_request_store: filesystem
    retention_enabled: true
    working_directory: /data/loki/compactor
  ```

## Post-merge verification

After merging:

```bash
kubectl get pods -n telemetry -l app.kubernetes.io/name=loki
# loki-0 should be 2/2 Running, no restarts

kubectl logs -n telemetry -l app.kubernetes.io/name=loki -c loki --tail=50
# Look for "module=all" "level=info" startup lines, no error/validate messages

# Confirm the data flow end-to-end
kubectl logs -n telemetry -l app.kubernetes.io/name=alloy --tail=20
# Look for "loki.write" components flushing
```

The dashboard PR (jander99/homelab-dashboards#15) is ready to merge after this one is in and Alloy has shipped some logs.