### PR TITLE
feat(kopiur): onboard qbittorrent and sabnzbd to backup coverage

### DIFF
--- a/k3s/applications/qbittorrent/pvc.yaml
+++ b/k3s/applications/qbittorrent/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: csi-hostpath-sc
   resources:
     requests:
       storage: 5Gi
@@ -19,7 +19,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: csi-hostpath-sc
   resources:
     requests:
       storage: 1Gi

--- a/k3s/applications/sabnzbd/pvc.yaml
+++ b/k3s/applications/sabnzbd/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: csi-hostpath-sc
   resources:
     requests:
       storage: 5Gi
@@ -32,7 +32,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: csi-hostpath-sc
   resources:
     requests:
       storage: 1Gi

--- a/k3s/infrastructure/configs/kopiur-policies/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/kustomization.yaml
@@ -27,3 +27,7 @@ resources:
   - snapshotschedule-sonarr.yaml
   - snapshotpolicy-pihole.yaml
   - snapshotschedule-pihole.yaml
+  - snapshotpolicy-qbittorrent.yaml
+  - snapshotschedule-qbittorrent.yaml
+  - snapshotpolicy-sabnzbd.yaml
+  - snapshotschedule-sabnzbd.yaml

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-qbittorrent.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-qbittorrent.yaml
@@ -1,0 +1,46 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-qbittorrent.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: qbittorrent
+  namespace: qbittorrent
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: qbittorrent-config
+      sourcePathOverride: /config
+    - pvc:
+        name: gluetun-config
+      sourcePathOverride: /gluetun
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  credentialProjection:
+    enabled: true
+  mover:
+    # LinuxServer qbittorrent image (PUID=1027, PGID=100); same recipe as
+    # prowlarr/radarr/sonarr.
+    securityContext:
+      runAsUser: 1027
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd.yaml
@@ -1,0 +1,46 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: sabnzbd
+  namespace: sabnzbd
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  sources:
+    - pvc:
+        name: sabnzbd-config
+      sourcePathOverride: /config
+    - pvc:
+        name: gluetun-config
+      sourcePathOverride: /gluetun
+  copyMethod: Snapshot
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 14
+    keepWeekly: 8
+    keepMonthly: 6
+  verification:
+    quick:
+      schedule:
+        cron: "H 3 * * *"
+  credentialProjection:
+    enabled: true
+  mover:
+    # LinuxServer sabnzbd image (PUID=1027, PGID=100); same recipe as
+    # prowlarr/radarr/sonarr/qbittorrent.
+    securityContext:
+      runAsUser: 1027
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent.yaml
@@ -1,0 +1,13 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: qbittorrent-scheduled
+  namespace: qbittorrent
+spec:
+  policyRef:
+    name: qbittorrent
+  schedule:
+    cron: "H * * * *"
+    runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd.yaml
@@ -1,0 +1,13 @@
+---
+# k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd.yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: sabnzbd-scheduled
+  namespace: sabnzbd
+spec:
+  policyRef:
+    name: sabnzbd
+  schedule:
+    cron: "H * * * *"
+    runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur/kustomization.yaml
+++ b/k3s/infrastructure/configs/kopiur/kustomization.yaml
@@ -22,6 +22,8 @@ resources:
   - pv-gatus.yaml
   - pv-media.yaml
   - pv-pihole.yaml
+  - pv-qbittorrent.yaml
+  - pv-sabnzbd.yaml
   - clusterrepository.yaml
   - job-cleanup-rbac.yaml
   - job-cleanup-cronjob.yaml

--- a/k3s/infrastructure/configs/kopiur/pv-qbittorrent.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-qbittorrent.yaml
@@ -1,0 +1,52 @@
+---
+# Repository storage for kopiur snapshot Jobs in the qbittorrent namespace.
+# Static PV + PVC pair bound to the smb-media CSI provisioner. Mounts the
+# dedicated backup SMB sub-share \\MemoryAlpha\backups\. Shares the SMB
+# source with all other kopiur-repo PVs — each namespace has its own mount
+# = its own SMB session.
+#
+# uid/gid=1027/100 matches the qbittorrent user's PUID/PGID in the
+# LinuxServer qbittorrent image so the mover can read /config.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kopiur-repo-qbittorrent
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: kopiur-repo-qbittorrent-vol
+    volumeAttributes:
+      source: //192.168.1.20/backups
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-repo
+  namespace: qbittorrent
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: kopiur-repo-qbittorrent
+  resources:
+    requests:
+      storage: 50Gi

--- a/k3s/infrastructure/configs/kopiur/pv-sabnzbd.yaml
+++ b/k3s/infrastructure/configs/kopiur/pv-sabnzbd.yaml
@@ -1,0 +1,52 @@
+---
+# Repository storage for kopiur snapshot Jobs in the sabnzbd namespace.
+# Static PV + PVC pair bound to the smb-media CSI provisioner. Mounts the
+# dedicated backup SMB sub-share \\MemoryAlpha\backups\. Shares the SMB
+# source with all other kopiur-repo PVs — each namespace has its own mount
+# = its own SMB session.
+#
+# uid/gid=1027/100 matches the sabnzbd user's PUID/PGID in the
+# LinuxServer sabnzbd image so the mover can read /config.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kopiur-repo-sabnzbd
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: smb-media
+  mountOptions:
+    - vers=3.0
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=1027
+    - gid=100
+    - noperm
+    - cache=strict
+    - noserverino
+  csi:
+    driver: smb.csi.k8s.io
+    readOnly: false
+    volumeHandle: kopiur-repo-sabnzbd-vol
+    volumeAttributes:
+      source: //192.168.1.20/backups
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: kube-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-repo
+  namespace: sabnzbd
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: smb-media
+  volumeName: kopiur-repo-sabnzbd
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
## Summary

Onboards `qbittorrent` and `sabnzbd` to kopiur backups, both following the established recipe from PR #293 (prowlarr) and PR #294 (radarr/sonarr).

## Changes

**qbittorrent namespace:**
- `gluetun-config` (1Gi) and `qbittorrent-config` (5Gi): local-path → csi-hostpath-sc
- `kopiur-repo-qbittorrent` PV + `kopiur-repo` PVC in `qbittorrent` namespace
- SnapshotPolicy + SnapshotSchedule for `qbittorrent`

**sabnzbd namespace:**
- `gluetun-config` (1Gi) and `sabnzbd-config` (5Gi): local-path → csi-hostpath-sc
- `kopiur-repo-sabnzbd` PV + `kopiur-repo` PVC in `sabnzbd` namespace
- SnapshotPolicy + SnapshotSchedule for `sabnzbd`

## Why both PVCs per namespace

Both apps run inside `gluetun` (VPN) containers that share a network namespace. `gluetun-config` holds the VPN authentication state (openvpn/wireguard credentials, server selection state, port forwarding status). Backing it up alongside the app config means we don't have to re-authenticate VPN after a restore.

## Recipe (validated by PR #293, PR #294)

- LinuxServer base images: `lscr.io/linuxserver/qbittorrent:5.2.3`, `lscr.io/linuxserver/sabnzbd:5.0.4`
- PUID=1027, PGID=100 (matches LinuxServer convention)
- mountPaths: `/config` (app), `/gluetun` (VPN state)
- Mover securityContext: `runAsUser=1027, runAsGroup=100, fsGroup=100`

## Disruption

- qbittorrent downtime: ~3 min (14:20:32 → 14:23:23 EDT), 7.1M gluetun + 18.7M app config
- sabnzbd downtime: ~1 min (14:27:36 → 14:28:50 EDT), 9.2M gluetun + 12.5G app config
- Pre-existing qbittorrent readiness issue (gluetun ICMP healthcheck vs HTTP probe mismatch — deployment predates this work) is unrelated to the migration

## Skipped

- `sabnzbd-downloads` (200Gi local-path) — too costly to migrate. The user's actual media library is on the SMB share which is already backed up via other paths.
- `qbittorrent-media` / `sabnzbd-media` — SMB share, NAS is the backup.

## Validation (will update after first snapshots fire)

- [ ] qbittorrent first scheduled snapshot reaches `Succeeded`
- [ ] sabnzbd first scheduled snapshot reaches `Succeeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)