### PR TITLE
feat(sabnzbd): add Restore CR for gluetun-config csi-hostpath → longhorn migration

### DIFF
--- a/k3s/applications/sabnzbd/migration/restore.yaml
+++ b/k3s/applications/sabnzbd/migration/restore.yaml
@@ -1,0 +1,59 @@
+---
+# Restore CR for the sabnzbd gluetun-config csi-hostpath-sc → longhorn migration.
+# Part of the csi-hostpath → longhorn migration batch.
+#
+# sabnzbd-config is intentionally NOT in this Restore — the source PVC contains
+# Downloads/complete/*.mkv (sabnzbd is misconfigured to write COMPLETE inside
+# /config instead of /downloads) which exceeds any reasonable target capacity.
+# The user will reconfigure sabnzbd to write COMPLETE outside /config, then
+# a separate Restore CR will be created for sabnzbd-config.
+#
+# This Restore restores ONLY gluetun-config from the new sabnzbd-gluetun
+# SnapshotPolicy (split out by PR #318 to fix the multi-source policy bug).
+#
+# Operator-applied (NOT in kustomization.yaml — Flux will not reconcile it
+# on every sync). Run with `kubectl apply -f` once after scaling sabnzbd
+# to 0 replicas.
+#
+# Pre-conditions:
+#   - sabnzbd deployment scaled to 0 (force-delete if Flux reschedules)
+#   - The old csi-hostpath-sc PVC `gluetun-config` deleted (Restore's
+#     target.pvc would otherwise hit a name conflict)
+#
+# Post-conditions:
+#   - PVC `gluetun-config` exists, bound on `longhorn`, populated with the
+#     sabnzbd-gluetun snapshot (which has gluetun's hostname verification
+#     settings restored — fixes the broken WebUI access).
+#   - sabnzbd deployment scaled back to 1 — both PVCs mount; sabnzbd-config
+#     is empty (acceptable for now); gluetun-config has original settings.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: sabnzbd-gluetun-config-longhorn-migration
+  namespace: sabnzbd
+spec:
+  source:
+    fromPolicy:
+      name: sabnzbd-gluetun
+      offset: 0
+  target:
+    pvc:
+      name: gluetun-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail


### PR DESCRIPTION
## Summary

Adds the Restore CR record for migrating `gluetun-config` from `csi-hostpath-sc` → `longhorn` in the sabnzbd namespace.

## Background

The sabnzbd deploy came up with empty `gluetun-config` after the cleanup pass, and Flux reverted the deployment to 1 replica — gluetun's hostname verification now fails because the original config (which had the VPN endpoint / control-host settings the WebUI needs) is gone.

A new split `SnapshotPolicy` `sabnzbd-gluetun` was deployed (PR #318, fix for the multi-source policy bug). Its very first schedule at `20260821221400` is `Succeeded` and `READYTOUSE=true`.

## What this PR does

- Adds `k3s/applications/sabnzbd/migration/restore.yaml` — a single Restore CR that restores **only** `gluetun-config` from the new `sabnzbd-gluetun` policy.
- `sabnzbd-config` is intentionally NOT included — that PVC contains `Downloads/complete/*.mkv` (sabnzbd is misconfigured to write COMPLETE inside `/config` instead of `/downloads`), which exceeds any reasonable target capacity. The user will reconfigure sabnzbd to write COMPLETE outside `/config`, then a separate Restore CR will be created for `sabnzbd-config`.

## Operator-applied

Like the headlamp / gatus / portainer / prowlarr / qbittorrent / radarr migration Restore CRs, this is **not** added to `kustomization.yaml` — Flux will not reconcile it on every sync. Apply once with `kubectl apply -f` after scaling `deploy/sabnzbd` to 0 replicas and deleting the old `csi-hostpath-sc` PVC `gluetun-config`.

Once the restore completes, the Restore CR is a no-op and the completed status is harmless.

## Post-conditions

- PVC `gluetun-config` exists, bound on `longhorn`, populated from the `sabnzbd-gluetun` snapshot.
- `deploy/sabnzbd` scaled back to 1; pod Running; VPN tunnel up; WebUI hostname verification restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)