### PR TITLE
prowlarr: migrate config PVC to csi-hostpath-sc for kopiur backup

### DIFF
--- a/k3s/applications/prowlarr/kustomization.yaml
+++ b/k3s/applications/prowlarr/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - pvc.yaml
+  - prowlarr-config-v2.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/k3s/applications/prowlarr/migrate-job.yaml
+++ b/k3s/applications/prowlarr/migrate-job.yaml
@@ -1,0 +1,69 @@
+---
+# One-time Job to copy prowlarr-config data from local-path to csi-hostpath-sc.
+# NOT in the Flux Kustomization — apply manually via `kubectl apply -f`
+# AFTER the prowlarr Deployment is scaled to 0 (releases the old PVC).
+# The Job mounts the OLD `prowlarr-config` PVC read-only and the NEW
+# `prowlarr-config-v2` PVC read-write, then `cp -a /old/. /new/`.
+# ttlSecondsAfterFinished GC's the Job 1 hour after success.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prowlarr-config-migrate
+  namespace: media
+  labels:
+    app: prowlarr
+    app.kubernetes.io/component: pvc-migration
+spec:
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        # LinuxServer PUID/PGID so the migrated files keep their
+        # 1027:100 ownership — prowlarr reads /config as that user.
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: cp
+          image: alpine:3.20
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -e
+              echo "=== Source /old ==="
+              ls -la /old/
+              if [ ! -f /old/prowlarr/prowlarr.db ]; then
+                echo "FATAL: /old/prowlarr/prowlarr.db missing — aborting"
+                exit 1
+              fi
+              echo "=== Destination /new (pre-copy) ==="
+              ls -la /new/ 2>/dev/null || echo "(empty)"
+              echo "=== Copying /old -> /new ==="
+              cp -a /old/. /new/
+              echo "=== After copy ==="
+              ls -la /new/prowlarr/prowlarr.db
+              echo "OK: migration complete"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: old
+              mountPath: /old
+              readOnly: true
+            - name: new
+              mountPath: /new
+      volumes:
+        - name: old
+          persistentVolumeClaim:
+            claimName: prowlarr-config
+            readOnly: true
+        - name: new
+          persistentVolumeClaim:
+            claimName: prowlarr-config-v2

--- a/k3s/applications/prowlarr/prowlarr-config-v2.yaml
+++ b/k3s/applications/prowlarr/prowlarr-config-v2.yaml
@@ -1,0 +1,37 @@
+---
+# Static PV + PVC pair for prowlarr-config on csi-hostpath-sc.
+# Migrating prowlarr-config off local-path so the PVC can be snapshotted
+# via VolumeSnapshotClass `csi-hostpath-snapclass` for kopiur backup
+# (PR #274 did the same migration for gatus/headlamp). Same PVC size
+# as the original; only the storageClassName changes. The new PVC
+# name `prowlarr-config-v2` is intentional — the old `prowlarr-config`
+# PVC name is reserved by the existing local-path PV, and PVC
+# storageClassName is immutable so we can't simply rename in place.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: prowlarr-config-v2
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: csi-hostpath-sc
+  csi:
+    driver: hostpath.csi.k8s.io
+    volumeHandle: prowlarr-config-v2-vol
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prowlarr-config-v2
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: csi-hostpath-sc
+  volumeName: prowlarr-config-v2
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Problem

`prowlarr-config` is on `local-path`, which has no VolumeSnapshot support. To enable kopiur backup we need to migrate to `csi-hostpath-sc` (same pattern PR #274 used for gatus/headlamp).

PVC `storageClassName` is immutable, so we can't repurpose the existing PVC in place. The new pair is named `prowlarr-config-v2` (separate from the existing `prowlarr-config`).

## What's in this PR

- `k3s/applications/prowlarr/prowlarr-config-v2.yaml` (new) — static PV + PVC pair on `csi-hostpath-sc`, 2Gi, RWO
- `k3s/applications/prowlarr/migrate-job.yaml` (new, NOT in kustomization) — one-time `cp -a` Job, `ttlSecondsAfterFinished: 3600`, applied manually
- `k3s/applications/prowlarr/kustomization.yaml` — include the new PV/PVC file

The Deployment is intentionally NOT updated in this PR. See the runbook below.

## Files in the runbook (not in kustomization.yaml)

`migrate-job.yaml` is referenced by the runbook and lives in the same directory but is excluded from the kustomization so Flux doesn't auto-apply it.

## Runbook (after merge)

```bash
# 1. Wait for Flux to apply the new PV/PVC
kubectl -n media get pvc prowlarr-config-v2 -o jsonpath='{.status.phase}'  # expect Bound

# 2. Scale prowlarr to 0 (releases the old PVC)
kubectl -n media scale deploy prowlarr --replicas=0
kubectl -n media wait pod -l app=prowlarr --for=delete --timeout=120s

# 3. Apply the migration Job manually
kubectl apply -f k3s/applications/prowlarr/migrate-job.yaml
kubectl -n media wait job prowlarr-config-migrate --for=condition=complete --timeout=120s

# 4. Verify data in the new PVC
kubectl -n media debug -it --image=alpine:3.20 --target=ignored -- ls -la /host/var/lib/csi-hostpath-data/prowlarr-config-v2-vol/prowlarr/prowlarr.db

# 5. Scale prowlarr back to 1 with the OLD PVC (Deployment not yet updated)
kubectl -n media scale deploy prowlarr --replicas=1
kubectl -n media wait deploy prowlarr --for=condition=available --timeout=120s

# 6. Verify prowlarr started clean with the old data (sanity check)
kubectl -n media get pods -l app=prowlarr -o jsonpath='{.items[0].status.phase}'
```

## Followup

After the runbook completes and prowlarr is verified healthy on the old PVC, PR B will:
- Flip the Deployment to `claimName: prowlarr-config-v2`
- Delete the old PVC + auto-generated PV
- Remove the legacy `pvc.yaml` from the kustomization
- Add the kopiur SnapshotPolicy + SnapshotSchedule + `media` kopiur-repo PVC