### PR TITLE
fix(sabnzbd): sync pvc + snapshot policy to match migrated gluetun-config

### DIFF
--- a/k3s/applications/sabnzbd/pvc.yaml
+++ b/k3s/applications/sabnzbd/pvc.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: csi-hostpath-sc
+  storageClassName: longhorn   # was: csi-hostpath-sc
   resources:
     requests:
       storage: 1Gi

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd-gluetun.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd-gluetun.yaml
@@ -14,7 +14,7 @@ spec:
         name: gluetun-config
       sourcePathOverride: /gluetun
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  volumeSnapshotClassName: longhorn-snapclass   # was: csi-hostpath-snapclass
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
Fixes Flux `apps` Kustomization failing with:

```
PersistentVolumeClaim/sabnzbd/gluetun-config dry-run failed (Invalid): spec is immutable after creation
```

The gluetun-config PVC was successfully migrated to `longhorn` (via operator-applied Restore CR), but the GitOps manifest and snapshot policy still referenced `csi-hostpath-sc` / `csi-hostpath-snapclass`. This drift caused every Flux reconcile to fail with an immutability error.

Changes:
- `k3s/applications/sabnzbd/pvc.yaml`: `gluetun-config` storageClassName: `csi-hostpath-sc` → `longhorn`
  - `sabnzbd-config` block is intentionally untouched (deferred per user)
  - `sabnzbd-downloads` (`local-path`) and `sabnzbd-media` (`smb-media`) untouched
- `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd-gluetun.yaml`: volumeSnapshotClassName: `csi-hostpath-snapclass` → `longhorn-snapclass`

Pattern mirrors the headlamp/portainer (#309/#310) and qbittorrent snapshot policy (#318) changes.