### PR TITLE
k3s: right-size csi-hostpath's kube-system neighbors per fresh krr

### DIFF
--- a/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
@@ -28,12 +28,35 @@ spec:
     extraEnv:
       - name: DCGM_EXPORTER_COLLECTORS
         value: /etc/dcgm-exporter/default-counters.csv
+    # Chart default (100m/128Mi request, 200m/512Mi limit) predates the
+    # krr sweeps in #150/#170. Fresh krr (2026-08-13, post-#284) shows real
+    # P95 memory usage at ~539Mi — above the chart's default 128Mi request,
+    # meaning the pod has been scheduled without enough headroom for its
+    # actual usage. Bumped memory request/limit to the krr recommendation
+    # (539Mi, rounded to 540Mi); CPU request lowered to krr's 14m (rounded
+    # to 15m; the chart's 100m default was over-provisioned).
+    resources:
+      requests:
+        cpu: 15m
+        memory: 540Mi
+      limits:
+        memory: 540Mi
 
   # Add a startupProbe and drop the chart's defensive 45s initialDelaySeconds
   # via Kustomize post-render. The dcgm-exporter chart doesn't expose
   # startupProbe as a value. Real startup is ~1s; the chart's 45s buffer made
   # pods appear NotReady for 45+ seconds even though `/health` answered
   # immediately.
+  #
+  # The trailing `remove` op drops the chart's hardcoded 200m CPU limit —
+  # krr recommends no CPU limit here, matching this repo's general policy
+  # (see #284). Verified empirically (helm template + kustomize build) that
+  # a values-only override CANNOT remove this: the chart sets
+  # `resources.limits.cpu: 200m` as a literal default, and Helm's values
+  # merge keeps unspecified nested keys from the chart default rather than
+  # dropping them — the same class of bug #284 hit with Kustomize SMP, just
+  # on the Helm side instead. A JSON 6902 remove op on the rendered manifest
+  # is the only way to actually clear it.
   postRenderers:
     - kustomize:
         patches:
@@ -57,3 +80,5 @@ spec:
                   periodSeconds: 5
                   failureThreshold: 12
                   timeoutSeconds: 2
+              - op: remove
+                path: /spec/template/spec/containers/0/resources/limits/cpu

--- a/k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/node-feature-discovery/helmrelease.yaml
@@ -35,6 +35,17 @@ spec:
             # uses for its default node affinity.
             deviceLabelFields:
               - vendor
+      # #170 right-sized master/gc but missed worker — it was still running on
+      # the chart's own default (5m/64Mi request, 512Mi memory limit, no CPU
+      # limit). Fresh krr (2026-08-13, post-#284) shows real usage close to
+      # the 10m/100Mi floor; the 512Mi limit was ~5x oversized. Pinned to the
+      # krr recommendation, same pattern as master/gc below.
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi
     # Resource tuning (2026-06-02 krr recommendations): drop memory limits,
     # set requests to observed P95 usage. The chart default has no CPU limit
     # and unbounded memory; this pins memory to the krr recommendation.

--- a/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/nvidia-device-plugin/helmrelease.yaml
@@ -40,3 +40,16 @@ spec:
               resources:
                 - name: nvidia.com/gpu
                   replicas: 2
+    # Chart default is `resources: {}` (unbounded) — krr (2026-08-13, post-#284)
+    # flagged this as WARNING with no request/limit data at all. Pinned to the
+    # krr floor recommendation (10m/100Mi); no CPU limit. Only bounds the
+    # `nvidia-device-plugin-ctr` container — the chart's `-sidecar` init-style
+    # container (config copy step) has no resources templating at all and stays
+    # unbounded regardless of this value; that's a chart limitation, not
+    # something fixable from values.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+      limits:
+        memory: 100Mi

--- a/k3s/infrastructure/controllers/snapshot-controller/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/snapshot-controller/helmrelease.yaml
@@ -37,6 +37,16 @@ spec:
       # Safe on single-node K3s testbed; leader-election is on by default upstream
       # but a single replica is fine.
       replicaCount: 1
+      # Chart default is `resources: {}` (unbounded) — krr (2026-08-13, post-#284)
+      # flagged this as WARNING with no request/limit data at all. Pinned to the
+      # krr floor recommendation (10m/100Mi); no CPU limit, matching this repo's
+      # general policy of not throttling controller CPU.
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi
     # Disable the validation webhook to skip the cert-manager dependency.
     # Single-node homelab; v1beta1/v1beta2 VolumeGroupSnapshot objects aren't
     # in play, so we don't need webhook-side validation.


### PR DESCRIPTION
## Summary

`snapshot-controller`, `nvidia-device-plugin`, and `csi-hostpath` all run in `kube-system`, which krr excludes by default unless namespaces are passed explicitly — so none of them were covered by the earlier krr sweeps (#150, #170). Ran krr v1.28.0 against the live testbed cluster with `kube-system` explicitly included and applied its recommendations where the chart actually allows it.

- **`snapshot-controller`**: chart default is `resources: {}` (fully unbounded, WARNING). Pinned to krr's floor recommendation (10m/100Mi), no CPU limit.
- **`nvidia-device-plugin`**: same — `resources: {}` unbounded, WARNING. Pinned to the same floor. Only bounds the `-ctr` container; the chart's `-sidecar` container has no resources templating in its template at all (verified against the rendered manifest), so it stays unbounded regardless of any value — a chart limitation, not something fixable from `values:`.
- **`dcgm-exporter`**: not unbounded, but under-provisioned — chart default memory request (128Mi) sits well below real P95 usage (~539Mi per krr). Bumped request/limit to 540Mi. Also drops the chart's hardcoded 200m CPU limit via the existing `postRenderers` JSON 6902 patch — verified with `helm template` + `kustomize build` that a values-only override *cannot* remove it (Helm's merge keeps the chart's nested default key, same class of bug as the Kustomize SMP issue in #284, just on the Helm side).
- **`node-feature-discovery` worker**: #170 right-sized `master`/`gc` but missed `worker`, which was still running on the chart default (512Mi memory limit — ~5x oversized vs real usage). Brought in line with `master`/`gc`.

**Not touched:**
- `csi-hostpath` — the `csi-hostpathplugin` chart (v1.17.1) exposes no `resources` field anywhere in its values schema for any of its 8 containers (confirmed via `helm show values`). Bounding it needs either a Kustomize postRenderer patch per container or an upstream chart change — left as a follow-up.
- `csi-driver-smb` — krr scores every container GOOD against its existing chart defaults; nothing to fix.

## Test plan

- [x] `yamllint -c .yamllint.yaml` clean on all four changed files
- [x] `helm template` against the pinned chart version + this repo's actual committed values for all four (confirms the resources land where intended, including confirming the `nvidia-device-plugin-sidecar` container gap)
- [x] `kustomize build` against the rendered `dcgm-exporter` DaemonSet confirms the new JSON 6902 `remove` op actually clears `resources.limits.cpu` alongside the existing probe patches
- [ ] Flux reconciles cleanly on the testbed cluster (`kubectl get hr -n flux-system`)
- [ ] Re-run krr after rollout to confirm the four workloads move off WARNING

🤖 Generated with [Claude Code](https://claude.com/claude-code)