### PR TITLE
fix(flux): make dependsOn names explicit (name + namespace fields)

### DIFF
--- a/k3s/clusters/homelab/apps.yaml
+++ b/k3s/clusters/homelab/apps.yaml
@@ -25,7 +25,9 @@ spec:
     name: flux-system
   dependsOn:
     - name: platform
+      namespace: flux-system
     - name: infra-configs
+      namespace: flux-system
   decryption:
     provider: sops
     secretRef:

--- a/k3s/clusters/homelab/infra-configs.yaml
+++ b/k3s/clusters/homelab/infra-configs.yaml
@@ -24,6 +24,7 @@ spec:
     name: flux-system
   dependsOn:
     - name: infra-controllers
+      namespace: flux-system
   decryption:
     provider: sops
     secretRef:

--- a/k3s/clusters/homelab/infra-controllers.yaml
+++ b/k3s/clusters/homelab/infra-controllers.yaml
@@ -22,6 +22,7 @@ spec:
     name: flux-system
   dependsOn:
     - name: platform
+      namespace: flux-system
   decryption:
     provider: sops
     secretRef:


### PR DESCRIPTION
Switch each `dependsOn` entry from bare-name to the explicit Flux v2 form:

```yaml
dependsOn:
  - name: platform
    namespace: flux-system
```

## Why

`flux-local diff ks` was silently skipping the `infra-controllers` and `infra-configs` diffs in every PR. The bare-name format `name: platform` is functionally correct (Flux resolves it to `<own-namespace>/platform` = `flux-system/platform`), but flux-local's validator doesn't prepend the Kustomization's own namespace when cross-checking dependsOn names — so it could never resolve `name: platform` to the actual `flux-system/platform` Kustomization and dropped the diff silently.

CI's `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` was therefore incomplete on every PR touching `infra-controllers/` or `infra-configs/` — neither reviewers nor post-merge could see what those layers were actually changing.

## Changes

- `k3s/clusters/homelab/infra-controllers.yaml` — dependsOn `platform` + `namespace: flux-system`
- `k3s/clusters/homelab/infra-configs.yaml` — dependsOn `infra-controllers` + `namespace: flux-system`
- `k3s/clusters/homelab/apps.yaml` — dependsOn `platform` and `infra-configs` both + `namespace: flux-system`

Runtime behavior is identical (Flux resolves both forms to `flux-system/<name>`); side benefit is the dependency becomes robust to the Kustomization ever being moved to a different namespace.

## Verified

- `yamllint -c .yamllint.yaml k3s/clusters/homelab/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 5/5 pass
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` — now renders all 4 Kustomizations cleanly (was: only `platform` namespace diff visible; the other three were silently dropped)

## Related

This fix unblocks accurate diffs for `feat/kopiur` (next PR), which adds resources under `infra-controllers/kopiur/` and `infra-configs/kopiur/` that weren't appearing in the diff until the format was corrected.