### PR TITLE
k3s: unsuspend flux2 HelmRelease (Phase 2B)

### DIFF
--- a/k3s/infrastructure/controllers/flux2/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/flux2/helmrelease.yaml
@@ -27,19 +27,6 @@ metadata:
   name: flux2
   namespace: flux-system
 spec:
-  # Suspended on merge — purely a scheduling gate, not a workaround.
-  #
-  # Helm *will* adopt the 6 existing controller Deployments cleanly:
-  # `install.disableTakeOwnership` defaults to false, so helm-controller
-  # (v1.5.4 here, field present in our CRD) takes ownership of existing
-  # resources during install and relabels them for the release. There is
-  # no ownership-conflict failure to work around.
-  #
-  # The suspend exists so that merging this PR does not immediately race
-  # the still-active `flux-system-components` Kustomization for those same
-  # Deployments. Phase 2 suspends that Kustomization first, performs the
-  # takeover, then unsuspends this HelmRelease.
-  suspend: true
   interval: 1h
   timeout: 10m
   chartRef:


### PR DESCRIPTION
## What this PR does

Removes the `suspend: true` flag from the `flux2` HelmRelease so Flux takes over the manually-installed release. Single-file change: `k3s/infrastructure/controllers/flux2/helmrelease.yaml` (−13 lines: the `suspend: true` line and the 12-line suspend-rationale comment block immediately above it). No other fields touched; `interval: 1h` is now the first non-comment key under `spec:`.

## Prerequisites

- **PR #286 merged**: the legacy `flux-system-components` Kustomization is suspended with `deletionPolicy: Orphan`, so no race for the 6 controller Deployments.
- **Manual gate from PR #285 runbook completed**: `helm upgrade --install flux2 ... --take-ownership --wait` ran successfully against the chart-rendered state.
- **All 6 Flux controllers are Ready on Flux 2.9.1**: helm-controller, source-controller, kustomize-controller, notification-controller, image-automation-controller, image-reflector-controller.
- **source-watcher RBAC subject removed**: either via the `postRenderers` kustomize patch on a previous reconcile (after the post-renderer gap is closed), or via the `kubectl patch --type=json` workaround documented in PR #285.

## Expected first reconcile

A Helm upgrade from the manual install's revision (Helm revision 1) to a Flux-managed revision (Helm revision 2). Identity match on **release name `flux2`** and **namespace `flux-system`** is what allows helm-controller to adopt the existing release rather than failing on a name collision. Expected to be a no-op — the release is already at the chart's rendered state, so all rendered resources should be byte-identical.

## Risks

- **Manual install render mismatch**: if any value in the chart's rendered output diverges from what the manual install produced (e.g. a defaulted field the manual install didn't set), the HelmRelease's first reconcile will trigger another rollout of the affected controller(s). Mitigated by the manual gate having run successfully — but any subsequent chart-render drift between manual install and HelmRelease take-over will surface here.
- **Reconcile failure**: if the manual install was somehow not at the chart's expected state (e.g. partial rollout, stuck Helm release secret), the HelmRelease may fail to reconcile and the controllers could flap. `upgrade.remediation.strategy: rollback` will roll back to revision 1, which is the manual install state, so the worst case is a brief flap then recovery.

## What is NOT in this PR

- **Deletion of the legacy `k3s/clusters/homelab/flux-system-components/` directory** — PR #3.
- **Deletion of the legacy `flux-system-components` Kustomization CR** — PR #3.
- **Deletion of the orphan `artifactgenerators.source.extensions.fluxcd.io` CRD** — PR #3 manual step (the chart 2.19.0 does not ship this CRD; it was carried over from `gotk-components.yaml`).

## Merge gate order

```
PR #286 (suspend legacy Kustomization)
    → manual gate (PR #285 runbook: helm upgrade --install --take-ownership)
    → THIS PR (unsuspend HelmRelease)
    → 24h hold (observe reconciliation stability)
    → PR #3 (delete legacy directory, Kustomization CR, orphan CRD)
```

## Validation

Run from this worktree:

```
yamllint -c .yamllint.yaml k3s/infrastructure
kustomize build k3s/infrastructure/controllers/flux2/
flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths
flux-local diff ks --path k3s/clusters/homelab --skip-invalid-kustomization-paths --branch-orig origin/feat/flux2-suspend-legacy
```

All passed. The diff shows only the removal of `suspend: true`; zero removals of values, zero drift on other kustomizations.