### PR TITLE
fix(snapshot-storage): correct longhorn-snapclass type to 'snap'

### DIFF
--- a/k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass-longhorn.yaml
+++ b/k3s/infrastructure/configs/snapshot-storage/volumesnapshotclass-longhorn.yaml
@@ -5,10 +5,11 @@
 # alongside the kopiur configs in the infra-configs layer, same as
 # csi-hostpath-snapclass.
 #
-# type: longhorn-snapshot takes an in-cluster, copy-on-write Longhorn
-# snapshot (fast, node-local) rather than pushing to a configured Longhorn
-# backup target — kopiur's mover Pods handle moving data off-cluster, so
-# there's no need for Longhorn's own backup-target push here.
+# type: snap takes an in-cluster, copy-on-write Longhorn snapshot (fast,
+# node-local) rather than pushing to a configured Longhorn backup target
+# (which would require type: bak) — kopiur's mover Pods handle moving data
+# off-cluster, so there's no need for Longhorn's own backup-target push
+# here. Valid values per the Longhorn CSI driver are "snap", "bak", or "".
 #
 # Deliberately NOT setting snapshot.storage.kubernetes.io/is-default-class,
 # same reasoning as csi-hostpath-snapclass.
@@ -19,4 +20,4 @@ metadata:
 driver: driver.longhorn.io
 deletionPolicy: Delete
 parameters:
-  type: longhorn-snapshot
+  type: snap


### PR DESCRIPTION
## Defect

`longhorn-snapclass` VolumeSnapshotClass had `type: longhorn-snapshot`, which the Longhorn CSI driver rejects with:

```
invalid CSI snapshot type: longhorn-snapshot. Must be snap or bak or ""
```

The file's own comment block claimed `longhorn-snapshot` was a valid Longhorn CoW snapshot type. It is not.

## Impact

Every SnapshotPolicy pointing at `longhorn-snapclass` has been failing its hourly backup since the first migration in #307 (gatus). Eight policies total: gatus, headlamp, portainer, alertmanager, grafana, prowlarr, sonarr, radarr.

Still-working policies (authentik, qbittorrent, pihole, tdarr ×2) are on `csi-hostpath-snapclass` and unaffected.

## Fix

One-word change: `type: longhorn-snapshot` → `type: snap`.

Per the Longhorn CSI driver:
- `snap` — in-cluster, copy-on-write Longhorn snapshot (fast, node-local); kopiur mover Pods handle off-cluster push
- `bak` — push to configured Longhorn backup target (off-cluster via Longhorn's own mechanism)
- `""` — driver default (currently `snap`)

`snap` is the right choice: kopiur's mover Pods already move the snapshot data off-cluster, so there's no need for Longhorn's own backup-target push.

## Urgency

This must land **before Batch 2** of the csi-hostpath → longhorn migration (#307, #308, #309, #310, #311) to avoid switching qbittorrent/sabnzbd/tdarr/pihole/authentik onto the broken class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)