### PR TITLE
feat(kopiur): onboard pihole to backup coverage

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -81,13 +81,17 @@ spec:
       existingSecret: "pihole-admin-password"
       passwordKey: "password"
 
-    # -- PVC persistence: local-path, 1Gi, for /etc/pihole
+    # -- PVC persistence: csi-hostpath-sc, 1Gi, for /etc/pihole
+    # Changed from local-path → csi-hostpath-sc when pihole was onboarded
+    # to kopiur backups. Only csi-hostpath-sc PVCs can be snapshotted
+    # (csi-hostpath-snapclass is bound 1:1 to this storage class).
+    # Helm won't migrate the existing PVC; that's an imperative job.
     persistentVolumeClaim:
       enabled: true
       accessModes:
         - ReadWriteOnce
       size: "1Gi"
-      storageClass: "local-path"
+      storageClass: "csi-hostpath-sc"
 
     # -- Probes: initialDelaySeconds: 30 — FTL is up in ~5s, the chart's
     #    default is 60s. 30s leaves a small buffer for first-boot gravity DB

--- a/k3s/infrastructure/configs/kopiur-policies/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/kustomization.yaml
@@ -25,3 +25,5 @@ resources:
   - snapshotschedule-radarr.yaml
   - snapshotpolicy-sonarr.yaml
   - snapshotschedule-sonarr.yaml
+  - snapshotpolicy-pihole.yaml
+  - snapshotschedule-pihole.yaml

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
@@ -1,0 +1,44 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: pihole
+  namespace: pihole
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: pihole
+      sourcePathOverride: /etc/pihole
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  credentialProjection:
+    enabled: true
+  mover:
+    # Official pihole/pihole image runs as `pihole` user (UID 1000 GID 1000).
+    # The pod drops to that user for FTL operations; the data on disk is
+    # owned by pihole:pihole.
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    podSecurityContext:
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-pihole.yaml
@@ -1,0 +1,13 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotschedule-pihole.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: pihole-scheduled
+  namespace: pihole
+spec:
+  policyRef:
+    name: pihole
+  schedule:
+    cron: "H * * * *"
+    runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - pv-headlamp.yaml
   - pv-gatus.yaml
   - pv-media.yaml
+  - pv-pihole.yaml
   - clusterrepository.yaml
   - job-cleanup-rbac.yaml
   - job-cleanup-cronjob.yaml

--- a/k3s/infrastructure/configs/kopiur/pv-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-pihole.yaml
@@ -1,0 +1,55 @@
+---
+# Repository storage for kopiur snapshot Jobs in the pihole namespace.
+# Static PV + PVC pair bound to the smb-media CSI provisioner. Mounts the
+# dedicated backup SMB sub-share \\MemoryAlpha\backups\ (separate from
+# \\MemoryAlpha\data\ used by the media stack). Shares the SMB source with
+# pv-kopiur-system.yaml, pv-headlamp.yaml, pv-gatus.yaml, pv-media.yaml —
+# each namespace has its own mount = its own SMB session. Kopia's
+# content-addressable storage makes concurrent multi-mount writes safe
+# (different jobs write to different blob files).
+#
+# uid/gid=1000 matches the pihole user (UID 1000 GID 1000 in the official
+# pihole/pihole image) so the mover can read /etc/pihole on the source PVC.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kopiur-repo-pihole
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1000
+    - gid=1000
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: kopiur-repo-pihole-vol
+    volumeAttributes:
+      source: //192.168.1.20/backups
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-repo
+  namespace: pihole
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: kopiur-repo-pihole
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
## Summary

Onboards the `pihole` namespace to kopiur backups. Same recipe as PR #293 (prowlarr) and PR #294 (radarr/sonarr):

1. **Storage class migration**: pihole PVC (`local-path` → `csi-hostpath-sc`). The pihole chart owns its PVC, so the storageClassName in `helmrelease.yaml` values drives future PVCs; the existing one was migrated imperatively.
2. **Per-namespace kopiur-repo**: PV+PVC pair in `pihole` namespace, bound to the dedicated backup SMB sub-share. UID/GID 1000 to match the pihole user.
3. **SnapshotPolicy + SnapshotSchedule** for pihole, registered in the existing `kopiur-policies` Kustomization.

## Recipe (validated by PR #293, PR #294)

- Official `pihole/pihole` image runs as `pihole` user (UID 1000 GID 1000); data on `/etc/pihole` is owned by `pihole:pihole`.
- Mover `securityContext.runAsUser=1000, runAsGroup=1000`, `podSecurityContext.fsGroup=1000`.
- Two-step rsync during cutover (~100s downtime).
- `sourcePathOverride: /etc/pihole`.

## Disruption

Observed downtime: **~100s** (03:27:30 → 03:29:30 UTC). The actual `Recreate`-strategy pod restart itself is sub-second; most of the window is the rsync data copy and Bound wait.

## Validation (will update after first snapshot fires)

- [ ] pihole first scheduled snapshot at 03:35 UTC reaches `Succeeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)