### PR TITLE
k3s: suspend flux-system-components and move namespace/quota to platform (Phase 2A)

### DIFF
--- a/k3s/clusters/homelab/flux-system-components.yaml
+++ b/k3s/clusters/homelab/flux-system-components.yaml
@@ -28,6 +28,26 @@ metadata:
   name: flux-system-components
   namespace: flux-system
 spec:
+  # PHASE 2A — quiesced ahead of the manual Helm takeover.
+  #
+  # suspend: stops new reconciliations so this Kustomization cannot fight
+  # the flux2 HelmRelease over the same 6 controller Deployments during
+  # (or after) the manual `helm upgrade --install --take-ownership`.
+  #
+  # deletionPolicy: Orphan — prevents the eventual Phase 3 deletion of this
+  # Kustomization from taking the controllers with it. By then those objects
+  # are Helm-owned, but they are still in THIS Kustomization's inventory.
+  # The default is MirrorPrune, which "mirrors the Prune field (orphan if
+  # false, delete if true)" — and prune is true below, so the default would
+  # garbage-collect every inventory entry at Phase 3, including the
+  # Helm-owned Deployments, the CRDs and the RBAC. Orphan leaves the whole
+  # inventory in place and simply drops the bookkeeping.
+  #
+  # force and prune are deliberately unchanged: while suspended neither has
+  # any effect, and leaving them lets Phase 3 be a pure deletion with no
+  # further edits to this file.
+  suspend: true
+  deletionPolicy: Orphan
   force: true
   dependsOn:
     - name: flux-system

--- a/k3s/platform/namespaces/flux-system.yaml
+++ b/k3s/platform/namespaces/flux-system.yaml
@@ -1,0 +1,66 @@
+---
+# k3s/platform/namespaces/flux-system.yaml
+#
+# Durable home for Namespace/flux-system and its critical-pods
+# ResourceQuota. Both objects originate from `flux bootstrap` output and
+# today live in the flux-system-components Kustomization's inventory. That
+# Kustomization is suspended (Phase 2A) and deleted in Phase 3, so the two
+# objects need an owner that outlives it — otherwise Phase 3 would leave
+# them unmanaged, and a future `flux bootstrap` would be the only thing
+# recreating them.
+#
+# The flux2 Helm chart does NOT ship either object: `helm upgrade --install
+# --namespace flux-system` expects the namespace to already exist, and the
+# chart has no ResourceQuota template. Hence the platform layer, which is
+# the first Kustomization in the reconciliation graph.
+#
+# Labels and spec are copied verbatim from
+# k3s/clusters/homelab/flux-system-components/gotk-components.yaml so that
+# adopting these objects into the platform Kustomization is a no-op against
+# the running cluster.
+#
+# NOTE — duplication is intentional and temporary. Until Phase 3 removes
+# the legacy Kustomization, both this file and gotk-components.yaml declare
+# these objects. There is no conflict: flux-system-components is suspended,
+# so only the platform Kustomization is actively reconciling them.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+  labels:
+    app.kubernetes.io/instance: flux-system
+    app.kubernetes.io/part-of: flux
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  annotations:
+    # Excluded from garbage collection on purpose.
+    #
+    # The platform Kustomization runs with `prune: true`. Without this
+    # annotation, dropping flux-system.yaml from namespaces/kustomization.yaml
+    # — a one-line mistake — would make Flux delete its own namespace and
+    # cascade-delete every controller, Secret and CRD instance inside it.
+    # That is unrecoverable without a re-bootstrap.
+    #
+    # `kustomize.toolkit.fluxcd.io/prune: disabled` tells kustomize-controller
+    # to keep applying this object but never garbage-collect it. No effect on
+    # the Namespace itself.
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: critical-pods
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/instance: flux-system
+    app.kubernetes.io/part-of: flux
+spec:
+  hard:
+    pods: '1000'
+  scopeSelector:
+    matchExpressions:
+      - operator: In
+        scopeName: PriorityClass
+        values:
+          - system-node-critical
+          - system-cluster-critical

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - telemetry.yaml
   - gatus.yaml
   - kopiur-system.yaml
+  - flux-system.yaml


### PR DESCRIPTION
> **Stacked on #285.** Base is `feat/flux2-helm-chart`, not `master`. Merge #285 first.

## Why this PR exists

Two things must happen *before* the manual Helm takeover described in #285's **Phase 2 manual gate**, and neither belongs in #285:

1. **The legacy `flux-system-components` Kustomization has to be quiesced.** It actively reconciles the 6 Flux controller Deployments today. If it is still running when `helm upgrade --install --take-ownership` lands, the two reconcilers fight over the same objects — Helm sets the chart's pod template, the kustomize-controller reverts it to the bootstrap snapshot, repeat.

2. **`Namespace/flux-system` and `ResourceQuota/flux-system/critical-pods` need an owner that outlives Phase 3.** Both come from `flux bootstrap` output and today exist *only* in the legacy Kustomization's inventory. The flux2 chart ships neither — `helm --namespace flux-system` expects the namespace to already exist, and the chart has no ResourceQuota template. Delete the legacy Kustomization in Phase 3 without moving them first and they become unmanaged, recreated only by a future `flux bootstrap`.

## `deletionPolicy: Orphan` — the real blocker

`suspend: true` on its own is **not sufficient**, and this is the subtle part.

Suspending stops *reconciliation*. It does not empty the **inventory**. The 6 Deployments, the CRDs, the RBAC, the Services all remain recorded as belonging to `flux-system-components`. By the time Phase 3 deletes that Kustomization CR, those same objects are Helm-owned and live — but Flux still thinks it owns them.

What happens on deletion is decided by `spec.deletionPolicy`. Enum verified against the live `kustomizations.kustomize.toolkit.fluxcd.io` CRD:

| value | behaviour on Kustomization deletion | outcome here |
|---|---|---|
| `MirrorPrune` *(default)* | "mirrors the Prune field (orphan if false, delete if true)" | **`prune: true` here → deletes the entire inventory**, i.e. the live Helm-owned control plane |
| `Delete` | always garbage-collect the inventory | same catastrophe, unconditionally |
| `WaitForTermination` | delete, then block until objects are gone | same, but slower |
| `Orphan` | drop the inventory bookkeeping, leave every object in place | ✅ what we want |

So `deletionPolicy: Orphan` is what makes Phase 3 survivable. Without it, Phase 3 is an outage.

`force: true` and `prune: true` are deliberately left untouched — both are inert while suspended, and leaving them means Phase 3 is a pure `kubectl delete` with no further edits to this file.

## The namespace/quota manifest

New file `k3s/platform/namespaces/flux-system.yaml` (comments trimmed here for readability):

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: flux-system
  labels:
    app.kubernetes.io/instance: flux-system
    app.kubernetes.io/part-of: flux
    pod-security.kubernetes.io/warn: restricted
    pod-security.kubernetes.io/warn-version: latest
  annotations:
    kustomize.toolkit.fluxcd.io/prune: disabled
---
apiVersion: v1
kind: ResourceQuota
metadata:
  name: critical-pods
  namespace: flux-system
  labels:
    app.kubernetes.io/instance: flux-system
    app.kubernetes.io/part-of: flux
spec:
  hard:
    pods: '1000'
  scopeSelector:
    matchExpressions:
      - operator: In
        scopeName: PriorityClass
        values:
          - system-node-critical
          - system-cluster-critical
```

Labels and spec are copied verbatim from `flux-system-components/gotk-components.yaml` and **verified field-for-field equal** by a scripted comparison, so the object bodies do not change.

### Two deliberate deltas, called out

**1. Ownership labels flip.** This is not a pure no-op. Flux stamps every managed object with its owning Kustomization, so both objects go from:

```
kustomize.toolkit.fluxcd.io/name: flux-system-components
```

to:

```
kustomize.toolkit.fluxcd.io/name: platform
```

That flip *is* the handover. Since `flux-system-components` is suspended, only `platform` reconciles them and there is no contention.

**2. `kustomize.toolkit.fluxcd.io/prune: disabled` on the Namespace — added beyond the original plan.** The `platform` Kustomization runs with `prune: true`. Moving `flux-system` into it means that dropping `flux-system.yaml` from `namespaces/kustomization.yaml` — a plausible one-line mistake — would make Flux **delete its own namespace** and cascade-delete every controller, Secret and CRD instance inside it. Unrecoverable without a re-bootstrap. The annotation tells kustomize-controller to keep applying the object but never garbage-collect it. No functional effect on the Namespace.

## Intentional duplication

`gotk-components.yaml` is **not** edited in this PR. Until Phase 3, both it and `platform/namespaces/flux-system.yaml` declare these two objects.

This is safe because `flux-system-components` is suspended — only `platform` actively reconciles them. Verified: `kustomize build k3s/clusters/homelab/flux-system-components/` output is **byte-identical** to before this change (same 40 documents, same 6 controllers, still no `source-watcher`).

## Merge gate order

1. **This PR (2A)** — merge, then verify the controller pods are *unchanged*: `kubectl -n flux-system get pods` should show no restarts and no new image tags. This PR must be a no-op on the running control plane.
2. **Manual takeover** — follow #285 **Phase 2 manual gate** (suspend check → `flux migrate --dry-run` → CRD inventory check → digest-verified `helm upgrade --install --take-ownership` → `kubectl patch` for post-renderer parity → unsuspend the HelmRelease).
3. **PR #2B**
4. **24h hold** — leave everything suspended and watch.
5. **PR #3** — delete the legacy Kustomization CR and the `flux-system-components/` directory. Safe only because of `deletionPolicy: Orphan`.

## What is NOT in this PR

- ❌ Removing `Namespace/flux-system` / `ResourceQuota/critical-pods` from `gotk-components.yaml` (deferred to Phase 3 — the duplication above is intentional)
- ❌ Deleting the `source-watcher` CRD or the orphaned `artifactgenerators.source.extensions.fluxcd.io` CRD
- ❌ Deleting the `flux-system-components` Kustomization CR or its directory
- ❌ Any change to the 6 controller Deployments, the flux2 HelmRelease, or the chart values
- ❌ The manual takeover itself

## Risks

- **Duplication gap.** `gotk-components.yaml` and `platform/namespaces/flux-system.yaml` both declare the namespace and quota until Phase 3. Benign while the legacy Kustomization is suspended, but if anyone **unsuspends it** before Phase 3, two Kustomizations will contend for the same two objects and flap the ownership labels. Don't unsuspend it — Phase 3 deletes it.
- **A suspended Kustomization loses health gating.** `flux-system-components` will keep reporting its last-known `Ready` status; `wait: true` and `healthChecks` no longer run. It is no longer a signal for anything. Do not read it as "the controllers are healthy" — check `kubectl -n flux-system get deploy` directly during the takeover.
- **`platform` now owns the namespace containing Flux itself.** Mitigated by the `prune: disabled` annotation, but it does mean an error in `k3s/platform/` has a blast radius that now includes `flux-system`. The annotation blocks garbage collection; it does not block a bad *apply*.
- **Orphan is permanent-ish.** After Phase 3 the ex-inventory objects have no Flux owner at all until the HelmRelease adopts them. That window is exactly why the takeover (gate 2) precedes Phase 3.

## Validation

- ✅ `yamllint -c .yamllint.yaml k3s/clusters/homelab k3s/platform` — clean, exit 0
- ✅ Modified Kustomization CR **schema-validated field-by-field against the live CRD** — every field present, `deletionPolicy: Orphan` legal per the enum
- ✅ Namespace + ResourceQuota **verified field-for-field identical** to the `gotk-components.yaml` originals (modulo the documented `prune: disabled` annotation)
- ✅ `kustomize build k3s/clusters/homelab/flux-system-components/` — **byte-identical** to the same build on `origin/feat/flux2-helm-chart`
- ✅ `kustomize build k3s/platform/` — 18 objects, both new objects render as expected
- ✅ `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` — 7 passed
- ✅ `flux-local diff ks … --branch-orig origin/feat/flux2-helm-chart` — exactly 3 changes, **zero removals**:
  - `+ Namespace: flux-system/flux-system` under `Kustomization: flux-system/platform`
  - `+ ResourceQuota: flux-system/critical-pods` under `Kustomization: flux-system/platform`
  - `Kustomization: flux-system/flux-system-components` gains `+ deletionPolicy: Orphan` and `+ suspend: true`
