### PR TITLE
fix(recyclarr): switch to TRaSH profiles with full quality ladder

### DIFF
--- a/k3s/applications/recyclarr/configmap.yaml
+++ b/k3s/applications/recyclarr/configmap.yaml
@@ -13,8 +13,8 @@ data:
         quality_definition:
           type: series
         quality_profiles:
-          - trash_id: d1498e7d189fbe6c7110ceaabb7473e6  # WEB-2160p
-            name: WEB-2160p
+          - trash_id: 72dae194fc92bf828f32cde7744e51a1  # WEB-1080p (full ladder; 2160p upgrade target via upgrade.until_quality)
+            name: WEB-1080p
             reset_unmatched_scores:
               enabled: true
             upgrade:
@@ -31,8 +31,8 @@ data:
         quality_definition:
           type: movie
         quality_profiles:
-          - trash_id: 64fb5f9858489bdac2af690e27c8f42f  # UHD Bluray + WEB
-            name: UHD Bluray + WEB
+          - trash_id: d1d67249d3890e49bc12e275d989a7e9  # HD Bluray + WEB (full ladder; 2160p upgrade target via upgrade.until_quality)
+            name: HD Bluray + WEB
             reset_unmatched_scores:
               enabled: true
             upgrade:


### PR DESCRIPTION
## Summary

Switches the Recyclarr-synced Sonarr and Radarr quality profiles from TRaSH’s narrow `WEB-2160p` / `UHD Bluray + WEB` profiles to the wider `WEB-1080p` / `HD Bluray + WEB` profiles, giving the “prefer 4K, accept 720p, upgrade later” behavior that was missing.

## Symptom

Sonarr’s WEB-2160p profile had only `WEB 2160p` enabled in the quality ladder; everything below was `allowed: false`. As a result, automatic episode searches returned no results when only 720p/1080p releases were available, forcing manual interactive searches.

## Root cause

TRaSH’s named Sonarr/Radarr profiles are intentionally narrow. `WEB-2160p` is *only* WEB 2160p; there is no built-in “prefer 2160p, fall back to 720p” profile. The “upgrade” block in the existing config (`until_quality: WEB 2160p`, `until_score: 10000`) only governs upgrades of already-downloaded files, not the initial grab.

## Fix

Swap the Sonarr profile to TRaSH’s `WEB-1080p` (full ladder, 720p → 2160p) and the Radarr profile to TRaSH’s `HD Bluray + WEB` (full ladder, 720p → 2160p). Keep the upgrade rules intact, so a higher-scoring 4K release will still replace an existing lower-quality file.

## Diff

```yaml
# Sonarr
- trash_id: d1498e7d189fbe6c7110ceaabb7473e6  # WEB-2160p
- name: WEB-2160p
+ trash_id: 72dae194fc92bf828f32cde7744e51a1  # WEB-1080p
+ name: WEB-1080p

# Radarr
- trash_id: 64fb5f9858489bdac2af690e27c8f42f  # UHD Bluray + WEB
- name: UHD Bluray + WEB
+ trash_id: d1d67249d3890e49bc12e275d989a7e9  # HD Bluray + WEB
+ name: HD Bluray + WEB
```

`delete_old_custom_formats`, `reset_unmatched_scores`, `upgrade.allowed`, `upgrade.until_quality`, `upgrade.until_score`, and `min_format_score` are unchanged.

## Verification

- `yamllint -c .yamllint.yaml k3s/applications/recyclarr/configmap.yaml`: clean.
- `kubectl apply --dry-run=server -f k3s/applications/recyclarr/configmap.yaml`: accepted.
- Pre-flight in cluster confirmed the old WEB-2160p profile had only 1 of 18 qualities enabled and the `UHD Bluray + WEB` profile was equally narrow.
- The trash_ids match the current TRaSH Guides JSON at:
  - <https://github.com/TRaSH-Guides/Guides/blob/master/docs/json/sonarr/quality-profiles/web-1080p.json>
  - <https://github.com/TRaSH-Guides/Guides/blob/master/docs/json/radarr/quality-profiles/hd-bluray-web.json>

## Operator action required after merge

1. Flux will roll the new `recyclarr-config` ConfigMap and the next CronJob run (or a manual `kubectl create job -n media recyclarr-manual --from=cronjob/recyclarr`) will create two new profiles in Sonarr/Radarr: `WEB-1080p` and `HD Bluray + WEB`.
2. Reassign each show/movie from the old `WEB-2160p` / `UHD Bluray + WEB` profile to the new one. Existing 4K files keep their quality; existing lower-quality files get upgraded on the next qualifying release.
3. Optionally delete the now-unused `WEB-2160p` profile from Sonarr and the old `UHD Bluray + WEB` profile from Radarr via the UI. Recyclarr does not delete orphaned profiles.

Refs: [Sonarr `WEB-1080p` TRaSH profile](https://github.com/TRaSH-Guides/Guides/blob/master/docs/json/sonarr/quality-profiles/web-1080p.json), [Radarr `HD Bluray + WEB` TRaSH profile](https://github.com/TRaSH-Guides/Guides/blob/master/docs/json/radarr/quality-profiles/hd-bluray-web.json), [Recyclarr `trash_id` reference](https://github.com/recyclarr/recyclarr/wiki/TRaSH-Guides-Quality-Profiles).