### PR TITLE
feat(prowlarr): migrate prowlarr-config PVC from csi-hostpath-sc to longhorn (preserve data)

### DIFF
--- a/k3s/applications/prowlarr/migration/restore.yaml
+++ b/k3s/applications/prowlarr/migration/restore.yaml
@@ -1,0 +1,57 @@
+---
+# Restore CR for the prowlarr csi-hostpath-sc → longhorn migration.
+#
+# Operator-applied (NOT in kustomization.yaml). Run with `kubectl apply -f`
+# once after scaling prowlarr to 0 replicas. Matches the pattern in
+# gatus/migration/, headlamp/migration/, portainer/migration/.
+#
+# Delete manually if desired:
+#   kubectl delete restore -n media prowlarr-longhorn-migration
+#
+# Pre-conditions (operator must do before applying):
+#   - prowlarr deployment scaled to 0 replicas (releases RWO on old PVC).
+#   - Stale csi-hostpath-snapclass VolumeSnapshots cleared (they hold
+#     pvc-as-source-protection finalizers on the source PVC).
+#   - The old csi-hostpath-sc PVC `prowlarr-config` deleted (Restore's
+#     target.pvc would otherwise hit a name conflict; data is safe in kopia).
+#
+# Post-conditions:
+#   - PVC `prowlarr-config` exists, bound on `longhorn`, populated with snapshot.
+#   - prowlarr deployment scaled back to 1 replica binds to longhorn PVC.
+#   - Restored files are owned by UID 1027 GID 100 (LinuxServer prowlarr
+#     PUID/PGID), matching the policy's recorded snapshot metadata.
+#
+# credentialProjection: REQUIRED. ClusterRepository `nas` secret lives in
+# kopiur-system, not media. Without `credentialProjection.enabled: true`
+# the Restore stalls with MissingCredentialsSecret.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: prowlarr-longhorn-migration
+  namespace: media
+spec:
+  source:
+    fromPolicy:
+      name: prowlarr
+      offset: 0
+  target:
+    pvc:
+      name: prowlarr-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/applications/prowlarr/pvc.yaml
+++ b/k3s/applications/prowlarr/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: csi-hostpath-sc
+  storageClassName: longhorn   # was: csi-hostpath-sc
   resources:
     requests:
       storage: 2Gi

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-prowlarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-prowlarr.yaml
@@ -14,7 +14,11 @@ spec:
         name: prowlarr-config
       sourcePathOverride: /config
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/prowlarr-longhorn. The prowlarr-config PVC is now on the `longhorn`
+  # StorageClass (PR prepping the move in pvc.yaml), so the CSI snapshot
+  # must use the matching Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
Closes the csi-hostpath-sc cleanup for prowlarr. See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md.

Pattern matches gatus #307, headlamp #309, portainer #310/#312, monitoring #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)