### PR TITLE
fix(kopiur): set copyMethod=Direct on headlamp + gatus SnapshotPolicies

### DIFF
--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-gatus.yaml
@@ -12,7 +12,7 @@ spec:
     - pvc:
         name: gatus
       sourcePathOverride: /data
-  copyMethod: Snapshot
+  copyMethod: Direct
   compression:
     compressor: zstd
   retention:

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml
@@ -15,7 +15,7 @@ spec:
       # source path; harmless to keep here for forward compatibility if we
       # later adopt an existing repo into this one.
       sourcePathOverride: /data
-  copyMethod: Snapshot
+  copyMethod: Direct
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
## Problem

After PR #272 the operator + ClusterRepository + SnapshotPolicies deploy end-to-end, but the first manual snapshot failed on staging with:

```
Phase: Failed
Stalled: SnapshotStackMissing
Message: the CSI snapshot stack is not installed (no VolumeSnapshotClass API),
so copyMethod: Snapshot cannot run; install the external-snapshotter
(snapshot-controller + CRDs) and a VolumeSnapshotClass for driver
`rancher.io/local-path`, or set copyMethod: Direct on the SnapshotPolicy
to read the live PVC without CSI snapshots.
```

This cluster doesn't run the external-snapshotter (snapshot-controller + CRDs + VolumeSnapshotClass), so the CSI VolumeSnapshot staging path can't work. Billimek's PR uses `copyMethod: Snapshot` because he has Ceph CSI snapshots wired in (`volumeSnapshotClassName: csi-ceph-blockpool`); we don't, so `Direct` is the right choice for our (small, non-DB) config data.

## Fix

Set `copyMethod: Direct` on both SnapshotPolicies. kopiur's mover Pod reads the live source PVC directly — no CSI volume snapshot infrastructure required. Two-line change, same change applied to both policies (headlamp + gatus).

## Diff

```diff
   compression:
     compressor: zstd
-  copyMethod: Snapshot
+  copyMethod: Direct
```

(× 2 — one for headlamp, one for gatus)

## Verified locally

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur-policies/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 6/6 pass
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — 28 lines, exactly the two `Snapshot → Direct` swaps, no warnings

## Verified on testbed

The original failure surfaced as `Phase: Failed` / `Stalled: SnapshotStackMissing` on the first manual `headlamp` snapshot. The mover pod still completed successfully (the maintenance cycle ran and ran `kopia maintenance set --claim`), so the controller + repo wiring is sound — only the staging step (creating a VolumeSnapshot of the source PVC) was blocked.

## Verification plan on testbed after merge

1. Force-reconcile `kopiur-policies`
2. Re-trigger manual snapshot for headlamp:
   ```
   kubectl create -f - <<EOF
   apiVersion: kopiur.home-operations.com/v1alpha1
   kind: Snapshot
   metadata:
     generateName: headlamp-manual-
     namespace: headlamp
   spec:
     policyRef:
       name: headlamp
   EOF
   ```
3. `kubectl get snapshots -n headlamp` — confirm `Phase: Succeeded`
4. `kubectl get clusterrepository nas -o jsonpath='{.status.storageStats}'` — `snapshotCount: 1` (was 0)
5. Verify on the NAS: `\\MemoryAlpha\data\backups\k3s\blobs\...` should have content

## Trade-off note

`copyMethod: Direct` reads the live PVC without taking a CSI snapshot first, so it's not crash-consistent for live-write workloads. For our use case (headlamp + gatus config data, the apps are quiesced when backups run), this is fine. If we later add a database app (postgres, mariadb), we'd want to either install the external-snapshotter for `copyMethod: Snapshot` or wire a preid backuppoint hook to quiesce the app before backup.

## Followups (separate PRs, not this one)

1. K3s etcd-snapshot cron → SMB offload (datastore backup)
2. Add remaining PVCs: radarr, sonarr, prowlarr, sabnzbd, qbittorrent, recyclarr, tdarr
3. OCIRepository + chart SHA digest pinning