### PR TITLE
docs(kopiur): document subDir prerequisite; flag subPath gotcha

### DIFF
--- a/k3s/AGENTS.md
+++ b/k3s/AGENTS.md
@@ -48,6 +48,7 @@ k3s/
 - **Do not hardcode a speculative storage vendor into new planning docs unless the repo actually adopts one.**
 - **Do not run `ansible-playbook` commands from `BOOTSTRAP.md`** without verifying nodes are provisioned.
 - **Do not add namespaces inside `k3s/infrastructure/configs/`** — namespaces belong in `k3s/platform/namespaces/` (established pattern; all existing namespaces follow this).
+- **Do not set `volumeAttributes.subPath: ...` on csi-driver-smb static PVs** — the driver honors `subDir` (camelCase). Unknown keys are silently ignored, so the pod ends up mounted at the share root and writes go to the wrong place. PRs #275 and #276 document this. Even with the right key, the subdirectory must pre-exist on the SMB share before any Pod mounts — NodeStageVolume only mounts, never creates; the CIFS client silently falls back to the share root on this kernel if the path doesn't resolve. See `k3s/infrastructure/configs/kopiur/pv-*.yaml` for the full comment block.
 ## NOTES
 - `BOOTSTRAP.md` is the authoritative guide for standing up the cluster when ready.
 - `k3s.md` contains the concrete repo blueprint, Flux kustomization graph, and Nx/CDK8s workflow.

--- a/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
@@ -35,6 +35,14 @@ spec:
       # (CephFS-style). The driver silently ignores unknown keys,
       # so PR #275's `subPath: backups/k3s` left every mover Pod
       # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
+      #
+      # PREREQUISITE: the SMB subdirectory must pre-exist on the share
+      # before any mover Pod runs. NodeStageVolume only mounts; it does
+      # NOT create the subdirectory (auto-create only happens in
+      # CreateVolume, which is the dynamic-provisioning path —
+      # irrelevant for static PVs). Without the dir, the CIFS client
+      # silently falls back to the share root on this kernel and Kopia
+      # writes to the existing repo at \\MemoryAlpha\data\.
       subDir: backups/k3s
     nodeStageSecretRef:
       name: smbcreds

--- a/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
@@ -37,6 +37,14 @@ spec:
       # (CephFS-style). The driver silently ignores unknown keys,
       # so PR #275's `subPath: backups/k3s` left every mover Pod
       # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
+      #
+      # PREREQUISITE: the SMB subdirectory must pre-exist on the share
+      # before any mover Pod runs. NodeStageVolume only mounts; it does
+      # NOT create the subdirectory (auto-create only happens in
+      # CreateVolume, which is the dynamic-provisioning path —
+      # irrelevant for static PVs). Without the dir, the CIFS client
+      # silently falls back to the share root on this kernel and Kopia
+      # writes to the existing repo at \\MemoryAlpha\data\.
       subDir: backups/k3s
     nodeStageSecretRef:
       name: smbcreds

--- a/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
@@ -37,6 +37,14 @@ spec:
       # (CephFS-style). The driver silently ignores unknown keys,
       # so PR #275's `subPath: backups/k3s` left every mover Pod
       # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
+      #
+      # PREREQUISITE: the SMB subdirectory must pre-exist on the share
+      # before any mover Pod runs. NodeStageVolume only mounts; it does
+      # NOT create the subdirectory (auto-create only happens in
+      # CreateVolume, which is the dynamic-provisioning path —
+      # irrelevant for static PVs). Without the dir, the CIFS client
+      # silently falls back to the share root on this kernel and Kopia
+      # writes to the existing repo at \\MemoryAlpha\data\.
       subDir: backups/k3s
     nodeStageSecretRef:
       name: smbcreds


### PR DESCRIPTION
## Problem

After PR #276 landed, the live testbed still wrote snapshots to the share-root repo at `\\MemoryAlpha\data\` instead of `\\MemoryAlpha\data\backups\k3s\`. ClusterRepository's `uniqueId` stayed `9b6ba0ca...` across the swap. Source investigation of `csi-driver-smb v1.20.3` (`pkg/smb/nodeserver.go:183–317`) confirmed:

- NodeStageVolume DOES read `volumeAttributes.subDir` and bind-mount the subdirectory for the pod. PR #275's `subPath: backups/k3s` was the original bug; PR #276's `subDir: backups/k3s` is the correct key.
- But NodeStageVolume only mounts — it does **not** create the subdirectory. Auto-creation happens only during `CreateVolume` (controller path), which is irrelevant for static PVs.
- With `\\MemoryAlpha\data\backups\k3s\` not present on the share, the CIFS client on this kernel silently falls back to the share root. The mount "succeeds" and Kopia writes to the existing repo at the share root.

## Fix

This is a docs-only change. The actual fix requires the operator to mkdir `\\MemoryAlpha\data\backups\k3s\` on the NAS before the next mover Pod runs (planned, in parallel with this PR). The next scheduled tick will then land snapshots at the intended path automatically.

Documentation added:

1. **`k3s/infrastructure/configs/kopiur/pv-{kopiur-system,headlamp,gatus}.yaml`** — every `subDir: backups/k3s` block now has a `PREREQUISITE` comment explaining:
   - NodeStageVolume only mounts, never creates the subdirectory.
   - The CIFS client silently falls back to the share root if the path doesn't resolve.
   - The directory must be created on the SMB share before any Pod mounts.

2. **`k3s/AGENTS.md` anti-patterns** — new bullet flagging the `subPath` vs `subDir` key-name trap from PR #275/#276 and pointing future readers at the PV comments.

No manifest change beyond comments. Validated:

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur/ k3s/clusters/homelab/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 6/6 pass

## Verification on testbed after merge

This PR is documentation; no cluster change. The cluster fix is the NAS directory:

1. Operator creates `\\MemoryAlpha\data\backups\k3s\` on the Synology SMB share (one `mkdir`).
2. Force-reconcile `kopiur-policies` to nudge the snapshot schedule if needed; otherwise wait for the next `H * * * *` tick.
3. The mover Pod's CIFS mount will navigate into `backups/k3s\` (instead of silently falling back to the share root).
4. Kopia, with `create.enabled: true` on `ClusterRepository/nas`, initializes a fresh repo at `/repo` (now mapped to `\\MemoryAlpha\data\backups\k3s\`).
5. Verify on the NAS: `\\MemoryAlpha\data\backups\k3s\kopia.repository` appears with new content.
6. `ClusterRepository/nas.status.uniqueId` changes from `9b6ba0ca...` to a new value (proof of new repo at new location). `storageStats.snapshotCount` resets (catalog reads from the new repo).
7. Old repo at `\\MemoryAlpha\data\` remains orphaned until operator cleanup.

## Out of scope

- The NAS-side mkdir (operator does this manually in parallel).
- AGENTS.md entries for the `k3s/infrastructure/configs/kopiur/` directory itself (currently no `infrastructure/AGENTS.md` mention of kopiur subdir details).