### PR TITLE
feat(portainer): migrate PVC from csi-hostpath-sc to longhorn (preserve data)

### DIFF
--- a/k3s/applications/portainer/helmrelease.yaml
+++ b/k3s/applications/portainer/helmrelease.yaml
@@ -49,15 +49,16 @@ spec:
     persistence:
       enabled: true
       size: "10Gi"
-      # -- csi-hostpath-sc is the only SC in this cluster that supports
-      # VolumeSnapshots, which is required for kopiur backup coverage.
-      # Migration from local-path was performed imperatively (Helm won't
-      # recreate an existing PVC just because the chart value changed);
-      # the imperative flow uses an intermediate `portainer-hostpath`
-      # PVC on csi-hostpath-sc, an rsync stage-1, then a chart-managed
-      # `portainer` PVC recreated on csi-hostpath-sc and an rsync
-      # stage-2 into it. Manifests in `migration/`.
-      storageClass: csi-hostpath-sc
+      # -- Migrated from csi-hostpath-sc to longhorn in
+      # feat/portainer-longhorn. The Restore CR in migration/restore.yaml
+      # creates a new 'portainer' PVC on longhorn and populates it from
+      # the latest kopia snapshot; the chart's PVC template then matches
+      # what's already there and Helm doesn't recreate it. The previous
+      # `portainer-hostpath` intermediate PVC from the local-path →
+      # csi-hostpath-sc migration (migration/pvc-hostpath.yaml) is no
+      # longer needed and is deleted separately after the migration is
+      # verified.
+      storageClass: longhorn
       accessMode: ReadWriteOnce
 
     resources:

--- a/k3s/applications/portainer/migration/restore.yaml
+++ b/k3s/applications/portainer/migration/restore.yaml
@@ -1,0 +1,103 @@
+---
+# Restore CR for the portainer csi-hostpath-sc → longhorn migration.
+#
+# This is operator-applied (NOT in kustomization.yaml — Flux will not
+# reconcile it on every sync). Run with `kubectl apply -f` once after
+# scaling portainer to 0 replicas.
+#
+# Kept in the tree as a record of the migration (matches the pattern
+# in gatus/migration/ and headlamp/migration/; the existing
+# portainer/migration/ directory holds the artifacts from the previous
+# local-path → csi-hostpath-sc migration, also kept for record).
+# Delete manually if desired:
+#   kubectl delete restore -n portainer portainer-longhorn-migration
+#
+# Why a Restore CR instead of rsync:
+#   The kopiur-repo PVC is a Kopia deduplicated repository, not a flat
+#   directory of snapshot files. The Restore CR pulls data from the
+#   kopia repository and writes it into a target PVC — the proper way
+#   to pull data back out of a kopiur backup.
+#
+# What this does:
+#   1. Resolves the latest successful Snapshot CR from SnapshotPolicy
+#      `portainer` (the live csi-hostpath-sc backup chain).
+#   2. Creates a new PVC named `portainer` on the `longhorn` StorageClass
+#      (operator-managed: target.pvc is a freshly created PVC, not a pre-existing one).
+#   3. Pops a mover Job that reads from kopia and writes to the new PVC.
+#   4. Records phase=Completed when the mover succeeds.
+#
+# Pre-conditions (operator must do before applying):
+#   - portainer HelmRelease suspended (so the controller doesn't try to
+#     upgrade-with-recreate while we're swapping the PVC underneath it).
+#   - portainer deployment scaled to 0 replicas (releases RWO on the old
+#     csi-hostpath-sc PVC).
+#   - The stale csi-hostpath-snapclass VolumeSnapshot
+#     (`portainer-scheduled-20260818100200-snap`) cleared of its
+#     `pvc-as-source-protection` finalizer on the source PVC. Same
+#     pattern as the gatus migration (PR #307).
+#   - The old csi-hostpath-sc PVC `portainer` deleted (Restore's
+#     target.pvc would otherwise hit a name conflict; the data is safe
+#     in the kopia snapshot).
+#   - Note: the `portainer-hostpath` leftover PVC from the previous
+#     migration is NOT in the snapshot policy, so it isn't restored.
+#     Delete it separately after the migration is verified.
+#
+# Post-conditions:
+#   - PVC `portainer` exists, bound on `longhorn`, populated with the latest snapshot.
+#   - HelmRelease can be updated to `storageClassClass: longhorn` and the chart's
+#     PVC template will match the existing PVC (no conflict).
+#   - portainer deployment scaled back to 1 replica binds to the longhorn PVC.
+#
+# UID/GID safety:
+#   The portainer snapshot policy uses privileged mover mode (runAsUser=0,
+#   runAsGroup=0, fsGroup=0) — the namespace carries the
+#   `kopiur.home-operations.com/privileged-movers: "true"` annotation
+#   that opts in. The Restore inherits the same identity from the recorded
+#   snapshot via `inheritSecurityContextFrom.snapshot: {}`. Result:
+#   restored files are owned by root, matching what the portainer chart's
+#   runtime expects (the chart's data directory is set up by root at
+#   startup, which is why this app needs privileged mode in the first
+#   place).
+#
+# credentialProjection:
+#   REQUIRED. The source SnapshotPolicy uses ClusterRepository `nas`,
+#   whose credential Secret lives in `kopiur-system`, not `portainer`.
+#   The mover Job mounts that Secret via envFrom (namespace-local).
+#   Without `credentialProjection.enabled: true`, the Restore stalls in
+#   Pending with `MissingCredentialsSecret`. See gatus PR #308 for the
+#   lesson learned.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: portainer-longhorn-migration
+  namespace: portainer
+spec:
+  source:
+    fromPolicy:
+      # Pull the latest snapshot taken by the `portainer` SnapshotPolicy.
+      name: portainer
+      offset: 0
+  target:
+    pvc:
+      # Name MUST match the chart-managed PVC name so the HelmRelease's
+      # PVC template reuses the restored PVC after the storageClass
+      # update in commit 2 of the migration.
+      name: portainer
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-portainer.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-portainer.yaml
@@ -14,7 +14,11 @@ spec:
         name: portainer
       sourcePathOverride: /data
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/portainer-longhorn. The portainer PVC is now on the `longhorn`
+  # StorageClass (PR prepping the move in helmrelease.yaml), so the
+  # CSI snapshot must use the matching Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
## What

Migrate portainer's PVC from `csi-hostpath-sc` to `longhorn` while preserving the Portainer data directory. Same technique as #307 (gatus) and #309 (headlamp) — the kopiur `Restore` CR pulls the latest snapshot from the kopia repository and writes it into a new `portainer` PVC on longhorn.

## Why

- Portainer is the next csi-hostpath-sc workload to move to Longhorn (the cluster's long-term block storage, PR #306).
- The snapshot chain is working and the policy uses privileged mover mode (root UID/GID 0:0). The restore exercises that same mode.

## How (the migration itself)

Operator workflow (after this PR merges):

1. `flux suspend helmrelease portainer -n portainer` (block retry during cutover)
2. `kubectl scale deployment -n portainer portainer --replicas=0`
3. Clear the stale csi-hostpath-snapclass VolumeSnapshot's `pvc-as-source-protection` finalizer on the source PVC. The gatus migration (PR #307) shows the exact patch sequence.
4. `kubectl delete pvc -n portainer portainer` (data is safe in kopia)
5. `kubectl apply -f k3s/applications/portainer/migration/restore.yaml`
6. Wait for `kubectl get restore -n portainer portainer-longhorn-migration -o jsonpath='{.status.phase}'` to report `Completed`
7. `flux resume helmrelease portainer -n portainer` — should succeed on first try (pre-suspended Helm doesn't get stuck in rollback). If it does, a suspend/resume cycle recovers.
8. `kubectl scale deployment -n portainer portainer --replicas=1`
9. Verify `kubectl get pvc -n portainer portainer -o jsonpath='{.spec.storageClassName}'` reports `longhorn`
10. Cleanup: `kubectl delete pvc -n portainer portainer-hostpath` (leftover from the previous local-path → csi-hostpath-sc migration, NOT in the snapshot policy)

## Commits

1. **`feat(portainer): add kopiur Restore CR for csi-hostpath → longhorn migration`** — operator-applied Restore CR (not in kustomization.yaml). Includes `credentialProjection.enabled: true` (lesson learned from gatus PR #308) and `inheritSecurityContextFrom.snapshot: {}` to inherit the privileged mover identity (0:0) recorded on the snapshot.
2. **`feat(portainer): switch storageClass to longhorn`** — HelmRelease's PVC template now matches the freshly-created PVC, so Helm doesn't recreate it.
3. **`feat(kopiur): switch portainer snapshot policy to longhorn-snapclass`** — keeps the snapshot policy in sync with the new StorageClass.

## Portainer-specific notes

- **Privileged mover mode** — the namespace carries `kopiur.home-operations.com/privileged-movers: "true"` and the snapshot policy mover runs as 0:0. The Restore inherits the same identity from the snapshot's recorded provenance.
- **Two PVCs in the namespace** — `portainer` (backed up, what we migrate) and `portainer-hostpath` (leftover from PR #298, NOT in the snapshot policy, deleted separately after the migration is verified).
- **Stale VolumeSnapshot** from 13h ago (`portainer-scheduled-20260818100200-snap`, csi-hostpath-snapclass) holds the `pvc-as-source-protection` finalizer on the source PVC. Cleared before the source PVC can be deleted.
- **Old migration files** (`migration/pvc.yaml`, `pvc-hostpath.yaml`, `pvc-copy-stage1.yaml`, `pvc-copy-stage2.yaml`) from the previous local-path → csi-hostpath-sc migration are kept in the tree as a record. The new `restore.yaml` joins them.

## Files

| Path | Change |
|---|---|
| `k3s/applications/portainer/migration/restore.yaml` | NEW — operator-applied Restore CR |
| `k3s/applications/portainer/helmrelease.yaml` | `storageClass: csi-hostpath-sc` → `longhorn` |
| `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-portainer.yaml` | `volumeSnapshotClassName: csi-hostpath-snapclass` → `longhorn-snapclass` |

## Validation

- `yamllint -c .yamllint.yaml k3s/applications/portainer/ k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-portainer.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 6/6 passed
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — shows only portainer SC + snapclass changes (migration file correctly excluded from Flux)

## Related

- #307 (gatus migration — established the Restore-CR pattern)
- #308 (docs fix adding credentialProjection to the gatus migration manifest)
- #309 (headlamp migration — second workload)
- #306 (Longhorn CSI driver install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)