### PR TITLE
docs(gatus): document credentialProjection in Restore CR

### DIFF
--- a/k3s/applications/gatus/migration/restore.yaml
+++ b/k3s/applications/gatus/migration/restore.yaml
@@ -64,6 +64,16 @@ spec:
       accessModes:
         - ReadWriteOnce
       capacity: 1Gi
+  credentialProjection:
+    # Required when the source SnapshotPolicy uses a ClusterRepository
+    # whose credential Secret lives in another namespace (here:
+    # kopiur-system). Without this, the Restore mover Job can't read
+    # the kopia password and stalls in Pending. The matching
+    # SnapshotPolicy already has `credentialProjection.enabled: true`,
+    # so the source snapshot is restorable only if the Restore opts in
+    # the same way. See PR #307 for the gatus migration that exercised
+    # this.
+    enabled: true
   mover:
     inheritSecurityContextFrom:
       # Restore-only field: inherit UID/GID from the backup's recorded


### PR DESCRIPTION
## What

Document the `credentialProjection: { enabled: true }` requirement on the gatus migration's Restore CR. The field was missing from the original manifest in #307 and the restore stalled in Pending until I patched it at runtime.

## Why

The source `SnapshotPolicy` uses `ClusterRepository: nas`, whose credential Secret (`kopiur-nas-secret`) lives in `kopiur-system`. The kopiur Restore controller mounts that Secret into the mover Job via `envFrom`, which is namespace-local — the Secret has to also exist in the target namespace (`gatus`) for the restore to work. The field that opts in is `spec.credentialProjection.enabled`.

The matching SnapshotPolicy already sets `credentialProjection.enabled: true`, which is why the snapshot chain itself works. The Restore needs the same opt-in to read the same projected Secret.

## Outcome for the next migration

Whoever runs the next csi-hostpath → longhorn migration (or any Restore from a cross-namespace ClusterRepository) won't have to discover this via the controller's `MissingCredentialsSecret` event in the cluster log — the field is in the source manifest with a comment explaining the dependency.

## Files

| Path | Change |
|---|---|
| `k3s/applications/gatus/migration/restore.yaml` | Add `credentialProjection.enabled: true` + comment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)