### PR TITLE
feat(backup): add CSI snapshot stack + migrate headlamp/gatus to csi-hostpath

### DIFF
--- a/k3s/applications/gatus/helmrelease.yaml
+++ b/k3s/applications/gatus/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
       mountPath: /data
       accessModes:
         - ReadWriteOnce
-      storageClassName: local-path
+      storageClassName: csi-hostpath-sc
 
     # Ingress with Traefik + cert-manager. Auth is now Gatus-native OIDC
     # (via the security.oidc block in config.yaml), so no Traefik

--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -96,6 +96,7 @@ spec:
         - ReadWriteOnce
       enabled: true
       size: 1Gi
+      storageClassName: csi-hostpath-sc
     volumeMounts:
       - mountPath: /build/plugins
         name: headlamp-plugins

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-gatus.yaml
@@ -12,7 +12,8 @@ spec:
     - pvc:
         name: gatus
       sourcePathOverride: /data
-  copyMethod: Direct
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
   compression:
     compressor: zstd
   retention:

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml
@@ -15,7 +15,8 @@ spec:
       # source path; harmless to keep here for forward compatibility if we
       # later adopt an existing repo into this one.
       sourcePathOverride: /data
-  copyMethod: Direct
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
   compression:
     compressor: zstd
   retention:

--- a/k3s/infrastructure/configs/kustomization.yaml
+++ b/k3s/infrastructure/configs/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - smb-storage
   - coredns
   - kopiur
+  - snapshot-storage

--- a/k3s/infrastructure/configs/snapshot-storage/kustomization.yaml
+++ b/k3s/infrastructure/configs/snapshot-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - volumesnapshotclass.yaml

--- a/k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass.yaml
+++ b/k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass.yaml
@@ -1,0 +1,17 @@
+---
+# VolumeSnapshotClass for the csi-driver-host-path CSI driver installed by
+# k3s/infrastructure/controllers/csi-hostpath/. The CSI driver creates the
+# matching StorageClass 'csi-hostpath-sc' on its own; we manage the
+# VolumeSnapshotClass here so it sits alongside the kopiur configs in the
+# infra-configs layer (kopiur SnapshotPolicy references this class by name
+# in spec.volumeSnapshotClassName).
+#
+# Deliberately NOT setting snapshot.storage.kubernetes.io/is-default-class —
+# the kopiur SnapshotPolicy picks by name, and marking this default would
+# cause confusion if other VolumeSnapshotClasses ever show up.
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-hostpath-snapclass
+deletionPolicy: Delete
+driver: hostpath.csi.k8s.io

--- a/k3s/infrastructure/controllers/csi-hostpath/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/csi-hostpath/helmrelease.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-hostpath
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: csi-hostpathplugin
+      version: "v1.17.1"
+      sourceRef:
+        kind: HelmRepository
+        name: alvistack
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: kube-system
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # Single-node StatefulSet; not a DaemonSet. The chart bundles all CSI
+    # sidecars (csi-snapshotter v8.2.0, csi-attacher v4.8.0, csi-provisioner
+    # v5.2.0, csi-resizer v1.13.1, node-driver-registrar v2.13.0,
+    # liveness-probe v2.15.0, csi-external-health-monitor-controller v0.14.0).
+    csiHostpathplugin:
+      replicaCount: 1
+    # Have the chart create the StorageClass matching what our kopiur
+    # SnapshotPolicy will reference (csi-hostpath-sc). Do NOT make it the
+    # default — K3s's local-path remains the implicit default for everything
+    # else, and we only want headlamp + gatus PVCs on this driver.
+    storageClass:
+      create: true
+      name: csi-hostpath-sc
+    # VolumeSnapshotClass is created manually in infra-configs/snapshot-storage/
+    # so it sits alongside kopiur configs in Flux layering.
+    volumeSnapshotClass:
+      create: false
+      name: csi-hostpath-snapclass
+    volumeGroupSnapshotClass:
+      create: false

--- a/k3s/infrastructure/controllers/csi-hostpath/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/csi-hostpath/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: alvistack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://alvistack.github.io/kubernetes-csi-csi-driver-host-path/

--- a/k3s/infrastructure/controllers/csi-hostpath/kustomization.yaml
+++ b/k3s/infrastructure/controllers/csi-hostpath/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
   - loki
   - alloy
   - kopiur
+  - snapshot-controller
+  - csi-hostpath

--- a/k3s/infrastructure/controllers/snapshot-controller/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/snapshot-controller/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: snapshot-controller
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: snapshot-controller
+      version: "5.2.0"
+      sourceRef:
+        kind: HelmRepository
+        name: piraeus-charts
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: kube-system
+  install:
+    createNamespace: false
+    # CRDs are part of the chart and need re-application on chart bumps so any
+    # new fields (e.g. VolumeGroupSnapshot) reach the cluster.
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    # CRDs are regular resources managed by the chart; must be true on fresh
+    # install. The chart ships the v1 VolumeSnapshot, VolumeSnapshotContent,
+    # VolumeSnapshotClass, plus VolumeGroupSnapshot CRDs.
+    installCRDs: true
+    controller:
+      enabled: true
+      # Safe on single-node K3s testbed; leader-election is on by default upstream
+      # but a single replica is fine.
+      replicaCount: 1
+    # Disable the validation webhook to skip the cert-manager dependency.
+    # Single-node homelab; v1beta1/v1beta2 VolumeGroupSnapshot objects aren't
+    # in play, so we don't need webhook-side validation.
+    webhook:
+      enabled: false

--- a/k3s/infrastructure/controllers/snapshot-controller/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/snapshot-controller/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: piraeus-charts
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://piraeus.io/helm-charts/

--- a/k3s/infrastructure/controllers/snapshot-controller/kustomization.yaml
+++ b/k3s/infrastructure/controllers/snapshot-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary

Adds the CSI snapshot stack that kopiur needs for `copyMethod: Snapshot` to actually work on K3s v1.36, and migrates headlamp + gatus off K3s's in-tree `local-path` provisioner (which doesn't implement the CSI gRPC protocol, so it can't take snapshots no matter what).

After this PR: end-to-end backup pipeline works — kopiur operator deploys, ClusterRepository connects to `\\MemoryAlpha\data\backups\k3s\`, snapshots are taken via CSI VolumeSnapshots, Kopia stores them in the SMB-backed repo.

## Why this PR exists

PR #270/#271/#272 got the kopiur operator + ClusterRepository + SnapshotPolicies deployed. PR #273 set `copyMethod: Direct` to bypass the missing CSI stack. But kopiur 0.9.1/0.10.0 ignores `copyMethod: Direct` — the controller still tries to use CSI staging. The error message recommends installing the snapshot stack, but research revealed K3s v1.36's bundled `local-path-provisioner` is an in-tree provisioner with no CSI gRPC socket — installing just the snapshot-controller chart provides CRDs but no driver ever receives the `CreateSnapshot` RPC. Adding a real CSI driver is unavoidable.

## Changes

### infra-controllers/ — two new charts

**`snapshot-controller/`** — piraeus-charts/snapshot-controller v5.2.0 (appVersion v8.6.0) in kube-system. Installs the `VolumeSnapshot` / `VolumeSnapshotContent` / `VolumeSnapshotClass` / `VolumeGroupSnapshot` CRDs (CreateReplace on install/upgrade). Validation webhook disabled (no cert-manager dependency; we're on the current v1 API). Leader election + single replica fine on single-node.

**`csi-hostpath/`** — alvistack chart `csi-hostpathplugin` v1.17.1 in kube-system. Single-node StatefulSet with all six CSI sidecars bundled (csi-snapshotter v8.2.0, csi-attacher, csi-provisioner, csi-resizer, node-driver-registrar, liveness-probe, csi-external-health-monitor-controller). Creates `StorageClass: csi-hostpath-sc` (NOT default — K3s's `local-path` stays default for everything else).

### infra-configs/snapshot-storage/ — VolumeSnapshotClass

```yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: csi-hostpath-snapclass
deletionPolicy: Delete
driver: hostpath.csi.k8s.io
```

Deliberately not setting `is-default-class` — kopiur `SnapshotPolicy` picks by name (`volumeSnapshotClassName: csi-hostpath-snapclass`), and a default annotation would cause confusion if other VSCs ever appear.

### kopiur-policies/ — revert copyMethod + add VSC name

Both SnapshotPolicies get `copyMethod: Snapshot` (was: `Direct` after PR #273) and a new `volumeSnapshotClassName: csi-hostpath-snapclass` field. This is the change that actually enables snapshots now that the CSI stack exists.

### applications/ — PVC migration

- `headlamp/helmrelease.yaml`: added `persistentVolumeClaim.storageClassName: csi-hostpath-sc` (the chart's default was K3s's `local-path`; PVC spec is immutable so a fresh PVC lands on the new class)
- `gatus/helmrelease.yaml`: `persistence.storageClassName: local-path` → `csi-hostpath-sc`

**PVC data loss**: the existing 1Gi `local-path` PVCs for headlamp + gatus are orphaned by the storageClassName change. User explicitly approved this — both PVCs only hold log files.

## Deployment order on the cluster after merge

1. `infra-controllers` reconciles first → installs `snapshot-controller` + `csi-hostpath`
2. `infra-configs` reconciles → applies the new `VolumeSnapshotClass`
3. `apps` reconciles → headlamp + gatus PVCs migrate to `csi-hostpath-sc` (orphans the old `local-path` PVCs)
4. `kopiur-policies` reconciles → SnapshotPolicy reverts to `copyMethod: Snapshot` + VSC name
5. Force-reconcile kopiur-policies to pick up the new policy; the next scheduled `H * * * *` snapshot creates a real `VolumeSnapshot` via the new stack

## Verified locally

- `yamllint -c .yamllint.yaml k3s/infrastructure k3s/platform k3s/clusters/homelab k3s/applications` — clean (only the pre-existing opentelemetry-collector comment warning, untouched by this change)
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 6/6 pass
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — 201 lines, 8 Kustomizations with diffs (controllers + configs + apps + policies), **0** "invalid names" warnings. New resources visible: 2 `HelmRepository` (piraeus-charts, alvistack), 2 `HelmRelease` (snapshot-controller, csi-hostpath), 1 `VolumeSnapshotClass`, 2 `SnapshotPolicy` updates, 2 `helmrelease` updates

## Verified on testbed (prior PRs in this series)

- PR #270: kopiur operator deploys, pods Running
- PR #271: chartRef.namespace fix unblocked infra-controllers
- PR #272: SnapshotPolicies split (ClusterRepository now commits before SnapshotPolicy admission)
- PR #273: copyMethod: Direct — the only bug fix that worked partially; reverted here now that the real fix (CSI stack) is in place

## Verification plan on testbed after merge

1. `kubectl get pods -n kube-system` — confirm `snapshot-controller-0` and `csi-hostpathplugin-0` running
2. `kubectl get crd | grep snapshot.storage` — confirm `volumesnapshots.snapshot.storage.k8s.io` etc.
3. `kubectl get volumesnapshotclass` — confirm `csi-hostpath-snapclass`
4. `kubectl get sc` — confirm `csi-hostpath-sc` (not default)
5. Force-reconcile `infra-controllers`, `infra-configs`, `apps`, `kopiur-policies`
6. Watch headlamp + gatus pods restart on the new StorageClass
7. `kubectl get pvc -n headlamp` — confirm new PVC on `csi-hostpath-sc` (old one will be orphaned)
8. Manual snapshot:
   ```
   kubectl create -f - <<EOF
   apiVersion: kopiur.home-operations.com/v1alpha1
   kind: Snapshot
   metadata:
     generateName: headlamp-manual-
     namespace: headlamp
   spec:
     policyRef:
       name: headlamp
   EOF
   ```
9. `kubectl get snapshots -n headlamp` — confirm `Phase: Succeeded`
10. `kubectl get volumesnapshot -n headlamp` — confirm `READY: True`
11. `kubectl get clusterrepository nas -o jsonpath='{.status.storageStats}'` — `snapshotCount: 1`
12. Verify on NAS: `\\MemoryAlpha\data\backups\k3s\blobs\...` has content

## Caveats documented for the record

- **`csi-hostpath` is non-durable.** Data lives in the plugin pod's `emptyDir` volume, which on K3s single-node maps to `/var/lib/csi-hostpath-data` on the node. If that node dies, all PVCs vanish. Fine for config volumes; not acceptable for stateful workloads. Next step up is Longhorn (production-grade, distributed block storage) — separate PR when we need durable storage for actual databases.
- **Two CSI drivers now coexist** (`hostpath.csi.k8s.io` and `smb.csi.k8s.io`). They have separate CSIDriver objects and RBAC; no conflicts.

## Out of scope (separate PRs, not this one)

1. K3s datastore backup (`k3s etcd-snapshot` → SMB offload)
2. Adding kopiur `SnapshotPolicy` for the other apps: radarr, sonarr, prowlarr, sabnzbd, qbittorrent, recyclarr, tdarr
3. Longhorn migration for durable in-cluster storage
4. Bumping kopiur chart to a newer 0.9.x or 1.0.x once `copyMethod: Direct` is honored