### PR TITLE
fix(loki): wire tenant headers and disable unused caches

### DIFF
--- a/k3s/infrastructure/configs/monitoring/grafanadatasource-loki.yaml
+++ b/k3s/infrastructure/configs/monitoring/grafanadatasource-loki.yaml
@@ -26,3 +26,6 @@ data:
         jsonData:
           maxLines: 1000
           httpMethod: GET
+          httpHeaderName1: X-Scope-OrgID
+        secureJsonData:
+          httpHeaderValue1: homelab

--- a/k3s/infrastructure/controllers/alloy/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/alloy/helmrelease.yaml
@@ -87,6 +87,7 @@ spec:
           loki.write "loki" {
             endpoint {
               url = "http://loki-gateway.telemetry.svc.cluster.local:80/loki/api/v1/push"
+              tenant_id = "homelab"
             }
           }
 

--- a/k3s/infrastructure/controllers/loki/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
     deploymentMode: Monolithic
 
     loki:
+      # Multi-tenancy enabled explicitly so the intended auth model is
+      # declared (X-Scope-OrgID header required on every write/query) rather
+      # than relying on the chart's implicit default.
+      auth_enabled: true
       commonConfig:
         replication_factor: 1
       schemaConfig:
@@ -97,8 +101,14 @@ spec:
     serviceMonitor:
       enabled: true
 
-    # Memcached caches are optional for a single-node testbed; skip them.
+    # All three caches disabled: single-node filesystem deployment has no
+    # scale pressure worth caching. memcached (chart subchart), chunksCache,
+    # and resultsCache are all explicitly off.
     memcached:
+      enabled: false
+    chunksCache:
+      enabled: false
+    resultsCache:
       enabled: false
 
     # Canary is required by the chart's validate.yaml hook. Keep it minimal.


### PR DESCRIPTION
## Summary

Resolve the Loki `401 Unauthorized: no org id` errors that caused Alloy to drop every pod log line, and stop Loki from repeatedly failing DNS for cache backends we never enabled.

## Symptom (before)

- `Alloy` logged `final error sending batch, no retries left, dropping data ... status=401 ... no org id` ~1/sec.
- `Loki` logged `failed to lookup SRV records ... _memcached-client._tcp.loki-{results,chunks}-cache.telemetry.svc.cluster.local` every minute.
- `loki-canary` was the only writer actually landing data.

## Root cause

The chart defaults `loki.auth_enabled: true` (multi-tenancy on), but neither Alloy nor the Grafana datasource was sending `X-Scope-OrgID`. The chart canary injects its own `X-Scope-OrgID` automatically, which is why it was the only successful writer. Separately, `memcached.enabled: false` was set, but the chart still renders cache DNS configuration for the default-on `chunksCache` and `resultsCache`.

## Changes

- `k3s/infrastructure/controllers/loki/helmrelease.yaml`
  - Declare `loki.auth_enabled: true` explicitly (no behavior change; documents the model).
  - Disable `chunksCache` and `resultsCache` alongside `memcached` so no cache DNS is rendered.
- `k3s/infrastructure/controllers/alloy/helmrelease.yaml`
  - `tenant_id = "homelab"` on the `loki.write "loki"` endpoint.
- `k3s/infrastructure/configs/monitoring/grafanadatasource-loki.yaml`
  - `jsonData.httpHeaderName1: X-Scope-OrgID` and `secureJsonData.httpHeaderValue1: homelab`.
- Canary left on its existing `self-monitoring` tenant — independent self-test signal.

## Verification

- `helm template` for `loki@18.7.5` and `alloy@1.11.1` with the new values:
  - `loki.configMap.config.yaml` has `auth_enabled: true`.
  - No `loki-chunks-cache` / `loki-results-cache` resources or DNS entries in the rendered manifests.
  - `loki-canary` DaemonSet args still include `-tenant-id=self-monitoring`.
  - `alloy` ConfigMap contains `tenant_id = "homelab"`.
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master`: only the three approved Kustomization diffs.
- `kubectl apply --dry-run=server`: all three resources accepted.
- Live `curl /loki/api/v1/labels` through `loki-gateway` with `-H 'X-Scope-OrgID: homelab'`: `{"status":"success","data":["pod","service_name","stream"]}`.
- `yamllint`: clean.

## Cluster smoke (after Flux reconciles)

- `kubectl logs -n telemetry daemonset/alloy -c alloy | grep 'no org id'` should be empty.
- `kubectl logs -n telemetry loki-0 -c loki | grep -E 'loki-(chunks|results)-cache'` should be empty.
- In Grafana → Explore → Loki, `{cluster="homelab"}` should return pod logs.

Refs: [Loki multi-tenancy](https://github.com/grafana/loki/blob/main/docs/sources/operations/multi-tenancy.md), [Alloy `loki.write`](https://github.com/grafana/alloy/blob/main/docs/sources/reference/components/loki/loki.write.md), [Grafana provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/).