### PR TITLE
kopiur: fix cleanup CronJob image tag

### DIFF
--- a/k3s/infrastructure/configs/kopiur/job-cleanup-cronjob.yaml
+++ b/k3s/infrastructure/configs/kopiur/job-cleanup-cronjob.yaml
@@ -31,9 +31,12 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
           containers:
             - name: cleanup
-              # bitnami/kubectl ships bash + curl + kubectl — everything
-              # needed without pulling jq. Digest-pinned for reproducibility.
-              image: docker.io/bitnami/kubectl:1.32.4-debian-12-r1
+              # bitnami/kubectl on Docker Hub is now Bitnami Secure Images
+              # (commercial subscription). The free legacy Debian-based image
+              # lives at bitnamilegacy/kubectl. This tag is last published
+              # 2025-08-22 and includes bash + curl + kubectl + jq.
+              # Digest-pinned for reproducibility.
+              image: docker.io/bitnamilegacy/kubectl:1.33.4-debian-12-r0@sha256:681609aff6bf316acf464d9c9e369d84c49d50be6379247291b01ac311a7f5f5
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash


### PR DESCRIPTION
## Problem

The pinned tag `docker.io/bitnami/kubectl:1.32.4-debian-12-r1` from #279 doesn't exist on Docker Hub. The `bitnami/kubectl` repo is now **Bitnami Secure Images** (commercial subscription only). The free legacy Debian-based image lives at `bitnamilegacy/kubectl`.

Symptoms on the testbed: the CronJob fired at 04:00 UTC and the Job has been in `ImagePullBackOff` since. The kubelet will keep retrying the unresolvable digest, so the CronJob is effectively blocked while the bad image is in the running CronJob spec.

## Fix

Switch to `docker.io/bitnamilegacy/kubectl:1.33.4-debian-12-r0@sha256:681609aff6bf316acf464d9c9e369d84c49d50be6379247291b01ac311a7f5f5`. Free, Debian Bookworm, includes bash + curl + kubectl + jq. Most recent published tag (2025-08-22).

## Files

- `k3s/infrastructure/configs/kopiur/job-cleanup-cronjob.yaml` — image tag and comment

## Validation

- `yamllint -c .yamllint.yaml k3s/infrastructure/configs/kopiur` (matches CI)
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths`
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` (only the image tag differs from master)

## Followup

After merge, the stuck Job on the testbed (`kopiur-completed-job-cleanup-29775120`) will be force-deleted so the CronJob can resume normal operation.