### PR TITLE
fix(kopiur): bind repository PVCs to SMB subPath backups/k3s

### DIFF
--- a/k3s/infrastructure/configs/kopiur/clusterrepository.yaml
+++ b/k3s/infrastructure/configs/kopiur/clusterrepository.yaml
@@ -11,18 +11,27 @@ spec:
 
   backend:
     filesystem:
-      # Pod mount path = the SMB share root (\\MemoryAlpha\data\), exposed
-      # via the per-namespace kopiur-repo PVCs. Kopia's filesystem backend
-      # initialises the repository at <share>/backups/k3s/ by passing this
-      # path to 'kopia repository create filesystem --path=...'. Kopia's
-      # MkdirAll creates the intermediate 'backups/' and 'k3s/' directories
-      # on first reconcile. Final on-NAS path:
-      #   \\MemoryAlpha\data\backups\k3s\kopia.repository
-      #   \\MemoryAlpha\data\backups\k3s\blobs\...
+      # Pod mount path for the kopiur-repo PVC. The csi-driver-smb PVs use
+      # `volumeAttributes.subPath: backups/k3s`, which binds that SMB-share
+      # subdirectory to the pod, so `/repo` inside the mover Pod maps to
+      # `\\MemoryAlpha\data\backups\k3s\` on the NAS. Kopia's filesystem
+      # backend initialises the repository here via
+      # `kopia repository create filesystem --path=/repo`, creating
+      # kopia.repository, blobs/, index/, logs/ on first reconcile.
+      #
+      # Why this two-piece construction: kopiur 0.9.1 uses
+      # `spec.backend.filesystem.path` verbatim as BOTH the Kubernetes
+      # `mount_path` AND the kopia `--path` argument (no normalization,
+      # no path-relative-to-mount). See PR #270 — the original path
+      # `/repo/backups/k3s` mounted the SMB share root at that exact path,
+      # so the `/backups/k3s` tail had no meaning and Kopia wrote to
+      # `\\MemoryAlpha\data\` (share root) instead of the intended
+      # subdirectory.
+      #
       # SMB auth is handled by csi-driver-smb via kube-system/smbcreds on
-      # each PV; the SMB user must have write access to the share root so
-      # the intermediate directories can be created.
-      path: /repo/backups/k3s
+      # each PV; the SMB user must have write access to `backups/` and
+      # `backups/k3s/` on the share.
+      path: /repo
       volume:
         pvc:
           name: kopiur-repo
@@ -33,8 +42,13 @@ spec:
       namespace: kopiur-system
       key: KOPIA_PASSWORD
 
-  # Greenfield repo — let kopiur initialize the Kopia repository on first
-  # reconcile via `kopia repository create filesystem --path=/repo`.
+  # Greenfield repo at the new path — let kopiur initialize the Kopia
+  # repository on first reconcile via
+  # `kopia repository create filesystem --path=/repo`. Any pre-existing
+  # files at the SMB share root (\\MemoryAlpha\data\kopia.repository, blobs/,
+  # index/, logs/) are orphaned by this change; operator deletes them
+  # manually after verifying fresh snapshots land in
+  # \\MemoryAlpha\data\backups\k3s\.
   create:
     enabled: true
 

--- a/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
@@ -29,6 +29,9 @@ spec:
     volumeHandle: kopiur-repo-gatus-vol
     volumeAttributes:
       source: //192.168.1.20/data
+      # Bind SMB subdirectory so the pod's mount path maps to
+      # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
+      subPath: backups/k3s
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system

--- a/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
@@ -31,6 +31,9 @@ spec:
     volumeHandle: kopiur-repo-headlamp-vol
     volumeAttributes:
       source: //192.168.1.20/data
+      # Bind SMB subdirectory so the pod's mount path maps to
+      # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
+      subPath: backups/k3s
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system

--- a/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
@@ -31,6 +31,9 @@ spec:
     volumeHandle: kopiur-repo-kopiur-system-vol
     volumeAttributes:
       source: //192.168.1.20/data
+      # Bind SMB subdirectory so the pod's mount path maps to
+      # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
+      subPath: backups/k3s
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system


### PR DESCRIPTION
## Problem

`ClusterRepository/nas` specified `backend.filesystem.path: /repo/backups/k3s`, but kopiur 0.9.1 uses that string **verbatim** as both the Kubernetes `mount_path` for the repository PVC and the kopia `--path` argument (no normalization, no path-relative-to-mount logic). With the PVs mounting the SMB share root (`volumeAttributes.source: //192.168.1.20/data`, no subPath), Kubernetes mounted the share root directly at `/repo/backups/k3s` inside every mover Pod. Result on the NAS: Kopia wrote `kopia.repository`, `blobs/`, `index/`, `logs/` at `\\MemoryAlpha\data\` (share root) instead of the intended `\\MemoryAlpha\data\backups\k3s\`.

Verified evidence (Aug 11 2026, 23:30 ET):
- `ClusterRepository/nas.status.phase: Ready`, `backendPath=/repo/backups/k3s`
- `kubectl get pv kopiur-repo-{kopiur-system,headlamp,gatus}` → all `csi.volumeAttributes.source: //192.168.1.20/data` (no `subPath`)
- Mover Jobs mount the repository PVC at `/repo/backups/k3s` (read-write)
- 20 successful `Snapshot` CRs (Succeeded) with Kopia IDs and bytes — data is safe; layout is wrong
- `ClusterRepository.storageStats.snapshotCount: 0` is stale (catalog last refreshed 03:11Z, before snapshots started)

Snapshots are succeeding; the data lives where the comment in `clusterrepository.yaml` said it wouldn't. PR #270's docstring predicted `\\MemoryAlpha\data\backups\k3s\`; the actual on-NAS path is `\\MemoryAlpha\data\`.

## Fix

Two-piece construction so the SMB share subdirectory is what gets mounted, not the share root:

1. `ClusterRepository/nas.spec.backend.filesystem.path: /repo/backups/k3s` → `/repo`
2. Each of the three repository PVs (`pv-kopiur-system.yaml`, `pv-headlamp.yaml`, `pv-gatus.yaml`) gets `csi.volumeAttributes.subPath: backups/k3s`. The csi-driver-smb binds `\\MemoryAlpha\data\backups\k3s\` to the pod's mount point at `/repo`.

Final on-NAS path:

```
\\MemoryAlpha\data\backups\k3s\kopia.repository
\\MemoryAlpha\data\backups\k3s\blobs\...
\\MemoryAlpha\data\backups\k3s\index\...
\\MemoryAlpha\data\backups\k3s\logs\...
```

`create.enabled: true` stays on `ClusterRepository/nas` — kopiur initializes a fresh Kopia repository on first reconcile at the new path. Pre-existing files at `\\MemoryAlpha\data\` (orphaned by this change) are deleted by the operator manually once fresh snapshots are confirmed at the new location.

## Diff

```diff
 # clusterrepository.yaml
   backend:
     filesystem:
-      path: /repo/backups/k3s
+      path: /repo
       volume:
         pvc:
           name: kopiur-repo

 # pv-kopiur-system.yaml, pv-headlamp.yaml, pv-gatus.yaml
   csi:
     volumeAttributes:
       source: //192.168.1.20/data
+      subPath: backups/k3s
```

## Verified locally

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur/ k3s/clusters/homelab/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 6/6 pass
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` — 4 changes: ClusterRepository path field, three PV `volumeAttributes.subPath` additions. No warnings.

## Verification plan on testbed after merge

PVs are immutable. Step-by-step on the testbed:

1. Force-reconcile `infra-configs` so Flux picks up the new `ClusterRepository/nas` path. `ClusterRepository` will re-reconcile but keep status (it's not the immutable thing — the PVs are).
2. Delete the three PVCs (`kopiur-repo` in `kopiur-system`, `headlamp`, `gatus`). Releasing them lets the PVs go Available.
3. Delete the three static PVs (`kopiur-repo-kopiur-system`, `kopiur-repo-headlamp`, `kopiur-repo-gatus`).
4. Wait for Flux reconciliation to recreate the PVs from the updated manifests; PVCs auto-bind.
5. Confirm `kubectl get pv` shows new PVs with `subPath: backups/k3s` and `kubectl get pvc -A` shows Bound.
6. Force-reconcile `kopiur-policies` to pick up the consumer side (no change there, but flushes).
7. Trigger a manual snapshot per app:
   ```
   kubectl create -f - <<EOF
   apiVersion: kopiur.home-operations.com/v1alpha1
   kind: Snapshot
   metadata: { generateName: gatus-repopath-, namespace: gatus }
   spec: { policyRef: { name: gatus } }
   EOF
   ```
   Repeat for `headlamp`.
8. Verify Snapshot CR `Phase: Succeeded`, `Kopia ID` populated, `filesNew` and `sizeBytes` non-zero.
9. Verify on the NAS: `\\MemoryAlpha\data\backups\k3s\blobs\...` has new content. Old share-root files still present until the operator deletes them.
10. `kubectl get clusterrepository nas -o jsonpath='{.status.storageStats}'` after catalog refresh (`refreshFrequency: 20m`) shows `snapshotCount: 1+`.

## Caveats

- Existing Snapshot CRs with pre-move Kopia IDs will fail to restore (mover can't find the old repo). They're history records only; not a functional regression.
- In-flight mover during PV swap could corrupt data. The swap is short (delete PV + Flux recreate) and the next scheduled tick (`H * * * *`) is at most 60 min away, but to be safe: the cluster side swap should run during a quiet window.
- kopiur 0.9.1 has no path validation/normalization (confirmed in source: `filesystem_repo_path` returns the string verbatim; `validate_backend` accepts anything for PVC-backed filesystem). Future migrations that intend a subdirectory must use SMB CSI `subPath` (or an NFS export) — never assume kopiur's path string is relative to the mount.

## Out of scope (separate PRs, not this one)

1. K3s datastore (`/var/lib/rancher/k3s/server/db`) backup via `k3s etcd-snapshot` + SMB offload
2. Adding kopiur `SnapshotPolicy` for remaining apps (radarr, sonarr, prowlarr, sabnzbd, qbittorrent, recyclarr, tdarr)
3. Bumping kopiur chart to a newer 0.9.x / 1.0.x once `copyMethod: Direct` is honored
4. OCIRepository + chart SHA digest pinning