### PR TITLE
feat(velero): add Velero backup with filesystem BSL on CIFS share

### DIFF
--- a/k3s/applications/kustomization.yaml
+++ b/k3s/applications/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - sense-exporter/
   - unpoller/
   - gatus/
+  - velero/
 # Hand-authored manifests (e.g. headlamp/) and CDK8s-rendered output both live here.
 # CDK8s: run: nx run cdk8s:synth  (from repo root) — output lands in this directory.
 # Commit both hand-authored sources and rendered CDK8s output together.

--- a/k3s/applications/velero/helmrelease.yaml
+++ b/k3s/applications/velero/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero
+  namespace: velero
+spec:
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: velero
+      version: "9.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: velero
+        namespace: flux-system
+      interval: 12h
+  values:
+    # -- Backup target: filesystem provider writing to a CIFS-backed PVC
+    # mounted at /backups. Velero's filesystem plugin ignores the `bucket`
+    # field and reads `config.path` instead. No credentials needed.
+    configuration:
+      backupStorageLocation:
+        - name: default
+          provider: filesystem
+          default: true
+          accessMode: ReadWrite
+          config:
+            path: /backups
+
+    # -- Filesystem provider doesn't need cloud credentials
+    credentials:
+      useSecret: false
+
+    # -- No schedule. Backups are run manually with `velero backup create`
+    # so each one can be reviewed before kicking off. Add a Schedule resource
+    # in this directory when ready to automate.
+    schedules: {}
+
+    # -- Node-agent (kopia DaemonSet) for PV data backups. Replaces the
+    # deprecated restic path. Renders one pod per node; mounts pod volumes
+    # to dump their contents to the BSL.
+    deployNodeAgent: true
+
+    # -- Mount the CIFS-backed PVC into the Velero deployment at /backups.
+    # The BSL config.path above targets this mount.
+    extraVolumes:
+      - name: backups
+        persistentVolumeClaim:
+          claimName: velero-backups
+    extraVolumeMounts:
+      - name: backups
+        mountPath: /backups
+
+    # -- node-agent needs root to mount pod volumes for FS backup.
+    # runAsUser: 0 is the chart default; made explicit for clarity.
+    nodeAgent:
+      podSecurityContext:
+        runAsUser: 0
+
+    # -- Light resource footprint; Velero server is a small Go process
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+
+    # -- Scrape Velero + node-agent metrics via the kube-prometheus-stack
+    # ServiceMonitor/PodMonitor selectors (see monitoring chart config).
+    metrics:
+      serviceMonitor:
+        enabled: true
+      nodeAgentPodMonitor:
+        enabled: true

--- a/k3s/applications/velero/helmrepository.yaml
+++ b/k3s/applications/velero/helmrepository.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  # Renovate bumps chart versions; 24h was too long and caused HelmChart
+  # reconcile to stall when the index.yaml was republished between fetches
+  # (see PRs #250, #251). 1h aligns with Renovate's weekly schedule.
+  interval: 1h
+  url: https://vmware-tanzu.github.io/helm-charts

--- a/k3s/applications/velero/kustomization.yaml
+++ b/k3s/applications/velero/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - pvc.yaml

--- a/k3s/applications/velero/pvc.yaml
+++ b/k3s/applications/velero/pvc.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: velero-backups
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: velero-backups-volume
+    volumeAttributes:
+      source: //192.168.1.20/data
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: velero-backups
+  namespace: velero
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: velero-backups
+  resources:
+    requests:
+      storage: 1Ti

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - unpoller.yaml
   - telemetry.yaml
   - gatus.yaml
+  - velero.yaml

--- a/k3s/platform/namespaces/velero.yaml
+++ b/k3s/platform/namespaces/velero.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero


### PR DESCRIPTION
## Summary

Deploys [Velero](https://velero.io/) 9.0.0 to a new `velero` namespace with a filesystem BackupStorageLocation backed by a CIFS share on the Synology NAS.

## What's in

- **`k3s/platform/namespaces/velero.yaml`** — new namespace
- **`k3s/applications/velero/helmrepository.yaml`** — `vmware-tanzu` index, 1h reconcile
- **`k3s/applications/velero/helmrelease.yaml`** — chart `9.0.0` (renovate-managed)
- **`k3s/applications/velero/pvc.yaml`** — `velero-backups` PV + PVC, 1Ti on `smb-media`, source `//192.168.1.20/data`, references existing `kube-system/smbcreds`
- Parent kustomization entries in `k3s/applications/kustomization.yaml` and `k3s/platform/namespaces/kustomization.yaml`

## Backup target

- **BSL**: filesystem provider, path `/backups`, mounted into the Velero pod via the CIFS PVC. No S3 / cloud credentials required.
- **On disk**: Velero writes end up at `/data/backups/` on the NAS (same `data` share used by radarr/sonarr/sabnzbd/qbittorrent/tdarr, new subdir).
- **PV data**: `deployNodeAgent: true` enables the kopia DaemonSet (replaces deprecated restic) for in-cluster volume backups.

## Reused from existing setup

- `csi-driver-smb` controller (in `infra-controllers`)
- `smb-media` StorageClass (tag for binding; PV `volumeAttributes.source` overrides)
- `kube-system/smbcreds` Secret (referenced by the new PV via `nodeStageSecretRef`)
- PV pattern mirrors `k3s/applications/{radarr,sabnzbd}/pvc.yaml` exactly

## Monitoring

ServiceMonitor + PodMonitor enabled for Velero server and node-agent. Picked up by kube-prometheus-stack's open selectors (no chart-side `additionalLabels` needed since the monitoring chart is configured with `serviceMonitorSelectorNilUsesHelmValues: false`).

## Out of scope (deliberate)

- No `Schedule` resource — backups run manually with `velero backup create ...` so each one is reviewed before kicking off.
- No `velero` CLI install — out-of-cluster workstation setup, separate concern.
- No B2 / off-site BSL — deferred; revisit when on the HA cluster.

## Validation

- `yamllint -c .yamllint.yaml k3s/applications k3s/infrastructure k3s/platform k3s/clusters/homelab .github/workflows` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 5/5 passed
- `kustomize build k3s/applications` — velero manifests render correctly

## NAS prerequisites

- `/data/backups/` subdir exists on the data share, writable by the `smbcreds` user
- (Existing media write pattern doesn't touch that subdir — no collision)

## Verification after merge

1. `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — should show only the velero Namespace being added in the platform layer and the new HelmRelease + PV/PVC in the apps layer
2. After Flux applies: `kubectl get hr,pvc -n velero` should show `velero` HelmRelease reconciled and `velero-backups` PVC bound
3. Install `velero` CLI on a workstation, configure kubeconfig, then `velero backup create test --default-volumes-to-fs-backup=true` to validate end-to-end