### PR TITLE
fix(portainer): remove migration files from kustomization resources

### DIFF
--- a/k3s/applications/portainer/kustomization.yaml
+++ b/k3s/applications/portainer/kustomization.yaml
@@ -5,14 +5,12 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   # migration/ holds the imperative artifacts used to move portainer's PVC
-  # from local-path to csi-hostpath-sc. The intermediate PVC, copy Jobs, and
-  # recreate-on-cutover PVC live here. HelmRelease owns `portainer` (chart
-  # value `persistence.storageClass: csi-hostpath-sc`); once the migration
-  # is finished, the chart-managed PVC and the imperative ones in this
-  # directory must stay in sync — the intermediate and the stage copy Jobs
-  # are deleted at the end of the flow but the manifests are kept here as
-  # a record of the change.
-  - migration/pvc.yaml
-  - migration/pvc-hostpath.yaml
-  - migration/pvc-copy-stage1.yaml
-  - migration/pvc-copy-stage2.yaml
+  # from local-path to csi-hostpath-sc (PR #298) and from csi-hostpath-sc
+  # to longhorn (PR #310). The manifests are kept here as a record of the
+  # changes but are intentionally NOT Flux-managed — listing them in this
+  # resources list causes Flux to re-apply them on every reconcile, which
+  # conflicts with the HelmRelease's chart-managed PVC (storageClassName
+  # mismatch between the imperative manifest and the chart's rendered
+  # PVC). The new csi-hostpath → longhorn migration uses
+  # migration/restore.yaml, which is operator-applied (kubectl apply -f)
+  # and intentionally not listed here.


### PR DESCRIPTION
## What

Fix the portainer `apps` kustomization dry-run failure by removing the migration files from the `resources` list of `k3s/applications/portainer/kustomization.yaml`.

## Why

The kustomization was listing the previous migration's PVC and copy-Job manifests (`migration/pvc.yaml`, `migration/pvc-hostpath.yaml`, `migration/pvc-copy-stage1.yaml`, `migration/pvc-copy-stage2.yaml`) in its `resources` list. Flux applies everything in `resources` on every reconcile, so these manifests were being re-applied indefinitely.

The `migration/pvc.yaml` manifest has `storageClassName: csi-hostpath-sc` (the old storage class from PR #298). It conflicts with the HelmRelease's chart value of `longhorn` (PR #310). The `apps` kustomization was failing its dry-run because the imperative PVC wanted to update the storageClassName from `longhorn` back to `csi-hostpath-sc` on every reconcile.

The diff message looked like:
```
PersistentVolumeClaim/portainer/portainer dry-run failed (Invalid):
PersistentVolumeClaim "portainer" is invalid: spec: Forbidden: spec is
immutable after creation except resources.requests and volumeAttributesClassName
for bound claims
@@ -10,7 +10,7 @@
  },
  "VolumeName": "pvc-9b4c521a-38e9-4831-9666-e3fdbddce440",
- "StorageClassName": "longhorn",
+ "StorageClassName": "csi-hostpath-sc",
```

(`+` is the imperative manifest's value, `-` is the live state, but the imperative manifest was being re-applied every reconcile so the dry-run kept failing.)

## How (the fix)

Remove the migration files from the `resources` list. The `migration/` directory is kept as a record of the previous migrations (PR #298 and PR #310) but is intentionally not Flux-managed. The new csi-hostpath → longhorn migration uses `migration/restore.yaml`, which is operator-applied (`kubectl apply -f`) and intentionally not listed here — including it would re-apply the restore on every reconcile.

## Why this happened

The previous PRs (#298, #310) added the migration files to the kustomization's `resources` list as part of the local-path → csi-hostpath-sc migration. The intent was to keep the migration manifests in sync with the live PVC, but the comment in the kustomization said "the intermediate and the stage copy Jobs are deleted at the end of the flow" — that cleanup didn't happen for the file references, only the in-cluster resources. The filenames remained in the kustomization list and Flux kept re-applying them.

## What this fixes

- The `apps` kustomization dry-run will pass on the next reconcile.
- Portainer stays on longhorn (the HelmRelease's chart value).
- The `migration/` directory is preserved as a record.

## Files

| Path | Change |
|---|---|
| `k3s/applications/portainer/kustomization.yaml` | Remove `migration/pvc.yaml`, `migration/pvc-hostpath.yaml`, `migration/pvc-copy-stage1.yaml`, `migration/pvc-copy-stage2.yaml` from the `resources` list. Update the comment. |

## Validation

- `yamllint -c .yamllint.yaml k3s/applications/portainer/` — clean
- `flux-local diff ks --path k3s/clusters/homelab --branch-orig origin/master` — only the kustomization.yaml change is detected

## Related

- #298 (local-path → csi-hostpath-sc migration)
- #310 (csi-hostpath-sc → longhorn migration)
- #307 (gatus migration, established the Restore-CR pattern)
- #309 (headlamp migration, second restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)