### PR TITLE
fix(kopiur): set chartRef.namespace explicitly to flux-system

### DIFF
--- a/k3s/infrastructure/controllers/kopiur/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/kopiur/helmrelease.yaml
@@ -10,6 +10,11 @@ spec:
   chartRef:
     kind: OCIRepository
     name: kopiur
+    # OCIRepository lives in flux-system (Flux convention for source objects);
+    # without explicit namespace, chartRef defaults to the HelmRelease's own
+    # namespace (kopiur-system) and the cross-namespace lookup fails with
+    # 'OCIRepository "kopiur" not found'.
+    namespace: flux-system
   install:
     crds: CreateReplace
     createNamespace: false


### PR DESCRIPTION
## Problem

PR #270 (kopiur prototype) merged with a HelmRelease whose `chartRef` defaulted to the HelmRelease's own namespace (`kopiur-system`) when looking up the referenced OCIRepository. The OCIRepository lives in `flux-system` per Flux convention for source objects, so the cross-namespace lookup failed with:

```
ArtifactFailed: could not get Source object:
  OCIRepository.source.toolkit.fluxcd.io "kopiur" not found
```

The HelmRelease stayed in `ArtifactFailed` for the full 10m health-check window, which propagated as `infra-controllers` Readiness=False and stalled the downstream `infra-configs` and `apps` Kustomizations. Nothing got past `platform`.

## Fix

Add `namespace: flux-system` to the HelmRelease's `chartRef` so the cross-namespace lookup succeeds. Same lesson as PR #269 (dependsOn `name + namespace` format): Flux resource references between namespaces need explicit namespace fields, not bare names.

## Diff

```diff
   chartRef:
     kind: OCIRepository
     name: kopiur
+    namespace: flux-system
```

One line of meaningful change. PR #269 should be merged first (it is — it's on master).

## Verified locally

- `yamllint -c .yamllint.yaml k3s/infrastructure/controllers/kopiur/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 5/5 pass
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — 13 lines, single resource (the HelmRelease), only the `+ namespace: flux-system` line

## Verified on testbed

The original failure surfaced as `HelmRelease/kopiur-system/kopiur` stuck in `ArtifactFailed: could not get Source object: OCIRepository.source.toolkit.fluxcd.io "kopiur" not found`. Once this PR merges, Flux will reconcile, the HelmRelease will pick up the OCI chart, and the downstream infra-configs (ClusterRepository + PV/PVCs + SnapshotPolicies) will follow.

## Followup after merge

After merge, on the testbed, expect the first reconcile to:
1. Deploy kopiur operator (`installScope: cluster`)
2. Initialize the Kopia repo at `\\MemoryAlpha\data\backups\k3s\` (you've confirmed the directory exists)
3. Bind the three PV/PVCs (kopiur-system + headlamp + gatus)
4. Start scheduling backups per the SnapshotSchedules (`H * * * *`)

I'll verify on the testbed once merged.