### PR TITLE
fix(kopiur): use csi-driver-smb subDir key, not subPath

### DIFF
--- a/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
@@ -31,7 +31,11 @@ spec:
       source: //192.168.1.20/data
       # Bind SMB subdirectory so the pod's mount path maps to
       # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
-      subPath: backups/k3s
+      # NOTE: csi-driver-smb uses the key `subDir`, NOT `subPath`
+      # (CephFS-style). The driver silently ignores unknown keys,
+      # so PR #275's `subPath: backups/k3s` left every mover Pod
+      # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
+      subDir: backups/k3s
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system

--- a/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
@@ -33,7 +33,11 @@ spec:
       source: //192.168.1.20/data
       # Bind SMB subdirectory so the pod's mount path maps to
       # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
-      subPath: backups/k3s
+      # NOTE: csi-driver-smb uses the key `subDir`, NOT `subPath`
+      # (CephFS-style). The driver silently ignores unknown keys,
+      # so PR #275's `subPath: backups/k3s` left every mover Pod
+      # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
+      subDir: backups/k3s
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system

--- a/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
@@ -33,7 +33,11 @@ spec:
       source: //192.168.1.20/data
       # Bind SMB subdirectory so the pod's mount path maps to
       # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
-      subPath: backups/k3s
+      # NOTE: csi-driver-smb uses the key `subDir`, NOT `subPath`
+      # (CephFS-style). The driver silently ignores unknown keys,
+      # so PR #275's `subPath: backups/k3s` left every mover Pod
+      # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
+      subDir: backups/k3s
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system


### PR DESCRIPTION
## Problem

PR #275 added `volumeAttributes.subPath: backups/k3s` to the three repository PVs intending to bind `\\MemoryAlpha\data\backups\k3s\` on the SMB share. csi-driver-smb v1.20.3 honors the key **`subDir`** (camelCase), not `subPath`. The driver silently ignores unknown keys, so PR #275's `subPath: backups/k3s` was a no-op — every mover Pod continued to mount the SMB share root, and Kopia continued to write to `\\MemoryAlpha\data\` instead of the intended subdirectory.

The bug was caught on the testbed when the user confirmed `\\MemoryAlpha\data\backups\k3s\` was empty after PR #275. The `kopiur-system/nas-discovery` ConfigMap confirmed this: it contained 42 snapshots spanning pre-#275 through `headlamp-scheduled-20260812000600` at `00:06:14Z` (post-#275) — all referencing snapshots written to the share-root repo. The "fresh" Kopia IDs from the repopath manual snapshots were just new commits into the same old repo (Kopia content-addressed storage + identical source data → identical byte counts).

## Fix

Rename `volumeAttributes.subPath` to `volumeAttributes.subDir` in all three repository PVs. The csi-driver-smb driver auto-creates the subdirectory on first `NodeStageVolume` (verified from `internalMount` + `os.MkdirAll` flow in `pkg/smb/controllerserver.go` at tag `v1.20.3`, commit `59dce96`), so `\\MemoryAlpha\data\backups\k3s\` will be populated by the next mover Pod — no NAS pre-work required.

`csi.volumeAttributes` diff per PV:
```diff
   volumeAttributes:
     source: //192.168.1.20/data
-    subPath: backups/k3s
+    subDir: backups/k3s
```

`backend.filesystem.path: /repo` from PR #275 stays as-is — that's the correct mount path that the new `subDir` parameter binds.

## Source reference

csi-driver-smb v1.20.3 source (`pkg/smb/controllerserver.go`):

```go
const subDirField = "subDir"   // exact key name
// ...
switch strings.ToLower(name) {
case subDirField:
    subDir = v
}
```

Docs (`docs/driver-parameters.md` at v1.20.3):

> `volumeAttributes.subDir`: existing sub directory under SMB share. Required: No. The driver creates a new one if it does not exist.

## Verified locally

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur/ k3s/clusters/homelab/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 6/6 pass
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` — 3 changes, three `subPath → subDir` substitutions only

## Verification plan on testbed after merge

PVs are immutable. Same swap dance as PR #275:

1. Force-reconcile `infra-configs` so Flux picks up the new key.
2. Delete the three PVCs (`kopiur-repo` in `kopiur-system`, `headlamp`, `gatus`).
3. Delete the three static PVs (`kopiur-repo-kopiur-system`, `kopiur-repo-headlamp`, `kopiur-repo-gatus`).
4. Wait for Flux to recreate the PVs from updated manifests; PVCs auto-bind.
5. `kubectl get pv -o jsonpath='{.spec.csi.volumeAttributes.subDir}'` confirms the new key on each PV.
6. Trigger manual snapshots per app:
   ```
   kubectl create -f - <<EOF
   apiVersion: kopiur.home-operations.com/v1alpha1
   kind: Snapshot
   metadata: { generateName: gatus-subdir-verify-, namespace: gatus }
   spec: { policyRef: { name: gatus } }
   EOF
   ```
7. Verify `Snapshot` CR `Phase: Succeeded`, fresh Kopia ID, `filesNew`/`sizeBytes` non-zero.
8. **Verify on the NAS**: `\\MemoryAlpha\data\backups\k3s\` now exists with `kopia.repository`, `blobs/`, `index/`, `logs/`. `\\MemoryAlpha\data\` (share root) should no longer be touched by Kopiur — old files there are orphaned pending operator cleanup (per PR #275 agreement).
9. `kubectl get clusterrepository nas -o jsonpath='{.status.storageStats}'` after the next 20m catalog refresh shows fresh `snapshotCount`.

## Caveats

- csi-driver-smb parameter key is `subDir`, not `subPath`. Adding `subPath: ...` is a silent no-op — the driver ignores it. Worth noting in `k3s/AGENTS.md` anti-patterns so this isn't repeated.
- Old Kopia repo at `\\MemoryAlpha\data\` remains orphaned until operator deletes those files (planned; confirmed by user during PR #275 review).
- Driver's auto-create requires SMB credentials available during `CreateVolume` — we have `nodeStageSecretRef` + `kube-system/smbcreds`, so the subdir will be created.

## Out of scope (separate PRs, not this one)

1. K3s datastore (`/var/lib/rancher/k3s/server/db`) backup via `k3s etcd-snapshot` + SMB offload
2. Adding kopiur `SnapshotPolicy` for remaining apps (radarr, sonarr, prowlarr, sabnzbd, qbittorrent, recyclarr, tdarr)
3. Bumping kopiur chart to a newer 0.9.x / 1.0.x once `copyMethod: Direct` is honored
4. OCIRepository + chart SHA digest pinning
5. AGENTS.md update to flag the `subPath`-vs-`subDir` csi-driver-smb gotcha