### PR TITLE
fix(sabnzbd): disable gluetun HTTP proxy hostname check

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -82,6 +82,8 @@ spec:
               value: "30s"
             - name: UPDATER_PERIOD
               value: "24h"
+            - name: HTTPPROXY_HOSTNAME
+              value: ""
           volumeMounts:
             - name: gluetun-config
               mountPath: /gluetun


### PR DESCRIPTION
## Problem

After the gluetun-config Restore (sabnzbd PVC migration to Longhorn), accessing `https://sabnzbd.homelab.properties/` returned "Access denied - Hostname verification failed" from gluetun's HTTP proxy.

## Root Cause

gluetun's HTTP proxy enforces a hostname check on proxied requests requiring the `Host` header to match either `HTTPPROXY_HOSTNAME` or the container's hostname. The deployment did not set `HTTPPROXY_HOSTNAME`, so gluetun fell back to comparing the request's `Host` header to the container hostname, which fails for requests proxied through ingress with a different host.

## Fix

Set `HTTPPROXY_HOSTNAME=""` (empty string) on the gluetun container, which disables the hostname verification per gluetun v3 docs.

## Verification

- Imperative fix applied via `kubectl set env` and rolled out successfully
- `kubectl exec` confirms `HTTPPROXY_HOSTNAME=` (empty)
- yamllint clean

## Notes

- The Restore CR (PR #319) for sabnzbd-gluetun-config is still open; the imperative restore was applied to recover the migration. The stale airvpn servers.json will be regenerated by gluetun on next start with NordVPN servers — not a blocker.
- Imperative fix already applied live; this PR makes the change permanent so the next `kubectl apply` doesn't regress it.