### PR TITLE
feat(headlamp): migrate PVC from csi-hostpath-sc to longhorn (preserve data)

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -96,7 +96,12 @@ spec:
         - ReadWriteOnce
       enabled: true
       size: 1Gi
-      storageClassName: csi-hostpath-sc
+      # Migrated from csi-hostpath-sc to longhorn (paired with the
+      # Restore CR in migration/restore.yaml). The Restore creates a
+      # new 'headlamp' PVC on longhorn and populates it from the
+      # latest kopia snapshot; the chart's PVC template then matches
+      # what's already there and Helm doesn't recreate it.
+      storageClassName: longhorn
     volumeMounts:
       - mountPath: /build/plugins
         name: headlamp-plugins

--- a/k3s/applications/headlamp/migration/restore.yaml
+++ b/k3s/applications/headlamp/migration/restore.yaml
@@ -1,0 +1,102 @@
+---
+# Restore CR for the headlamp csi-hostpath-sc → longhorn migration.
+#
+# This is operator-applied (NOT in kustomization.yaml — Flux will not
+# reconcile it on every sync). Run with `kubectl apply -f` once after
+# scaling headlamp to 0 replicas.
+#
+# Kept in the tree as a record of the migration (matches the pattern
+# in gatus/migration/ and portainer/migration/). After the migration
+# succeeds, the Restore CR is a no-op and the completed status is
+# harmless; delete it manually if desired:
+#   kubectl delete restore -n headlamp headlamp-longhorn-migration
+#
+# Why a Restore CR instead of rsync:
+#   The kopiur-repo PVC is a Kopia deduplicated repository (kopia.repository.f
+#   in the root, packed blob dirs p00–pff), not a flat directory of snapshot
+#   files. We can't just rsync from it. The Restore CR pulls data from the
+#   kopia repository and writes it into a target PVC — the proper way to pull
+#   data back out of a kopiur backup.
+#
+# What this does:
+#   1. Resolves the latest successful Snapshot CR from SnapshotPolicy
+#      `headlamp` (the live csi-hostpath-sc backup chain). Headlamp runs
+#      hourly, so the latest snapshot is at most an hour old.
+#   2. Creates a new PVC named `headlamp` on the `longhorn` StorageClass
+#      (operator-managed: target.pvc is a freshly created PVC, not a pre-existing one).
+#   3. Pops a mover Job that reads from kopia and writes to the new PVC.
+#   4. Records phase=Completed when the mover succeeds.
+#
+# Pre-conditions (operator must do before applying):
+#   - headlamp HelmRelease suspended (so the controller doesn't try to
+#     upgrade-with-recreate while we're swapping the PVC underneath it).
+#   - headlamp deployment scaled to 0 replicas (releases RWO on the old
+#     csi-hostpath-sc PVC).
+#   - Stale csi-hostpath-snapclass VolumeSnapshots cleared (they hold
+#     pvc-as-source-protection finalizers on the source PVC). See the
+#     gatus migration (PR #307) for the exact patch sequence.
+#   - The old csi-hostpath-sc PVC `headlamp` deleted (Restore's target.pvc
+#     would otherwise hit a name conflict; the data is safe in the kopia
+#     snapshot).
+#
+# Post-conditions:
+#   - PVC `headlamp` exists, bound on `longhorn`, populated with the latest snapshot.
+#   - HelmRelease can be updated to `storageClassName: longhorn` and the chart's
+#     PVC template will match the existing PVC (no conflict).
+#   - headlamp deployment scaled back to 1 replica binds to the longhorn PVC.
+#   - The chart's initContainer runs as root and chowns /build/plugins to
+#     100:101 — the restored plugin state is preserved, the plugin binaries
+#     are re-populated from the image (the snapshot was never the source of
+#     truth for binaries; that's what the initContainer is for).
+#
+# UID/GID safety:
+#   `mover.inheritSecurityContextFrom.snapshot: {}` reads the UID/GID kopia
+#   recorded on the backup itself (kopiur-meta kopia tag). The snapshot
+#   policy's mover runs as runAsUser=100, runAsGroup=101, fsGroup=101; the
+#   restore mover inherits the same. Result: restored files are owned by
+#   100:101, matching what the chart's initContainer chowns to. No manual
+#   chown needed.
+#
+# credentialProjection:
+#   REQUIRED. The source SnapshotPolicy uses ClusterRepository `nas`, whose
+#   credential Secret lives in `kopiur-system`, not `headlamp`. The mover
+#   Job mounts that Secret via envFrom (namespace-local). Without
+#   `credentialProjection.enabled: true`, the Restore stalls in Pending
+#   with `MissingCredentialsSecret`. See gatus migration PR #308 for the
+#   lesson-learned doc.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: headlamp-longhorn-migration
+  namespace: headlamp
+spec:
+  source:
+    fromPolicy:
+      # Pull the latest snapshot taken by the `headlamp` SnapshotPolicy.
+      # The policy runs hourly; the latest snapshot is at most ~1h old.
+      name: headlamp
+      offset: 0
+  target:
+    pvc:
+      # Name MUST match the chart-managed PVC name so the HelmRelease's
+      # PVC template reuses the restored PVC after the storageClassName
+      # update in commit 2 of the migration.
+      name: headlamp
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml
@@ -16,7 +16,11 @@ spec:
       # later adopt an existing repo into this one.
       sourcePathOverride: /data
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/headlamp-longhorn. The headlamp PVC is now on the `longhorn`
+  # StorageClass (PR prepping the move in helmrelease.yaml), so the
+  # CSI snapshot must use the matching Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
## What

Migrate headlamp's PVC from `csi-hostpath-sc` to `longhorn` while preserving plugin state. Same technique as #307 (gatus) — the kopiur `Restore` CR pulls the latest snapshot from the kopia repository and writes it into a new `headlamp` PVC on longhorn.

## Why

- Headlamp was the workload alongside gatus that PR #274 moved to csi-hostpath-sc. Now that Longhorn is the cluster's long-term block storage layer (PR #306), headlamp is the next candidate.
- Headlamp snapshots are hourly, so the staleness window is at most ~1h — negligible for plugin config/cache state.
- The restore exercises the same backup chain that gatus PR #307 used, so the implementation is mostly templating a known-good pattern.

## How (the migration itself)

Operator workflow (after this PR merges):

1. `flux suspend helmrelease headlamp -n headlamp` (block retry during cutover)
2. `kubectl scale deployment -n headlamp headlamp --replicas=0`
3. Clear stale csi-hostpath-snapclass VolumeSnapshots (they hold `pvc-as-source-protection` finalizers on the source PVC). The gatus migration (PR #307) shows the exact patch sequence.
4. `kubectl delete pvc -n headlamp headlamp` (data is safe in kopia)
5. `kubectl apply -f k3s/applications/headlamp/migration/restore.yaml`
6. Wait for `kubectl get restore -n headlamp headlamp-longhorn-migration` to report `Completed`
7. `flux resume helmrelease headlamp -n headlamp` (may need a suspend/resume cycle if the controller is stuck in a rolled-back state — same as gatus)
8. `kubectl scale deployment -n headlamp headlamp --replicas=1`
9. Verify `kubectl get pvc -n headlamp headlamp` shows `longhorn` and the dashboard renders

## Commits

1. **`feat(headlamp): add kopiur Restore CR for csi-hostpath → longhorn migration`** — operator-applied Restore CR (not in kustomization.yaml). Includes `credentialProjection.enabled: true` (lesson learned from gatus PR #308) and `inheritSecurityContextFrom.snapshot: {}` to inherit the 100:101 UID/GID recorded on the headlamp snapshot.
2. **`feat(headlamp): switch storageClassName to longhorn`** — HelmRelease's PVC template now matches the freshly-created PVC, so Helm doesn't recreate it.
3. **`feat(kopiur): switch headlamp snapshot policy to longhorn-snapclass`** — keeps the snapshot policy in sync with the new StorageClass.

## Headlamp-specific notes

- **Mover UID/GID is 100:101**, not 1000:1000 like gatus. The chart's initContainer runs as root and chowns `/build/plugins` to 100:101. `inheritSecurityContextFrom.snapshot: {}` reads this from the snapshot's recorded identity.
- **InitContainer overwrites plugin binaries on every pod start** (`cp -r /plugins/* /build/plugins/`). The restore is meaningful for *plugin state* (config, caches) that headlamp writes at runtime; the plugin binaries are re-populated from the image regardless. The snapshot chain was designed this way — this is not a regression.
- **Stale VolumeSnapshots** with `csi-hostpath-snapclass` will likely exist (the snapshot policy has been running hourly for 7 days). They need to be cleared before the source PVC can be deleted. The gatus migration in #307 hit the same finalizer deadlock.

## Files

| Path | Change |
|---|---|
| `k3s/applications/headlamp/migration/restore.yaml` | NEW — operator-applied Restore CR |
| `k3s/applications/headlamp/helmrelease.yaml` | `storageClassName: csi-hostpath-sc` → `longhorn` |
| `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml` | `volumeSnapshotClassName: csi-hostpath-snapclass` → `longhorn-snapclass` |

## Validation

- `yamllint -c .yamllint.yaml k3s/applications/headlamp/ k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-headlamp.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 6/6 passed
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — shows only the headlamp storageClassName + snapclass changes (migration file correctly excluded from Flux)

## Related

- #307 (gatus migration — established the Restore-CR pattern)
- #308 (docs fix adding credentialProjection to the gatus migration manifest)
- #306 (Longhorn CSI driver install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)