### PR TITLE
feat(kopiur): prototype Kopia backup operator for headlamp + gatus

### DIFF
--- a/k3s/infrastructure/configs/kopiur/clusterrepository.yaml
+++ b/k3s/infrastructure/configs/kopiur/clusterrepository.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: nas
+spec:
+  # Match Billimek's pattern: every namespace can use this repo. Tighten with
+  # a label selector later if needed.
+  allowedNamespaces:
+    all: true
+
+  backend:
+    filesystem:
+      # Pod mount path = the SMB share root (\\MemoryAlpha\data\), exposed
+      # via the per-namespace kopiur-repo PVCs. Kopia's filesystem backend
+      # initialises the repository at <share>/backups/k3s/ by passing this
+      # path to 'kopia repository create filesystem --path=...'. Kopia's
+      # MkdirAll creates the intermediate 'backups/' and 'k3s/' directories
+      # on first reconcile. Final on-NAS path:
+      #   \\MemoryAlpha\data\backups\k3s\kopia.repository
+      #   \\MemoryAlpha\data\backups\k3s\blobs\...
+      # SMB auth is handled by csi-driver-smb via kube-system/smbcreds on
+      # each PV; the SMB user must have write access to the share root so
+      # the intermediate directories can be created.
+      path: /repo/backups/k3s
+      volume:
+        pvc:
+          name: kopiur-repo
+
+  encryption:
+    passwordSecretRef:
+      name: kopiur-nas-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+
+  # Greenfield repo — let kopiur initialize the Kopia repository on first
+  # reconcile via `kopia repository create filesystem --path=/repo`.
+  create:
+    enabled: true
+
+  # Consumers (SnapshotPolicy / Restore / Maintenance) MUST set
+  # credentialProjection.enabled: true to project this Secret into their
+  # own namespace at runtime. Without this, the per-consumer gate fails
+  # closed.
+  credentialProjection:
+    allowed: true
+
+  # Match HelmRelease TZ so schedules and reports use local time, not UTC.
+  scheduleDefaults:
+    timezone: America/New_York
+
+  # Kopia's default 24h epoch can't close fast enough on a busy repo
+  # ("too many index blobs" warning, climbing every run). Lowering to 6h
+  # matches kopiur's default quick-maintenance cadence so an epoch
+  # actually closes and compacts each cycle. (From billimek PR #5861.)
+  parameters:
+    epoch:
+      minDuration: 6h
+
+  moverDefaults:
+    podSecurityContext:
+      runAsNonRoot: true
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      mode: Ephemeral
+      storageClassName: local-path

--- a/k3s/infrastructure/configs/kopiur/kopiur-secret.sops.yaml
+++ b/k3s/infrastructure/configs/kopiur/kopiur-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kopiur-nas-secret
+    namespace: kopiur-system
+type: Opaque
+stringData:
+    KOPIA_PASSWORD: ENC[AES256_GCM,data:BZs/T7Zu5thVHZRShmEiKnDAysrGoWUUKNOWkQa0omoIvIzhsqKc30ZnAy0=,iv:Cu5b6vxx9baPvuJXRglpMGyw6Ak/JjrkJI82Uv4bU8I=,tag:573adkiSORcGINm6Wu00RQ==,type:str]
+sops:
+    age:
+        - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMmJRRWQ0NjVKNHNwSlkx
+            NjRsY3BkYUhNWko1eDU5cnI1Sjd5MXRGSEM0ClIwc3R4Q0dKMU1ZRDd3TkNMV0FC
+            SlpzWE9pbmVqTEVMSWdlTkk0aVNWSUEKLS0tIHpmRHBkYXpZL0FKRFF0Y0lGQi84
+            UjV3UUNyVWE2eXdhSkp3ZWpRUTB6QzAKuFqcal8YjAeSpSgNrWWiMQsCKMFIXbuE
+            i4KHPKYh+uC53fbS+ICr16JoP0r6sLT+jAe2J7Ykv5GccMrb2mnfow==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-08-09T21:57:18Z"
+    mac: ENC[AES256_GCM,data:Cj0o1p3GZ/+Qf757zebcZezxWl4vKW9IGQwMTDXYxiW7a+1M7RCuafp8dfFhUQaTwU6/DZwCXFjIGxnXYSLYUWqGl9JNpq3NuzVdifP7MH0xbdaMydcUjsUWG3wG4g2S7KmQA1nZTKXUAPjGpy3bjnLBwCKlDEcQEyMZz86cWZs=,iv:PkIS5RuBRgzpIaY3Z/jHMzdXvYFRNQi4WJFAvnBVg5c=,tag:XgKUvFdQYvTBQFCPVwyIXw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/k3s/infrastructure/configs/kopiur/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+# Resource ordering matters here:
+#   1. kopiur-secret               — independent
+#   2. pv-kopiur-system + pv-headlamp + pv-gatus — PVs cluster-scoped, PVCs
+#                                                namespaced; the snapshot
+#                                                Jobs in headlamp/gatus need
+#                                                their PVCs to bind before
+#                                                kopiur starts scheduling
+#   3. clusterrepository           — references the Secret; kopiur inits
+#                                    the Kopia repo on first reconcile
+#   4. snapshotpolicies            — reference clusterrepository by name
+#   5. snapshotschedules           — reference snapshotpolicies by name
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kopiur-secret.sops.yaml
+  - pv-kopiur-system.yaml
+  - pv-headlamp.yaml
+  - pv-gatus.yaml
+  - clusterrepository.yaml
+  - snapshotpolicy-headlamp.yaml
+  - snapshotschedule-headlamp.yaml
+  - snapshotpolicy-gatus.yaml
+  - snapshotschedule-gatus.yaml

--- a/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
@@ -1,0 +1,48 @@
+---
+# Repository storage for kopiur snapshot Jobs in gatus. Static PV + PVC pair
+# bound to the existing smb-media CSI provisioner. Shares the SMB source
+# path with pv-kopiur-system.yaml and pv-headlamp.yaml — each namespace has
+# its own mount = its own SMB session to //192.168.1.20/data.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kopiur-repo-gatus
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: kopiur-repo-gatus-vol
+    volumeAttributes:
+      source: //192.168.1.20/data
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-repo
+  namespace: gatus
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: kopiur-repo-gatus
+  resources:
+    requests:
+      storage: 50Gi

--- a/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
@@ -1,0 +1,50 @@
+---
+# Repository storage for kopiur snapshot Jobs in headlamp. Static PV + PVC
+# pair bound to the existing smb-media CSI provisioner. Shares the SMB
+# source path with pv-kopiur-system.yaml and pv-gatus.yaml — each namespace
+# has its own mount = its own SMB session to //192.168.1.20/data. Kopia's
+# content-addressable storage makes concurrent multi-mount writes safe
+# (different jobs write to different blob files).
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kopiur-repo-headlamp
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: kopiur-repo-headlamp-vol
+    volumeAttributes:
+      source: //192.168.1.20/data
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-repo
+  namespace: headlamp
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: kopiur-repo-headlamp
+  resources:
+    requests:
+      storage: 50Gi

--- a/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
@@ -1,0 +1,50 @@
+---
+# Repository storage for kopiur maintenance Jobs (run in kopiur-system every 6h).
+# Static PV + PVC pair bound to the existing smb-media CSI provisioner. The
+# PV's source matches the other kopiur-repo PVs in headlamp/gatus so all
+# three namespaces mount the same SMB share; each mount = its own SMB session
+# (see pv-headlamp.yaml / pv-gatus.yaml). Same name 'kopiur-repo' in each
+# namespace is what kopiur's volume.pvc.name resolver expects.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kopiur-repo-kopiur-system
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: kopiur-repo-kopiur-system-vol
+    volumeAttributes:
+      source: //192.168.1.20/data
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-repo
+  namespace: kopiur-system
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: kopiur-repo-kopiur-system
+  resources:
+    requests:
+      storage: 50Gi

--- a/k3s/infrastructure/configs/kopiur/snapshotpolicy-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/snapshotpolicy-gatus.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: gatus
+  namespace: gatus
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: gatus
+      sourcePathOverride: /data
+  copyMethod: Snapshot
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  credentialProjection:
+    enabled: true
+  mover:
+    # gatus image is a Go binary; the chart's stock UID/GID is 1000:1000.
+    # Verify with `kubectl describe pod -n gatus` if the first mover run
+    # fails on permission denied.
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    podSecurityContext:
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur/snapshotpolicy-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/snapshotpolicy-headlamp.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: headlamp
+      # /data is the convention from the volsync-perfectra1n fork's recorded
+      # source path; harmless to keep here for forward compatibility if we
+      # later adopt an existing repo into this one.
+      sourcePathOverride: /data
+  copyMethod: Snapshot
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  # Daily quick verification proves backups are actually restorable, not just
+  # that maintenance ran. Jenkins-style H substitution hashes a stable per-app
+  # minute within hour 3.
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  # Repository password Secret lives in kopiur-system; the mover runs in the
+  # app namespace, so the credential has to be projected at runtime.
+  credentialProjection:
+    enabled: true
+  mover:
+    # headlamp chart's initContainer chowns the PVC to UID 100 / GID 101
+    # ("mkdir -p /build/plugins && ... && chown -R 100:101 /build"). The
+    # mover must run as that user to read the data.
+    securityContext:
+      runAsUser: 100
+      runAsGroup: 101
+    podSecurityContext:
+      fsGroup: 101
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur/snapshotschedule-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/snapshotschedule-gatus.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: gatus-scheduled
+  namespace: gatus
+spec:
+  policyRef:
+    name: gatus
+  schedule:
+    cron: "H * * * *"
+    runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur/snapshotschedule-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/snapshotschedule-headlamp.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: headlamp-scheduled
+  namespace: headlamp
+spec:
+  policyRef:
+    name: headlamp
+  schedule:
+    # Jenkins-style H substitution hashes a stable per-policy minute; load
+    # self-distributes without manual offset bookkeeping.
+    cron: "H * * * *"
+    runOnCreate: false

--- a/k3s/infrastructure/configs/kustomization.yaml
+++ b/k3s/infrastructure/configs/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - authentik
   - smb-storage
   - coredns
+  - kopiur

--- a/k3s/infrastructure/controllers/kopiur/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/kopiur/helmrelease.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+  namespace: kopiur-system
+spec:
+  interval: 1h
+  timeout: 5m
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    # Cluster-scope so the ClusterRepository CRD can be cluster-wide;
+    # SnapshotPolicy / SnapshotSchedule / Restore remain namespaced and live
+    # in each app's own namespace.
+    installScope: cluster
+
+    streamingLists: true
+
+    # Credential projection lets us keep the repository password Secret in
+    # kopiur-system and project it into each consumer namespace at runtime.
+    features:
+      credentialProjection:
+        enabled: true
+
+    webhook:
+      tls:
+        mode: self
+      serviceMonitor:
+        enabled: true
+
+    monitoring:
+      # kube-prometheus-stack (not grafana-operator) is what we run, so
+      # only the Prometheus-Operator-native bits apply here. Skip the
+      # grafanaOperator dashboards block — it would silently no-op for us.
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+      fsGroup: 65534
+      fsGroupChangePolicy: OnRootMismatch
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi

--- a/k3s/infrastructure/controllers/kopiur/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kopiur/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/kopiur/ocirepository.yaml
+++ b/k3s/infrastructure/controllers/kopiur/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+  namespace: flux-system
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.9.1
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - tempo
   - loki
   - alloy
+  - kopiur

--- a/k3s/platform/namespaces/kopiur-system.yaml
+++ b/k3s/platform/namespaces/kopiur-system.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - unpoller.yaml
   - telemetry.yaml
   - gatus.yaml
+  - kopiur-system.yaml


### PR DESCRIPTION
## Summary

Adds [kopiur](https://github.com/home-operations/kopiur) (home-operations Kopia-native backup operator, chart 0.9.1) with a single ClusterRepository backed by the existing SMB infra, plus SnapshotPolicies + SnapshotSchedules for `headlamp` and `gatus` as proof.

Two-tier storage: per-namespace static PV/PVC pairs (one for `kopiur-system` maintenance, one each for `headlamp` and `gatus` snapshot Jobs), all mounting the same `//192.168.1.20/data` SMB share root via separate CSI volumeHandles. Each mount = its own SMB session to the NAS; Kopia's content-addressable storage makes concurrent multi-mount writes safe.

## Why now

Closes the gap left by the Velero pivot (#265 closed, not_planned). Backup value here is PVC data recovery, not manifest restoration — manifests are in Git (Flux).

## On-NAS path

Kopia's filesystem backend initialises at `path: /repo/backups/k3s` inside the mover Pods. The pod mount is the SMB share root (`/repo` → `\\MemoryAlpha\data\`), so Kopia creates `backups/` and `k3s/` as intermediate directories via `os.MkdirAll` on first reconcile. Final files:

```
\\MemoryAlpha\data\backups\k3s\kopia.repository
\\MemoryAlpha\data\backups\k3s\blobs\<prefix>\...
\\MemoryAlpha\data\backups\k3s\index\...
\\MemoryAlpha\data\backups\k3s\logs\...
```

**Prerequisite on the NAS**: the SMB credential in `kube-system/smbcreds` must have write access to the share root so Kopia can create `backups/` and `backups/k3s/` on first reconcile. If those directories already exist (created ahead of merge), even better.

## Layers added

- `platform/namespaces/kopiur-system.yaml` — new namespace
- `infra-controllers/kopiur/` — OCIRepository (chart 0.9.1 from `oci://ghcr.io/home-operations/charts/kopiur`) + HelmRelease with `installScope: cluster`, `webhook.tls.mode: self`, `features.credentialProjection.enabled: true`, monitoring bits for kube-prometheus-stack. **Also adds `kopiur` to `infra-controllers/kustomization.yaml`** (caught missing during PR review — without it, kustomize build doesn't include the new files).
- `infra-configs/kopiur/`:
  - `kopiur-secret.sops.yaml` — KOPIA_PASSWORD, SOPS-encrypted with the homelab age key
  - `pv-{kopiur-system,headlamp,gatus}.yaml` — static PV (50Gi, RWX, smb-media) + namespaced PVC named `kopiur-repo`
  - `clusterrepository.yaml` — `nas`, `create.enabled: true`, `credentialProjection.allowed: true`, `parameters.epoch.minDuration: 6h` (avoids "too many index blobs" accumulation), `backend.filesystem.path: /repo/backups/k3s` (lands at `\\MemoryAlpha\data\backups\k3s\`), `moverDefaults.cache` ephemeral on `local-path`
  - `snapshotpolicy-{headlamp,gatus}.yaml` — `H * * * *`, `compression: zstd`, GFS retention (24h/14d/8w/6mo), daily `verification.quick`, `credentialProjection.enabled: true`
  - `snapshotschedule-{headlamp,gatus}.yaml`
  - **Also adds `kopiur` to `infra-configs/kustomization.yaml`** (same reason)
- `platform/namespaces/kustomization.yaml` — adds `- kopiur-system.yaml`

## Non-obvious decisions baked in

From research (billimek PR #5861 and home-operations docs):

1. **`parameters.epoch.minDuration: 6h`** — kopia's default 24h epoch can't close fast enough on a busy repo, accumulating index blobs. Lowering to 6h matches kopiur's default quick-maintenance cadence so each epoch closes and compacts per cycle.
2. **`credentialProjection.enabled: true` on every SnapshotPolicy + Restore** — repository Secret lives in `kopiur-system`, movers run in the app namespace. Not inherited from `ClusterRepository` (it's the consumer-side gate).
3. **All-or-nothing migration** — kopiur takes ownership of repo maintenance repository-wide on first run. Greenfield for us; just commit to the full set of SnapshotPolicies in the same PR.
4. **H-style cron** — kopiur hashes a stable per-object minute; load self-distributes without manual jitter.
5. **Per-namespace PV/PVC pairs** — single-PVC-in-kopiur-system doesn't work because snapshot Jobs run in `headlamp`/`gatus` and PVCs are namespace-scoped in K8s. Pattern A: one static PV per consumer namespace (all sharing the same SMB source), each namespace has its own PVC named `kopiur-repo` so kopiur's `volume.pvc.name` resolver finds a local match.

## Verified locally

- `yamllint -c .yamllint.yaml k3s/platform/namespaces k3s/infrastructure/controllers/kopiur k3s/infrastructure/configs/kopiur` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 5/5 pass
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — 476 lines, renders **all 14 new resources**: 1 Namespace, 1 OCIRepository, 1 HelmRelease, 1 Secret, 3 PV, 3 PVC, 1 ClusterRepository, 2 SnapshotPolicy, 2 SnapshotSchedule

## Runtime risk to validate on first reconcile

Each consumer namespace has its own pre-provisioned `kopiur-repo` PVC bound to a namespace-local PV. kopiur's snapshot Jobs run in the SnapshotPolicy's namespace (headlamp / gatus), maintenance Jobs run in `kopiur-system`. Each Job's Pod mounts the namespace-local `kopiur-repo` PVC.

If first reconcile surfaces "PVC not found" or pod-sandbox errors, the only remaining plan B is migrating ClusterRepository `volume` to inline `volume.nfs` (billimek's pattern, needs Synology NFS export + `csi-driver-nfs`) — which the user has already ruled out. So this prototype must succeed or we iterate on the PVC structure.

## Out of scope

- K3s datastore (`/var/lib/rancher/k3s/server/db`) — kopiur is PVC-only. Planned as a follow-up via `k3s etcd-snapshot` + SMB offload.
- SHA digest pin on the OCI chart reference — billimek pins `0.9.1@sha256:1df335...`; we can add this in a follow-up once the initial deploy settles.
- OCIRepository digest pin — same as above.

## Prerequisite

PR #269 (dependsOn name+namespace format fix) is **already merged** on master — without it, flux-local diff silently drops infra-controllers and infra-configs diffs. This PR rebases onto that fix.

## Followups (separate PRs, not this one)

1. K3s etcd-snapshot cron → SMB offload (datastore backup).
2. Add remaining PVCs: radarr, sonarr, prowlarr, sabnzbd, qbittorrent, recyclarr, tdarr (after the prototype validates on headlamp + gatus).
3. OCIRepository + chart SHA digest pinning.