### PR TITLE
k3s: actually drop CPU limits on Flux controllers

### DIFF
--- a/k3s/clusters/homelab/flux-system-components/kustomization.yaml
+++ b/k3s/clusters/homelab/flux-system-components/kustomization.yaml
@@ -14,6 +14,51 @@ resources:
 patches:
   - path: patches/remove-unused.yaml
   - path: patches/resource-patch.yaml
+  # Drop the CPU limit on each of the 6 Flux controllers (followup to
+  # PR #283). resource-patch.yaml's `cpu: null` is a no-op in SMP, so
+  # we apply a JSON 6902 op: remove. The same ops file is referenced
+  # 6 times with a different Deployment target per entry — kustomize's
+  # JSON 6902 transformer requires target at the kustomization entry
+  # level, not per-op in the file. P95 values from krr v1.28.0
+  # (2026-08-12) — see patches/resource-patch.yaml for the request
+  # side. Single-node testbed: CPU throttling hurts reconciliation
+  # latency more than it helps.
+  - path: patches/drop-cpu-limit.json
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: helm-controller
+  - path: patches/drop-cpu-limit.json
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: image-automation-controller
+  - path: patches/drop-cpu-limit.json
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: image-reflector-controller
+  - path: patches/drop-cpu-limit.json
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kustomize-controller
+  - path: patches/drop-cpu-limit.json
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: notification-controller
+  - path: patches/drop-cpu-limit.json
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: source-controller
   # source-watcher subject removal from crd-controller. kustomize's
   # strategic-merge $patch: delete does not honor the multi-key merge
   # identifier for subjects (kind+name+namespace), so this uses an

--- a/k3s/clusters/homelab/flux-system-components/patches/drop-cpu-limit.json
+++ b/k3s/clusters/homelab/flux-system-components/patches/drop-cpu-limit.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/containers/0/resources/limits/cpu"
+  }
+]

--- a/k3s/clusters/homelab/flux-system-components/patches/resource-patch.yaml
+++ b/k3s/clusters/homelab/flux-system-components/patches/resource-patch.yaml
@@ -24,7 +24,7 @@ spec:
               cpu: 15m
               memory: 162Mi
             limits:
-              cpu: null
+              # CPU limit removed via drop-cpu-limit.yaml (JSON 6902 patch — SMP null is a no-op)
               memory: 162Mi
 ---
 apiVersion: apps/v1
@@ -42,7 +42,7 @@ spec:
               cpu: 10m
               memory: 100Mi
             limits:
-              cpu: null
+              # CPU limit removed via drop-cpu-limit.yaml (JSON 6902 patch — SMP null is a no-op)
               memory: 100Mi
 ---
 apiVersion: apps/v1
@@ -60,7 +60,7 @@ spec:
               cpu: 16m
               memory: 100Mi
             limits:
-              cpu: null
+              # CPU limit removed via drop-cpu-limit.yaml (JSON 6902 patch — SMP null is a no-op)
               memory: 100Mi
 ---
 apiVersion: apps/v1
@@ -78,7 +78,7 @@ spec:
               cpu: 21m
               memory: 178Mi
             limits:
-              cpu: null
+              # CPU limit removed via drop-cpu-limit.yaml (JSON 6902 patch — SMP null is a no-op)
               memory: 178Mi
 ---
 apiVersion: apps/v1
@@ -96,7 +96,7 @@ spec:
               cpu: 10m
               memory: 100Mi
             limits:
-              cpu: null
+              # CPU limit removed via drop-cpu-limit.yaml (JSON 6902 patch — SMP null is a no-op)
               memory: 100Mi
 ---
 apiVersion: apps/v1
@@ -114,5 +114,5 @@ spec:
               cpu: 44m
               memory: 195Mi
             limits:
-              cpu: null
+              # CPU limit removed via drop-cpu-limit.yaml (JSON 6902 patch — SMP null is a no-op)
               memory: 195Mi


### PR DESCRIPTION
## Problem

PR #283 right-sized all 6 Flux controllers to krr P95 (memory limits + CPU requests). It tried to drop the 1.0 CPU limit (krr WARNING — single-node testbed, throttling hurts reconciliation latency) by setting `cpu: null` in a strategic-merge patch. Kustomize SMP does **not** honor `null` as "clear this field" — the 1.0 CPU limit stayed in place on every controller.

Verified live state pre-fix (orchestrator pre-flight):
```
helm-controller/manager:           lim={'cpu': '1', 'memory': '162Mi'}
image-automation-controller/manager: lim={'cpu': '1', 'memory': '100Mi'}
image-reflector-controller/manager:  lim={'cpu': '1', 'memory': '100Mi'}
kustomize-controller/manager:       lim={'cpu': '1', 'memory': '178Mi'}
notification-controller/manager:     lim={'cpu': '1', 'memory': '100Mi'}
source-controller/manager:          lim={'cpu': '1', 'memory': '195Mi'}
```

Note: locally with `kustomize build` v5.7.1 the SMP `cpu: null` *does* remove the CPU limit (the chart's `cpu: 1000m` is gone). But the testbed's kustomize-controller v1.8.5 (which embeds an older kustomize) does not honor it. The JSON 6902 patch in this PR removes the CPU limit explicitly with `op: remove`, which works regardless of the embedded kustomize version.

## Fix

New file `k3s/clusters/homelab/flux-system-components/patches/drop-cpu-limit.json` — a standard JSON 6902 patch (`op: remove`) targeting `/spec/template/spec/containers/0/resources/limits/cpu`. The patch is referenced from `kustomization.yaml` six times, once per controller, with a different Deployment target per entry. (kustomize's `PatchTransformerPlugin.transformJson6902` requires target at the kustomization entry level, not per-op in the file — verified against kustomize v5.7.1 source. Per-op `target:` fields in the file would be silently ignored by the JSON 6902 parser.)

The existing `resource-patch.yaml` keeps setting memory limits and CPU requests but no longer carries the misleading `cpu: null` line; a comment in each per-controller `limits:` block points to the JSON 6902 patch.

The `.json` extension (not `.yaml`) is deliberate: `kustomize cfg grep` (which flux-local invokes) only walks YAML files and rejects SequenceNode patches with `wrong node kind: expected MappingNode but got SequenceNode`. JSON 6902 patches are inherently sequences (RFC 6902), so naming the file `*.json` keeps flux-local's `kustomize cfg grep` happy while kustomize's patch transformer accepts it just fine.

## Validation

- `yamllint -c .yamllint.yaml k3s/clusters/homelab` — exit 0
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 7 passed
- `flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/master` — exit 0 (build output unchanged from origin/master locally because SMP `cpu: null` works in kustomize 5.7.1; the diff becomes a real change on the testbed where the embedded kustomize does not honor null)
- `kustomize build k3s/clusters/homelab/flux-system-components/` — confirmed `resources.limits.cpu` is ABSENT from every controller's manager container

## Risk

Bounded. Same shape as PR #283: the kustomize-controller restarts once when applying the change to itself, then steady state. The other 5 controllers roll over their pods normally.