### PR TITLE
gatus: expand monitoring to cover all HTTP-exposed services

### DIFF
--- a/k3s/applications/gatus/config.yaml
+++ b/k3s/applications/gatus/config.yaml
@@ -71,6 +71,47 @@ data:
         conditions:
           - "[STATUS] < 400"
 
+      - name: prowlarr
+        group: media
+        # /ping is the *arr-stack health endpoint; returns "OK" with no auth.
+        url: https://prowlarr.homelab.properties/ping
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      - name: radarr
+        group: media
+        url: https://radarr.homelab.properties/ping
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      - name: sonarr
+        group: media
+        url: https://sonarr.homelab.properties/ping
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      - name: sabnzbd
+        group: media
+        # The root path returns 200 with a redirect to /sabnzbd/. The API
+        # at /api?mode=version returns JSON but requires the API key, so
+        # the unauthenticated root check matches what we have for tdarr.
+        url: https://sabnzbd.homelab.properties/
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      - name: qbittorrent
+        group: media
+        # qBittorrent's root returns the login page (302 -> /login.html).
+        # Accept anything sub-400, matching the tdarr pattern.
+        url: https://qbittorrent.homelab.properties/
+        interval: 60s
+        conditions:
+          - "[STATUS] < 400"
+
       # monitoring group
       - name: grafana
         group: monitoring
@@ -83,6 +124,16 @@ data:
       - name: prometheus
         group: monitoring
         url: https://prometheus.homelab.properties/-/healthy
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+
+      - name: alertmanager
+        group: monitoring
+        # /-/healthy is the unauthenticated liveness endpoint. If this
+        # fails, the alerting pipeline is down — which is exactly when
+        # you most need to know.
+        url: https://alertmanager.homelab.properties/-/healthy
         interval: 60s
         conditions:
           - "[STATUS] == 200"


### PR DESCRIPTION
## Summary

Bring every HTTP-exposed service in the cluster under gatus's watch.

| Group | Before | After | Added |
|---|---|---|---|
| media | tdarr | tdarr + 5 | prowlarr, radarr, sonarr, sabnzbd, qbittorrent |
| monitoring | grafana, prometheus | + alertmanager | alertmanager |
| **Total** | **7 endpoints** | **13 endpoints** | **+6** |

## Why alertmanager?

`/-/healthy` is the unauthenticated liveness endpoint. If this fails, the alerting pipeline itself is down — which is exactly when you most need to know.

## Why these and not others?

Skipped on purpose:
- **sense-exporter, unpoller** — Prometheus exporters with no user-facing UI. Already covered by their `ServiceMonitor`s; if they go down, Alertmanager fires (and we now monitor Alertmanager itself).
- **recyclarr** — `CronJob`, no HTTP endpoint to probe.
- **Control-plane services** (cert-manager, metallb, flux, csi-*, snapshot-controller, nfd, nvidia-device-plugin, dcgm-exporter) — no HTTP health endpoints; covered by kube-prometheus-stack.

## Endpoint notes

- `*arr /ping` is the documented health endpoint; returns `"OK"` with no auth. If any instance is hardened to require auth, the check will need to switch to authenticated `/api/v3/health`.
- `sabnzbd` and `qbittorrent` run behind gluetun/NordVPN, so their ingress relies on the VPN tunnel. If NordVPN drops, both fail Gatus checks (good — matches existing tdarr pattern).
- `alertmanager` uses the standard `/-/healthy` endpoint that Prometheus itself uses.

## Verification

- `yamllint -c .yamllint.yaml k3s/applications/gatus/` → exit 0
- CI will run `flux-local diff ks` post-merge; the only change is the ConfigMap body (Flux `interval: 1h` on the HelmRelease means the new endpoints will go live within an hour of merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)