### PR TITLE
kopiur: prune completed operator Jobs to avoid PV/PVC finalizer deadlock

### DIFF
--- a/k3s/infrastructure/configs/kopiur/job-cleanup-cronjob.yaml
+++ b/k3s/infrastructure/configs/kopiur/job-cleanup-cronjob.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kopiur-completed-job-cleanup
+  namespace: kopiur-system
+  labels:
+    app.kubernetes.io/name: kopiur
+    app.kubernetes.io/component: cleanup
+spec:
+  # Hourly. Pruning window is 1h, so this is well below the threshold and
+  # gives plenty of room for ad-hoc kubectl log inspection between sweeps.
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata: {}
+        spec:
+          serviceAccountName: kopiur-completed-job-cleanup
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
+          containers:
+            - name: cleanup
+              # bitnami/kubectl ships bash + curl + kubectl — everything
+              # needed without pulling jq. Digest-pinned for reproducibility.
+              image: docker.io/bitnami/kubectl:1.32.4-debian-12-r1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  set -euo pipefail
+                  NAMESPACE="kopiur-system"
+                  CUTOFF_TS="$(date -u -d '1 hour ago' +%s)"
+                  # Use a single jsonpath that emits one line per Job with
+                  # name|completionTime|complete|failed. Empty fields mean
+                  # the Job hasn't finished yet — skip it.
+                  while IFS='|' read -r name completion complete failed; do
+                    [ -n "$name" ] || continue
+                    if [ "$complete" != "True" ] && [ "$failed" != "True" ]; then
+                      continue
+                    fi
+                    [ -n "$completion" ] || continue
+                    completion_ts="$(date -u -d "$completion" +%s)"
+                    if [ "$completion_ts" -lt "$CUTOFF_TS" ]; then
+                      echo "deleting ${NAMESPACE}/${name} (completed at ${completion})"
+                      kubectl delete job -n "$NAMESPACE" "$name" --ignore-not-found
+                    fi
+                  done <<< "$(
+                    kubectl get jobs -n "$NAMESPACE" -o jsonpath='{range .items[*]}\
+                      {.metadata.name}|{.status.completionTime}|\
+                      {(.status.conditions[?(@.type==\"Complete\")].status)}{|\
+                      {(.status.conditions[?(@.type==\"Failed\")].status)}\
+                      {"\n"}{end}'
+                  )"
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi

--- a/k3s/infrastructure/configs/kopiur/job-cleanup-rbac.yaml
+++ b/k3s/infrastructure/configs/kopiur/job-cleanup-rbac.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kopiur-completed-job-cleanup
+  namespace: kopiur-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kopiur-completed-job-cleanup
+  namespace: kopiur-system
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kopiur-completed-job-cleanup
+  namespace: kopiur-system
+subjects:
+  - kind: ServiceAccount
+    name: kopiur-completed-job-cleanup
+    namespace: kopiur-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kopiur-completed-job-cleanup

--- a/k3s/infrastructure/configs/kopiur/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur/kustomization.yaml
@@ -21,3 +21,5 @@ resources:
   - pv-headlamp.yaml
   - pv-gatus.yaml
   - clusterrepository.yaml
+  - job-cleanup-rbac.yaml
+  - job-cleanup-cronjob.yaml


### PR DESCRIPTION
## Problem

The [kopiur](https://github.com/home-operations/kopiur) Helm chart hardcodes `ttl_seconds_after_finished = None` for `RepositorySnapshotDeleteBatch` Jobs (and other one-shot Job types) — see the `JobLimits` struct in `crates/mover/src/jobs.rs`. The chart has no `values.yaml` knob for setting TTL on these Job types.

Finished Jobs therefore persist indefinitely. Their pods keep the `kopiur-repo` PVC in their `Used By` list, which prevents the kubelet from clearing `kubernetes.io/pvc-protection` on the PVC when the PVC enters Terminating. Combined with Flux-owned PV/PVC rotation, this produced a deadlock that required force-clearing the PVC finalizer to recover (incident 2026-08-12, ops memory ID 193).

## Fix

Hourly sweep CronJob in `kopiur-system` that deletes Completed/Failed Jobs older than 1h. RBAC is namespace-scoped to a dedicated ServiceAccount, so blast radius is limited to operator-created Jobs in that namespace only.

## Files

- `k3s/infrastructure/configs/kopiur/job-cleanup-rbac.yaml` (new) — ServiceAccount + Role (jobs get/list/delete in kopiur-system) + RoleBinding
- `k3s/infrastructure/configs/kopiur/job-cleanup-cronjob.yaml` (new) — hourly sweep, 1h retention, low resource footprint
- `k3s/infrastructure/configs/kopiur/kustomization.yaml` — include both new resources

## Validation

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur` (matches CI)
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths`
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` (no expected drift besides the new sweep CronJob)

## Followup

Once upstream exposes a `jobs.ttlSecondsAfterFinished` Helm value that flows into `JobLimits::ttl_seconds_after_finished` for `RepositorySnapshotDeleteBatch` Jobs, this CronJob can be retired.