### PR TITLE
feat(monitoring): migrate alertmanager + grafana PVCs from csi-hostpath-sc to longhorn (preserve data)

### DIFF
--- a/k3s/applications/monitoring/migration/restore.yaml
+++ b/k3s/applications/monitoring/migration/restore.yaml
@@ -1,0 +1,154 @@
+---
+# Restore CRs for the monitoring stack csi-hostpath-sc → longhorn migration.
+#
+# Two Restores in one file — alertmanager and grafana — both in the
+# `monitoring` namespace, both backed up by hourly kopiur snapshots.
+# Both are owned by the kube-prometheus-stack HelmRelease, so the
+# HelmRelease update + suspend/resume cycle has to happen after both
+# Restores complete.
+#
+# This is operator-applied (NOT in kustomization.yaml — Flux will not
+# reconcile it on every sync). Run with `kubectl apply -f` once after
+# suspending the kube-prometheus-stack HelmRelease and scaling both
+# workloads to 0 replicas.
+#
+# Kept in the tree as a record of the migration (matches the pattern
+# in gatus/migration/, headlamp/migration/, portainer/migration/; the
+# existing `monitoring/migration/` directory holds the artifacts from
+# the previous local-path → csi-hostpath-sc migration, also kept for
+# record).
+#
+# Why a Restore CR instead of rsync:
+#   The kopiur-repo PVC is a Kopia deduplicated repository, not a flat
+#   directory of snapshot files. The Restore CR pulls data from the
+#   kopia repository and writes it into a target PVC — the proper way
+#   to pull data back out of a kopiur backup.
+#
+# What this does:
+#   1. Resolves the latest successful Snapshot CR from each SnapshotPolicy.
+#   2. Creates a new PVC per workload on the `longhorn` StorageClass
+#      (operator-managed: target.pvc is a freshly created PVC, not a pre-existing one).
+#   3. Pops a mover Job per workload that reads from kopia and writes
+#      to the new PVC.
+#   4. Records phase=Completed per workload when the mover succeeds.
+#
+# Pre-conditions (operator must do before applying):
+#   - SnapshotSchedules `alertmanager-scheduled` and `grafana-scheduled`
+#     suspended (`kubectl patch snapshotschedule -n monitoring
+#     <name> --type merge -p '{"spec":{"suspend":true}}'`). The
+#     policies in this PR were updated to longhorn-snapclass, but the
+#     PVCs are still on csi-hostpath-sc; an hourly snapshot run during
+#     the cutover would fail. Re-suspend after migrations complete.
+#   - kube-prometheus-stack HelmRelease suspended (so the controller
+#     doesn't try to upgrade-with-recreate while we're swapping the
+#     PVCs underneath it).
+#   - alertmanager StatefulSet scaled to 0 replicas (releases RWO on
+#     the old csi-hostpath-sc PVC).
+#   - grafana Deployment scaled to 0 replicas (releases RWO on the old
+#     csi-hostpath-sc PVC).
+#   - Stale csi-hostpath-snapclass VolumeSnapshots cleared. As of
+#     2026-08-18, only one stale snapshot exists:
+#       alertmanager-scheduled-20260818100000-snap (13h old)
+#     Grafana has none. Same patch-the-finalizer pattern as the gatus
+#     migration.
+#   - The old csi-hostpath-sc PVCs deleted. Two PVCs to delete:
+#       alertmanager-kube-prometheus-stack-alertmanager-db-alertmanager-kube-prometheus-stack-alertmanager-0
+#       kube-prometheus-stack-grafana
+#     Both are bound to csi-hostpath-sc PVs that will be auto-collected
+#     by the reclaim-policy=Delete default.
+#   - Stale Completed pods from the previous migration (in the same
+#     directory's `*-pvc-copy-stage[12].yaml` artifacts) checked and
+#     deleted if they still hold the kubernetes.io/pvc-protection
+#     finalizer on the source PVCs. The portainer migration hit this.
+#
+# Post-conditions:
+#   - PVC `alertmanager-...` exists, bound on `longhorn`, populated.
+#   - PVC `kube-prometheus-stack-grafana` exists, bound on `longhorn`,
+#     populated.
+#   - HelmRelease can be updated to `storageClassName: longhorn` and the
+#     chart's volumeClaimTemplate / PVC will match the existing PVCs.
+#   - Both workloads scaled back to 1+ replicas bind to the longhorn PVCs.
+#
+# UID/GID safety:
+#   `mover.inheritSecurityContextFrom.snapshot: {}` reads the UID/GID
+#   kopia recorded on the backup itself. The SnapshotPolicy mover
+#   identities are:
+#     alertmanager: runAsUser=1000, runAsGroup=2000, fsGroup=2000
+#     grafana:      runAsUser=472,  runAsGroup=472,  fsGroup=472
+#   These are the recorded identities; the Restore inherits them.
+#
+# credentialProjection:
+#   REQUIRED. The source SnapshotPolicies use ClusterRepository `nas`,
+#   whose credential Secret lives in `kopiur-system`, not `monitoring`.
+#   The mover Job mounts that Secret via envFrom (namespace-local).
+#   Without `credentialProjection.enabled: true`, the Restores stall
+#   in Pending with `MissingCredentialsSecret`. See gatus PR #308 for
+#   the lesson learned.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: alertmanager-longhorn-migration
+  namespace: monitoring
+spec:
+  source:
+    fromPolicy:
+      name: alertmanager
+      offset: 0
+  target:
+    pvc:
+      # Matches the StatefulSet's volumeClaimTemplate name. The
+      # volumeClaimTemplate is immutable, so this name is fixed.
+      name: alertmanager-kube-prometheus-stack-alertmanager-db-alertmanager-kube-prometheus-stack-alertmanager-0
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: grafana-longhorn-migration
+  namespace: monitoring
+spec:
+  source:
+    fromPolicy:
+      name: grafana
+      offset: 0
+  target:
+    pvc:
+      # Matches the chart-managed PVC name. Same name as the existing
+      # csi-hostpath-sc PVC; the operator deletes the old one before
+      # this Restore creates the new one.
+      name: kube-prometheus-stack-grafana
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 5Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-alertmanager.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-alertmanager.yaml
@@ -14,7 +14,12 @@ spec:
         name: alertmanager-kube-prometheus-stack-alertmanager-db-alertmanager-kube-prometheus-stack-alertmanager-0
       sourcePathOverride: /alertmanager/alertmanager-db
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/monitoring-longhorn. The alertmanager PVC is now on the
+  # `longhorn` StorageClass (PR prepping the move in helmrelease.yaml),
+  # so the CSI snapshot must use the matching Longhorn
+  # VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-grafana.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-grafana.yaml
@@ -14,7 +14,11 @@ spec:
         name: kube-prometheus-stack-grafana
       sourcePathOverride: /var/lib/grafana
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/monitoring-longhorn. The grafana PVC is now on the `longhorn`
+  # StorageClass (PR prepping the move in helmrelease.yaml), so the
+  # CSI snapshot must use the matching Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -125,15 +125,14 @@ spec:
         storage:
           volumeClaimTemplate:
             spec:
-              # -- csi-hostpath-sc is the only SC in this cluster that
-              # supports VolumeSnapshots, which is required for kopiur
-              # backup coverage. The StatefulSet's volumeClaimTemplate
-              # is immutable, so the local-path → csi-hostpath-sc
-              # migration requires deleting the StatefulSet and letting
-              # Helm recreate it from the updated chart value. Data is
-              # preserved across that cutover by the imperative flow in
-              # k3s/applications/monitoring/migration/.
-              storageClassName: csi-hostpath-sc
+              # Migrated from csi-hostpath-sc to longhorn in
+              # feat/monitoring-longhorn. The Restore CR in
+              # k3s/applications/monitoring/migration/restore.yaml
+              # creates a new PVC on longhorn and populates it from
+              # the latest kopia snapshot; the chart's volumeClaimTemplate
+              # then matches what's already there and Helm doesn't
+              # recreate the StatefulSet.
+              storageClassName: longhorn
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
@@ -196,15 +195,13 @@ spec:
         accessModes:
           - ReadWriteOnce
         size: 5Gi
-        # -- csi-hostpath-sc is the only SC in this cluster that supports
-        # VolumeSnapshots, which is required for kopiur backup coverage.
-        # Migration from local-path was performed imperatively (the chart
-        # value change alone wouldn't move the existing PVC); the imperative
-        # flow uses an intermediate `grafana-hostpath` PVC on csi-hostpath-sc,
-        # an rsync stage-1, then a chart-managed `kube-prometheus-stack-grafana`
-        # PVC recreated on csi-hostpath-sc and an rsync stage-2 into it.
-        # Manifests in `k3s/applications/monitoring/migration/`.
-        storageClassName: csi-hostpath-sc
+        # Migrated from csi-hostpath-sc to longhorn in
+        # feat/monitoring-longhorn. The Restore CR in
+        # k3s/applications/monitoring/migration/restore.yaml
+        # creates a new PVC on longhorn and populates it from the
+        # latest kopia snapshot; the chart's PVC template then matches
+        # what's already there and Helm doesn't recreate it.
+        storageClassName: longhorn
       ingress:
         enabled: true
         ingressClassName: traefik


### PR DESCRIPTION
## What

Migrate the monitoring stack's alertmanager and grafana PVCs from `csi-hostpath-sc` to `longhorn`, preserving both data sets. Both PVCs are owned by the same `kube-prometheus-stack` HelmRelease, so the HelmRelease change is one commit covering both storageClassName values.

## Why

- Both PVCs are csi-hostpath-sc and backed up by hourly kopiur snapshots.
- Moving them in one PR (instead of two) keeps the HelmRelease change reviewable — a single file, two storageClassName values, atomic.
- Both migrations use the same Restore CR pattern established by #307 (gatus), #309 (headlamp), and #310 (portainer).

## How (the migration itself)

The operator workflow is more involved than the previous migrations because both workloads share a HelmRelease and the snapshot policies run hourly. Key sequencing:

1. **`kubectl patch snapshotschedule -n monitoring alertmanager-scheduled --type merge -p '{"spec":{"suspend":true}}'`**
2. **`kubectl patch snapshotschedule -n monitoring grafana-scheduled --type merge -p '{"spec":{"suspend":true}}'`** — SnapshotSchedules run hourly; the snapclass was changed to longhorn-snapclass in this PR, but the PVCs are still on csi-hostpath-sc, so a snapshot run during the cutover would fail.
3. `flux suspend helmrelease kube-prometheus-stack -n monitoring`
4. `kubectl scale statefulset -n monitoring alertmanager-kube-prometheus-stack-alertmanager --replicas=0`
5. `kubectl scale deployment -n monitoring kube-prometheus-stack-grafana --replicas=0`
6. Clear stale csi-hostpath-snapclass VolumeSnapshot finalizer on the source PVC. As of 2026-08-18 there's one stale snapshot: `alertmanager-scheduled-20260818100000-snap` (13h old). Grafana has none.
7. `kubectl delete pvc -n monitoring <alertmanager-pvc>` and `kubectl delete pvc -n monitoring kube-prometheus-stack-grafana`
8. `kubectl apply -f k3s/applications/monitoring/migration/restore.yaml` — both Restores can run concurrently (different operator pods, different PVCs)
9. Wait for both to report `phase: Completed`
10. `flux resume helmrelease kube-prometheus-stack -n monitoring` — should succeed on first try (pre-suspended Helm doesn't get stuck in rollback)
11. `kubectl scale statefulset -n monitoring alertmanager-kube-prometheus-stack-alertmanager --replicas=1`
12. `kubectl scale deployment -n monitoring kube-prometheus-stack-grafana --replicas=1`
13. **Resume the snapshot schedules** (reverses step 1 and 2): `kubectl patch snapshotschedule -n monitoring alertmanager-scheduled grafana-scheduled --type merge -p '{"spec":{"suspend":false}}'`

## Commits

1. **`feat(monitoring): add kopiur Restore CRs for csi-hostpath → longhorn migration`** — two Restore CRs in one file (alertmanager + grafana). Both in the `monitoring` namespace. Both inherit UID/GID from the recorded snapshot identity (alertmanager: 1000:2000, grafana: 472:472). Both carry `credentialProjection.enabled: true`.
2. **`feat(monitoring): switch alertmanager + grafana storageClassName to longhorn`** — one HelmRelease change covers both workloads. The chart's volumeClaimTemplate (alertmanager, StatefulSet) and PVC template (grafana, Deployment) both update to longhorn.
3. **`feat(kopiur): switch monitoring snapshot policies to longhorn-snapclass`** — both alertmanager and grafana SnapshotPolicies updated to `volumeSnapshotClassName: longhorn-snapclass`.

## Monitoring-specific notes

- **Two PVCs in one HelmRelease** — alertmanager uses a StatefulSet's volumeClaimTemplate (immutable name), grafana uses a chart-managed PVC. The alertmanager PVC name is the long `alertmanager-...-0` form; the grafana PVC is `kube-prometheus-stack-grafana`.
- **Hourly snapshots** — the operator runbook must suspend BOTH SnapshotSchedules before the migration; otherwise the next hourly snapshot run will try to take a Longhorn snapshot of a csi-hostpath-sc PVC (or vice versa) and fail.
- **UID/GID differs per workload** — alertmanager uses 1000:2000 (privileged mover enabled at namespace level), grafana uses 472:472. The `inheritSecurityContextFrom.snapshot: {}` field reads the recorded identity from each workload's snapshot.
- **Both moves happen concurrently** — the operator can apply both Restores in one `kubectl apply -f`. The two Restore CRs create separate mover Pods that race for the kopia repository but don't conflict.

## Files

| Path | Change |
|---|---|
| `k3s/applications/monitoring/migration/restore.yaml` | NEW — two Restore CRs (alertmanager + grafana) |
| `k3s/infrastructure/configs/monitoring/helmrelease.yaml` | `alertmanager.storageClassName` → `longhorn`, `grafana.storageClassName` → `longhorn` |
| `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-alertmanager.yaml` | `volumeSnapshotClassName: csi-hostpath-snapclass` → `longhorn-snapclass` |
| `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-grafana.yaml` | same |

## Validation

- `yamllint -c .yamllint.yaml k3s/applications/monitoring/ k3s/infrastructure/configs/monitoring/helmrelease.yaml k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-alertmanager.yaml k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-grafana.yaml` — clean
- `flux-local test --path k3s/clusters/homelab` — 6/6 passed
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — shows the four expected changes (two SC + two snapclass). The migration file is correctly excluded from Flux.

## Related

- #307 (gatus), #309 (headlamp), #310 (portainer) — established the Restore-CR pattern
- #308 (credentialProjection docs)
- #306 (Longhorn CSI driver install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)