### PR TITLE
fix(loki): move compactor working_directory to PVC-backed /var/loki

### DIFF
--- a/k3s/infrastructure/controllers/loki/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrelease.yaml
@@ -41,7 +41,12 @@ spec:
         retention_period: 168h  # 7 days, matches Tempo
       compactor:
         retention_enabled: true
-        working_directory: /data/loki/compactor
+        # working_directory must be on the Loki storage PVC. The chart mounts
+        # the PVC at /var/loki (chunks go to /var/loki/chunks, rules to
+        # /var/loki/rules). The default path /data/loki/compactor is not
+        # mounted — Loki's mkdir fails with "read-only file system" on the
+        # standard distroless container.
+        working_directory: /var/loki/compactor
         # delete_request_store is required whenever retention_enabled is true
         # (Loki's Validate() refuses to start otherwise). Filesystem storage
         # reuses the same PVC as the chunks — no extra wiring needed.


### PR DESCRIPTION
## Summary

Second follow-up to #260. After #261 merged, Loki still CrashLoopBackOff'd. The new error:

```
init compactor: mkdir /data: read-only file system
error initialising module: compactor
```

The distroless container has no writable `/data` to mkdir into. The chart mounts the Loki storage PVC at `/var/loki` (chunks at `/var/loki/chunks`, rules at `/var/loki/rules`). The compactor's `working_directory` must be on that same PVC.

## What changes

- `k3s/infrastructure/controllers/loki/helmrelease.yaml` — change `loki.compactor.working_directory: /data/loki/compactor` → `/var/loki/compactor`

## Why this didn't surface in #261

I had this in the original config but the Validate() error from #261 (`delete-request-store should be configured`) was the first failure. With that fixed, Loki ran Validate() and started booting, but then the compactor module failed at init because of the missing path. The chart's `loki.compactor` config is passed straight through to the runtime config, so my chosen path was honored literally — `/data` was never going to be writable.

## Validation

- `helm template` confirms the rendered runtime config now has:
  ```yaml
  compactor:
    delete_request_store: filesystem
    retention_enabled: true
    working_directory: /var/loki/compactor
  ```
- `yamllint` clean
- `flux-local diff ks` shows only the one-line working_directory change

## Post-merge verification

```bash
kubectl get pods -n telemetry -l app.kubernetes.io/name=loki
# loki-0 should be 2/2 Running, no restarts

kubectl logs -n telemetry -l app.kubernetes.io/name=loki -c loki --tail=50
# No "read-only file system" errors; module init should complete

# Confirm data flow
kubectl logs -n telemetry -l app.kubernetes.io/name=alloy --tail=20
```

Dashboard PR #15 (homelab-dashboards) is waiting on this.