### PR TITLE
feat(kopiur): onboard radarr-config and sonarr-config to backup coverage

### DIFF
--- a/k3s/applications/radarr/pvc.yaml
+++ b/k3s/applications/radarr/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: csi-hostpath-sc
   resources:
     requests:
       storage: 2Gi

--- a/k3s/applications/sonarr/pvc.yaml
+++ b/k3s/applications/sonarr/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: csi-hostpath-sc
   resources:
     requests:
       storage: 2Gi

--- a/k3s/infrastructure/configs/kopiur-policies/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/kustomization.yaml
@@ -21,3 +21,7 @@ resources:
   - snapshotschedule-gatus.yaml
   - snapshotpolicy-prowlarr.yaml
   - snapshotschedule-prowlarr.yaml
+  - snapshotpolicy-radarr.yaml
+  - snapshotschedule-radarr.yaml
+  - snapshotpolicy-sonarr.yaml
+  - snapshotschedule-sonarr.yaml

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-radarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-radarr.yaml
@@ -1,0 +1,43 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-radarr.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: radarr-config
+      sourcePathOverride: /config
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  credentialProjection:
+    enabled: true
+  mover:
+    # LinuxServer radarr image runs as abc (PUID=1027, PGID=100); matches
+    # prowlarr since both apps share the same LinuxServer base.
+    securityContext:
+      runAsUser: 1027
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sonarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sonarr.yaml
@@ -1,0 +1,43 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sonarr.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: sonarr-config
+      sourcePathOverride: /config
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  credentialProjection:
+    enabled: true
+  mover:
+    # LinuxServer sonarr image runs as abc (PUID=1027, PGID=100); matches
+    # prowlarr/radarr since all three share the same LinuxServer base.
+    securityContext:
+      runAsUser: 1027
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-radarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-radarr.yaml
@@ -1,0 +1,13 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotschedule-radarr.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: radarr-scheduled
+  namespace: media
+spec:
+  policyRef:
+    name: radarr
+  schedule:
+    cron: "H * * * *"
+    runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sonarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sonarr.yaml
@@ -1,0 +1,13 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sonarr.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: sonarr-scheduled
+  namespace: media
+spec:
+  policyRef:
+    name: sonarr
+  schedule:
+    cron: "H * * * *"
+    runOnCreate: false


### PR DESCRIPTION
## Summary

Onboards `radarr-config` and `sonarr-config` to kopiur backups using the same recipe as prowlarr (PR #293). Three commits:

1. **radarr-config**: migrate `local-path` → `csi-hostpath-sc` (PVC name kept stable)
2. **sonarr-config**: same migration
3. **SnapshotPolicy + SnapshotSchedule** for both, registered in the existing `kopiur-policies` Kustomization

## Why

`csi-hostpath-snapclass` only binds to `csi-hostpath-sc` PVCs. Both `radarr-config` and `sonarr-config` were on `local-path` (same as prowlarr pre-migration).

## Recipe (already validated by PR #293)

- Both apps: LinuxServer base image, PUID=1027, PGID=100, mountPath=`/config`
- Mover `securityContext.runAsUser=1027, runAsGroup=100`, `podSecurityContext.fsGroup=100`
- Two-step rsync during cutover (~100s downtime each, same as prowlarr)
- No new `kopiur-repo` PV/PVC needed — `kopiur-repo-media` from PR #293 covers the namespace

## Disruption

Observed downtime: **~100s each** for radarr (02:14:50 → 02:23:25 UTC window) and sonarr (02:20:32 → 02:23:25 UTC window). The actual `Recreate`-strategy pod restart itself is sub-second; most of the window is the rsync data copy and Bound wait.

## Validation (will update after first snapshots fire)

- [ ] radarr first scheduled snapshot at 03:00 UTC reaches `Succeeded`
- [ ] sonarr first scheduled snapshot at 03:18 UTC reaches `Succeeded`

## Out of scope

- `tdarr-node-config` (1Gi local-path) and `tdarr-server-data` (10Gi local-path) — separate PR; tdarr deployment uses a different label structure (no `app.kubernetes.io/name=tdarr`) so needs separate discovery.
- `radarr-media`, `sonarr-media`, `tdarr-media` — already on `smb-media` (NAS is the backup; snapshotting 10Ti is wasteful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)