### PR TITLE
fix(kopiur): mount repository PVCs from dedicated \\MemoryAlpha\backups sub-share

### DIFF
--- a/k3s/infrastructure/configs/kopiur/clusterrepository.yaml
+++ b/k3s/infrastructure/configs/kopiur/clusterrepository.yaml
@@ -11,26 +11,27 @@ spec:
 
   backend:
     filesystem:
-      # Pod mount path for the kopiur-repo PVC. The csi-driver-smb PVs use
-      # `volumeAttributes.subPath: backups/k3s`, which binds that SMB-share
-      # subdirectory to the pod, so `/repo` inside the mover Pod maps to
-      # `\\MemoryAlpha\data\backups\k3s\` on the NAS. Kopia's filesystem
+      # Pod mount path for the kopiur-repo PVC. The PVs in pv-*.yaml mount
+      # the dedicated backup SMB sub-share \\MemoryAlpha\backups\ (separate
+      # from \\MemoryAlpha\data\ used by the media stack), so `/repo` inside
+      # the mover Pod maps to the root of that sub-share. Kopia's filesystem
       # backend initialises the repository here via
       # `kopia repository create filesystem --path=/repo`, creating
       # kopia.repository, blobs/, index/, logs/ on first reconcile.
       #
-      # Why this two-piece construction: kopiur 0.9.1 uses
-      # `spec.backend.filesystem.path` verbatim as BOTH the Kubernetes
-      # `mount_path` AND the kopia `--path` argument (no normalization,
-      # no path-relative-to-mount). See PR #270 — the original path
-      # `/repo/backups/k3s` mounted the SMB share root at that exact path,
-      # so the `/backups/k3s` tail had no meaning and Kopia wrote to
-      # `\\MemoryAlpha\data\` (share root) instead of the intended
-      # subdirectory.
+      # Why a dedicated sub-share rather than a subdir on \\MemoryAlpha\data\:
+      # kopiur 0.9.1 uses `spec.backend.filesystem.path` verbatim as BOTH
+      # the Kubernetes `mount_path` AND the kopia `--path` argument (no
+      # normalization, no path-relative-to-mount). PRs #275/#276 tried
+      # putting the repo at `\\MemoryAlpha\data\backups\k3s\` via the csi
+      # driver's `subDir` key — but the Linux CIFS client on this kernel
+      # silently ignores path components in the mount source, falling back
+      # to the share root regardless. The CIFS kernel limitation makes
+      # share-level isolation via subDir unreliable. A dedicated SMB
+      # sub-share is the only clean fix on this kernel.
       #
       # SMB auth is handled by csi-driver-smb via kube-system/smbcreds on
-      # each PV; the SMB user must have write access to `backups/` and
-      # `backups/k3s/` on the share.
+      # each PV; the SMB user must have write access to the share root.
       path: /repo
       volume:
         pvc:

--- a/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-gatus.yaml
@@ -1,8 +1,9 @@
 ---
 # Repository storage for kopiur snapshot Jobs in gatus. Static PV + PVC pair
-# bound to the existing smb-media CSI provisioner. Shares the SMB source
-# path with pv-kopiur-system.yaml and pv-headlamp.yaml — each namespace has
-# its own mount = its own SMB session to //192.168.1.20/data.
+# bound to the smb-media CSI provisioner. Mounts the dedicated backup SMB
+# sub-share \\MemoryAlpha\backups\ (separate from \\MemoryAlpha\data\ used
+# by the media stack). Shares the SMB source with pv-kopiur-system.yaml and
+# pv-headlamp.yaml — each namespace has its own mount = its own SMB session.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -28,14 +29,7 @@ spec:
     readOnly: false
     volumeHandle: kopiur-repo-gatus-vol
     volumeAttributes:
-      source: //192.168.1.20/data
-      # Bind SMB subdirectory so the pod's mount path maps to
-      # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
-      # NOTE: csi-driver-smb uses the key `subDir`, NOT `subPath`
-      # (CephFS-style). The driver silently ignores unknown keys,
-      # so PR #275's `subPath: backups/k3s` left every mover Pod
-      # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
-      subDir: backups/k3s
+      source: //192.168.1.20/backups
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system

--- a/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-headlamp.yaml
@@ -1,8 +1,11 @@
 ---
 # Repository storage for kopiur snapshot Jobs in headlamp. Static PV + PVC
-# pair bound to the existing smb-media CSI provisioner. Shares the SMB
-# source path with pv-kopiur-system.yaml and pv-gatus.yaml — each namespace
-# has its own mount = its own SMB session to //192.168.1.20/data. Kopia's
+# pair bound to the smb-media CSI provisioner. Mounts the dedicated backup
+# SMB sub-share \\MemoryAlpha\backups\ (separate from \\MemoryAlpha\data\
+# used by the media stack — radarr, sonarr, qbittorrent, sabnzbd, tdarr —
+# which all write their own app-level subdirs into the share root). Shares
+# the SMB source with pv-kopiur-system.yaml and pv-gatus.yaml — each
+# namespace has its own mount = its own SMB session. Kopia's
 # content-addressable storage makes concurrent multi-mount writes safe
 # (different jobs write to different blob files).
 apiVersion: v1
@@ -30,14 +33,7 @@ spec:
     readOnly: false
     volumeHandle: kopiur-repo-headlamp-vol
     volumeAttributes:
-      source: //192.168.1.20/data
-      # Bind SMB subdirectory so the pod's mount path maps to
-      # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
-      # NOTE: csi-driver-smb uses the key `subDir`, NOT `subPath`
-      # (CephFS-style). The driver silently ignores unknown keys,
-      # so PR #275's `subPath: backups/k3s` left every mover Pod
-      # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
-      subDir: backups/k3s
+      source: //192.168.1.20/backups
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system

--- a/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-kopiur-system.yaml
@@ -1,10 +1,12 @@
 ---
 # Repository storage for kopiur maintenance Jobs (run in kopiur-system every 6h).
-# Static PV + PVC pair bound to the existing smb-media CSI provisioner. The
-# PV's source matches the other kopiur-repo PVs in headlamp/gatus so all
-# three namespaces mount the same SMB share; each mount = its own SMB session
-# (see pv-headlamp.yaml / pv-gatus.yaml). Same name 'kopiur-repo' in each
-# namespace is what kopiur's volume.pvc.name resolver expects.
+# Static PV + PVC pair bound to the smb-media CSI provisioner. Mounts the
+# dedicated backup SMB sub-share \\MemoryAlpha\backups\ (separate from
+# \\MemoryAlpha\data\ used by the media stack). The same SMB source is used
+# by the other two kopiur-repo PVs in headlamp/gatus — each namespace has its
+# own mount = its own SMB session (see pv-headlamp.yaml / pv-gatus.yaml).
+# Same name 'kopiur-repo' in each namespace is what kopiur's
+# volume.pvc.name resolver expects.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -30,14 +32,7 @@ spec:
     readOnly: false
     volumeHandle: kopiur-repo-kopiur-system-vol
     volumeAttributes:
-      source: //192.168.1.20/data
-      # Bind SMB subdirectory so the pod's mount path maps to
-      # \\MemoryAlpha\data\backups\k3s\ instead of the share root.
-      # NOTE: csi-driver-smb uses the key `subDir`, NOT `subPath`
-      # (CephFS-style). The driver silently ignores unknown keys,
-      # so PR #275's `subPath: backups/k3s` left every mover Pod
-      # mounted at the share root and Kopia wrote \\MemoryAlpha\data\.
-      subDir: backups/k3s
+      source: //192.168.1.20/backups
     nodeStageSecretRef:
       name: smbcreds
       namespace: kube-system


### PR DESCRIPTION
## Problem

PR #275 + #276 attempted to put the Kopia repo at `\\MemoryAlpha\data\backups\k3s\` via the csi-driver-smb `subDir` key on the static PVs. After both PRs the live testbed still wrote snapshots to the share-root repo at `\\MemoryAlpha\data\`. `ClusterRepository/nas.status.uniqueId` stayed `9b6ba0ca...` across both swaps; the byte counts on post-#276 snapshots are identical to pre-#275 snapshots, confirming the same old repo.

Root cause confirmed: **the Linux CIFS client on this kernel silently ignores path components in the mount source URL.** PRs #275 (`subPath`) and #276 (`subDir`) both failed for the same reason — the kernel mounts the share root regardless of the requested subdir, even when that subdir exists on the share. `NodeStageVolume` succeeds because the share root is always mountable; the path component is dropped before the CIFS handshake. The "create the subdir first, then mount" hypothesis was a red herring: the directory existing didn't change anything because the kernel never asks the server for the subdir path.

## Fix

Dedicate a separate SMB sub-share for backups. With `\\MemoryAlpha\backups\` as the source, the Kopia mount **IS** the share root — no subdir gymnastics needed.

Operator has already created the new `\\MemoryAlpha\backups\` share on the Synology (parallel to this PR).

Changes:

```diff
 # pv-kopiur-system.yaml, pv-headlamp.yaml, pv-gatus.yaml
   csi:
     volumeAttributes:
-      source: //192.168.1.20/data
-      subDir: backups/k3s
+      source: //192.168.1.20/backups
```

`backend.filesystem.path: /repo` stays — already correct from PR #275. The pod's mount at `/repo` is the share root now, and Kopia initializes a fresh repo there.

`\\MemoryAlpha\data\` remains the source for radarr-media, sonarr-media, qbittorrent-media, sabnzbd-media, tdarr-media. The LinuxServer media stack mounts share root and writes app-level subdirs at runtime (`/data/movies`, `/data/tv`, `/data/downloads`, ...) — works on this kernel because the apps don't need isolated mount points.

## Verified locally

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur/ k3s/clusters/homelab/` — clean
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 6/6 pass
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` — four expected changes: three PV source swaps, one ClusterRepository comment block update

## Verification plan on testbed after merge

PVs are immutable. Same swap dance as PR #275 / #276:

1. Force-reconcile `infra-configs` so Flux picks up the new sources.
2. Delete the three PVCs (`kopiur-repo` in `kopiur-system`, `headlamp`, `gatus`). The `kopiur-system` one is currently wedged on `kubernetes.io/pvc-protection` finalizer from earlier operations — strip that first.
3. Delete the three static PVs (`kopiur-repo-kopiur-system`, `kopiur-repo-headlamp`, `kopiur-repo-gatus`).
4. Wait for Flux to recreate PVs/PVCs from updated manifests.
5. `kubectl get pv -o jsonpath='{.spec.csi.volumeAttributes.source}'` confirms `//192.168.1.20/backups` on each.
6. Trigger manual snapshots per app:
   ```
   kubectl create -f - <<EOF
   apiVersion: kopiur.home-operations.com/v1alpha1
   kind: Snapshot
   metadata: { generateName: gatus-subshare-verify-, namespace: gatus }
   spec: { policyRef: { name: gatus } }
   EOF
   ```
7. Verify `Snapshot` CR `Phase: Succeeded`, fresh Kopia ID.
8. **`kubectl get clusterrepository nas -o jsonpath='{.status.uniqueId}'`** flips from `9b6ba0ca...` to a new value — definitive proof of new repo at new location.
9. Verify on the NAS: `\\MemoryAlpha\backups\kopia.repository` appears with new content; `\\MemoryAlpha\data\` (share root) no longer touched by Kopiur.
10. Old repo at `\\MemoryAlpha\data\` remains orphaned pending operator cleanup (as previously agreed with PR #270/#275).

## Caveats

- Operator MUST create `\\MemoryAlpha\backups\` on the Synology before merging (already done — confirmed during drafting of this PR).
- SMB credentials in `kube-system/smbcreds` must have write access to `\\MemoryAlpha\backups\` (same SMB user that's already writing to `\\MemoryAlpha\data\`).
- PR #277 (the docs-only subDir prerequisite note) is still open and should remain — it's now a general "subDir is dangerous on this kernel" warning for any future static PV using csi-driver-smb, even though we no longer need it for these three PVs.

## Out of scope (separate PRs, not this one)

1. K3s datastore (`/var/lib/rancher/k3s/server/db`) backup via `k3s etcd-snapshot` + SMB offload
2. Adding kopiur `SnapshotPolicy` for remaining apps (radarr, sonarr, prowlarr, sabnzbd, qbittorrent, recyclarr, tdarr)
3. Bumping kopiur chart to a newer 0.9.x / 1.0.x once `copyMethod: Direct` is honored
4. OCIRepository + chart SHA digest pinning
5. Closing PR #277 in favor of an updated note (or just landing it as the CIFS-kernel warning it now is)