### PR TITLE
feat(longhorn): install Longhorn CSI driver (no PVC migration)

### DIFF
--- a/k3s/bootstrap/ansible/AGENTS.md
+++ b/k3s/bootstrap/ansible/AGENTS.md
@@ -18,7 +18,7 @@ ansible/
 │   └── site.yml                       # Full entrypoint: runs all phases sequentially
 └── roles/
     ├── common/                        # apt upgrade, packages, timezone, UFW, passwordless sudo
-    ├── k3s-prereqs/                   # swap disable, kernel modules (br_netfilter, overlay), sysctl
+    ├── k3s-prereqs/                   # swap disable, kernel modules (br_netfilter, overlay), sysctl, open-iscsi (Longhorn)
     ├── k3s-server/                    # K3s install, config, kubeconfig fetch, token persistence
     ├── flux-bootstrap/                # Flux CLI, age key, sops-age Secret, GitHub bootstrap (first-time only)
     └── flux-upgrade/                  # Flux CLI install, CRD storedVersions migration, flux install
@@ -60,5 +60,5 @@ ansible all -i inventory/hosts.yml -m ping
 ## NOTES
 - **K3s config written**: `flannel-backend: vxlan`, `secrets-encryption: true`, `write-kubeconfig-mode: 0644`.
 - `common` role asserts that required vars (packages list, UFW rules) are non-empty before proceeding.
-- `k3s-prereqs` loads `br_netfilter` and `overlay` kernel modules + sets net.bridge sysctl.
+- `k3s-prereqs` loads `br_netfilter` and `overlay` kernel modules + sets net.bridge sysctl + installs/enables `open-iscsi` (required by the Longhorn CSI driver).
 - Testbed node (i7-4770k, 192.168.1.128) must be re-IP'd to 192.168.1.4x before joining the HA cluster.

--- a/k3s/bootstrap/ansible/roles/k3s-prereqs/tasks/main.yml
+++ b/k3s/bootstrap/ansible/roles/k3s-prereqs/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # roles/k3s-prereqs/tasks/main.yml
-# Kubernetes prerequisites: swap, kernel modules, sysctl, container runtime deps
+# Kubernetes prerequisites: swap, kernel modules, sysctl, container runtime deps, iSCSI
 
 - name: Check whether swap is currently enabled
   ansible.builtin.command: cat /proc/swaps
@@ -43,3 +43,14 @@
     reload: true
     state: present
   loop: "{{ k3s_sysctl_params | dict2items }}"
+
+- name: Install open-iscsi (required by the Longhorn CSI driver's engine pods)
+  ansible.builtin.apt:
+    name: open-iscsi
+    state: present
+
+- name: Ensure iscsid is running and enabled
+  ansible.builtin.systemd:
+    name: iscsid
+    state: started
+    enabled: true

--- a/k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass-longhorn.yaml
+++ b/k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass-longhorn.yaml
@@ -1,0 +1,22 @@
+---
+# VolumeSnapshotClass for the Longhorn CSI driver installed by
+# k3s/infrastructure/controllers/longhorn/. Unlike csi-hostpath, Longhorn
+# does not create this automatically — it's managed here so it sits
+# alongside the kopiur configs in the infra-configs layer, same as
+# csi-hostpath-snapclass.
+#
+# type: longhorn-snapshot takes an in-cluster, copy-on-write Longhorn
+# snapshot (fast, node-local) rather than pushing to a configured Longhorn
+# backup target — kopiur's mover Pods handle moving data off-cluster, so
+# there's no need for Longhorn's own backup-target push here.
+#
+# Deliberately NOT setting snapshot.storage.kubernetes.io/is-default-class,
+# same reasoning as csi-hostpath-snapclass.
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: longhorn-snapclass
+driver: driver.longhorn.io
+deletionPolicy: Delete
+parameters:
+  type: longhorn-snapshot

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
   - kopiur
   - snapshot-controller
   - csi-hostpath
+  - longhorn
   - flux2

--- a/k3s/infrastructure/controllers/longhorn/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/longhorn/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: longhorn
+      version: "1.12.1"
+      sourceRef:
+        kind: HelmRepository
+        name: longhorn
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: longhorn-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    persistence:
+      createStorageClass: true
+      # NOT the cluster default — local-path remains the implicit default,
+      # same policy as csi-hostpath-sc. Apps opt in explicitly.
+      defaultClass: false
+      # Single testbed node today: only one node is available to hold a
+      # replica, so anything higher leaves volumes permanently degraded.
+      # Raise to 2 or 3 once the 3-node cluster is up.
+      defaultClassReplicaCount: 1
+    defaultSettings:
+      # Same disk csi-hostpath-sc already writes into — no dedicated block
+      # device required, Longhorn stores replicas as files on this path.
+      defaultDataPath: /var/lib/longhorn

--- a/k3s/infrastructure/controllers/longhorn/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/longhorn/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: longhorn
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.longhorn.io

--- a/k3s/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k3s/infrastructure/controllers/longhorn/kustomization.yaml
@@ -2,5 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - volumesnapshotclass.yaml
-  - volumesnapshotclass-longhorn.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary
- Installs Longhorn as a real, replicated block-storage CSI driver alongside the existing `csi-hostpath-sc` demo driver — no PVCs are moved, no default storage class changes.
- `k3s/infrastructure/controllers/longhorn/`: HelmRepository + HelmRelease. `persistence.defaultClass: false` (local-path stays cluster default, same policy as csi-hostpath-sc); `defaultClassReplicaCount: 1` since the testbed is single-node today — bump once the 3-node cluster is up.
- Uses `defaultDataPath: /var/lib/longhorn`, the same disk csi-hostpath already writes into — no dedicated block device needed.
- `k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass-longhorn.yaml`: `longhorn-snapclass` (`type: longhorn-snapshot`, in-cluster CoW snapshot) so kopiur can target Longhorn volumes later, mirroring the existing `csi-hostpath-snapclass` pattern.
- `k3s-prereqs` role: installs and enables `open-iscsi`/`iscsid`, a hard requirement for Longhorn's engine pods that was otherwise missing from node provisioning.

## Test plan
- [x] `yamllint -c .yamllint.yaml k3s/infrastructure/ .github/workflows/` — clean (one pre-existing unrelated warning in opentelemetry-collector)
- [x] `kustomize build k3s/infrastructure/controllers/longhorn` and `.../configs/snapshot-storage` — both build
- [x] `flux-local test --path k3s/clusters/homelab` — 6 passed
- [x] `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — diff shows only the 3 new resources (HelmRepository, HelmRelease, VolumeSnapshotClass) added, nothing else changed
- [ ] Apply to the testbed and confirm the `longhorn-system` namespace comes up healthy, `open-iscsi` installed correctly via re-run of `provision-nodes.yml`
- [ ] Confirm a StorageClass named `longhorn` is created and is not the cluster default

## Explicitly out of scope
No existing PVC is migrated to Longhorn in this PR — that's a separate follow-up per app, using the same intermediate-PVC + rsync + cutover pattern already used for the tdarr storage-class migration.