### PR TITLE
fix(kopiur): enable privileged mover for pihole

### DIFF
--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
@@ -29,15 +29,25 @@ spec:
   credentialProjection:
     enabled: true
   mover:
-    # Official pihole/pihole image runs as `pihole` user (UID 1000 GID 1000).
-    # The pod drops to that user for FTL operations; the data on disk is
-    # owned by pihole:pihole.
+    # Pihole's official image starts as root and drops to the `pihole` user
+    # (UID 1000 GID 1000), but the chart-init creates `/etc/pihole/logrotate`
+    # as `root:root` mode 0640 during startup, BEFORE the user drop. The
+    # pihole user cannot read it back. Snapshotting as UID 1000 fails with
+    # PermissionDenied on that single file, killing the whole backup.
+    #
+    # Run the mover as root for pihole specifically. Opt-in via:
+    #   kubectl annotate namespace pihole kopiur.home-operations.com/privileged-movers=true
+    # (see k3s/platform/namespaces/pihole.yaml).
+    # privilegedMode also preserves UID/GID on restore, which matters for
+    # the pihole-FTL.db / gravity.db files that pihole opens as pihole:pihole.
     securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
     podSecurityContext:
       fsGroup: 1000
       fsGroupChangePolicy: OnRootMismatch
+    privilegedMode: true
     cache:
       capacity: 1Gi
       storageClassName: local-path

--- a/k3s/platform/namespaces/pihole.yaml
+++ b/k3s/platform/namespaces/pihole.yaml
@@ -1,5 +1,14 @@
 ---
+# kopiur.home-operations.com/privileged-movers=true opts the namespace in
+# to kopiur's privileged-mover mode (gate enforced in the kopiur admission
+# webhook). Required for pihole because /etc/pihole/logrotate is owned
+# root:root mode 0640 — the chart-init creates it during startup before
+# the user drops to `pihole` (UID 1000), and the pihole user can't read
+# it back. Without this annotation, the kopiur snapshot wedges with
+# `PermissionDenied: open /etc/pihole/logrotate: permission denied`.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: pihole
+  annotations:
+    kopiur.home-operations.com/privileged-movers: "true"


### PR DESCRIPTION
## Summary

Fixes the pihole kopiur snapshot that failed at 03:35 UTC with `PermissionDenied: open /etc/pihole/logrotate: permission denied`.

The pihole chart-init creates `/etc/pihole/logrotate` as `root:root` mode 0640 during startup, **before** the chart drops to the `pihole` user (UID 1000). The kopiur mover Pod defaults to running as UID 1000 (matching the unprivileged user), so it can't read that one file — killing the whole backup.

## Fix

Two coupled changes:

1. **Namespace opt-in**: `k3s/platform/namespaces/pihole.yaml` adds the `kopiur.home-operations.com/privileged-movers=true` annotation. This is the namespace gate enforced by the kopiur admission webhook — without it, the controller rejects root mover pods.

2. **Policy override**: `snapshotpolicy-pihole.yaml.mover.securityContext` now runs as root (`runAsUser=0, runAsGroup=0, runAsNonRoot=false`) with `privilegedMode: true`. The `privilegedMode` flag also preserves UID/GID on restore, which matters for `pihole-FTL.db` and `gravity.db` opened as `pihole:pihole`.

## Validation

- The 03:35 snapshot failed: `PermissionDenied: open /etc/pihole/logrotate: permission denied`
- The 04:35 snapshot also failed for the same reason (Flux SSA had reverted my imperative patches because the fix wasn't on master yet)
- Once merged, Flux will reconcile the corrected policy + namespace annotation, and the next scheduled snapshot should succeed

## Diagnostic reference

Apps whose chart-init runs as root and creates files in the data dir with restrictive ownership before the user drop will need this same treatment. Signature in `kubectl get snapshot -n <ns>`:

```yaml
failure:
  kopiaErrorClass: PermissionDenied
  message: "...unable to open file: unable to open local file: open <path>: permission denied..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)