### PR TITLE
docs(migration): add superpowers spec + plan for csi-hostpath → longhorn migration

### DIFF
--- a/docs/superpowers/plans/2026-08-20-finish-csi-hostpath-to-longhorn-migration.md
+++ b/docs/superpowers/plans/2026-08-20-finish-csi-hostpath-to-longhorn-migration.md
@@ -27,7 +27,13 @@ These commands MUST pass before marking any task complete. Run them, read the ou
 
 ```bash
 # Per-app snapshot health (after Task 0 and before each migration task)
-kubectl get snapshots -n <ns> -l kopiur.home-operations.com/policy-name=<policy> --sort-by=.metadata.creationTimestamp | tail -5
+# NOTE: kopiur Snapshot CRs use label `kopiur.home-operations.com/config=<policy>`
+# (not `policy-name` as documented elsewhere) and `status.phase` (not
+# `ReadyToUse`). Mapped from VolumeSnapshot convention.
+kubectl get snapshots -n <ns> --selector=kopiur.home-operations.com/config=<policy> --sort-by=.metadata.creationTimestamp | tail -5
+
+# To check ReadyToUse status, inspect:
+kubectl get snapshots -n <ns> --selector=kopiur.home-operations.com/config=<policy> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}' | tail -5
 
 # Per-app Restore CR status (after Commit 1 of each migration task)
 kubectl get restore -n <ns> -o jsonpath='{.items[*].status.phase}{"\n"}'
@@ -67,12 +73,12 @@ for ns in media media media pihole authentik qbittorrent sabnzbd tdarr; do
   esac
   for app in $apps; do
     echo "=== $ns / $app ==="
-    kubectl get snapshots -n "$ns" -l kopiur.home-operations.com/policy-name="$app" --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -3
+    kubectl get snapshots -n "$ns" --selector=kopiur.home-operations.com/config="$app" --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -3
   done
 done
 ```
 
-Note any app where the most recent snapshot is missing, `status: ReadyToUse: false`, or older than 2 hours.
+Note any app where the most recent snapshot is missing, `status.phase != Succeeded`, or older than 2 hours. (kopiur Snapshot uses `status.phase` not `ReadyToUse`.)
 
 - [ ] **Step 2: Check Restore CR conflicts**
 
@@ -97,10 +103,10 @@ Expected: All pods Running. If any are CrashLoopBackOff or Pending, pause and fi
 
 For each of the 8 apps, write down:
 - Most recent snapshot creation timestamp
-- Most recent snapshot ReadyToUse status
+- Most recent snapshot `status.phase` (Succeeded/Failed)
 - Backup policy name (for use in Task N Restore CRs)
 
-Expected outcome: each app has a recent (≤2h old) ReadyToUse snapshot.
+Expected outcome: each app has a recent (≤2h old) `Succeeded` snapshot.
 
 If any app has a missing/failed/old snapshot:
 - Investigate the snapshot policy: `kubectl get snapshotpolicy -n <ns> <policy> -o yaml`
@@ -333,8 +339,9 @@ Wait for the next hourly snapshot and verify it succeeds:
 # Find next scheduled time:
 kubectl get snapshotpolicy -n media prowlarr -o jsonpath='{.spec.schedule}{"\n"}'
 # Wait until that time, then:
-kubectl get snapshots -n media -l kopiur.home-operations.com/policy-name=prowlarr --sort-by=.metadata.creationTimestamp | tail -2
-# Expected: status shows ReadyToUse: True on the new snapshot
+kubectl get snapshots -n media --selector=kopiur.home-operations.com/config=prowlarr --sort-by=.metadata.creationTimestamp | tail -2
+# Expected: status.phase shows Succeeded on the new snapshot (NOT ReadyToUse — kopiur uses phase)
+kubectl get snapshots -n media --selector=kopiur.home-operations.com/config=prowlarr -o jsonpath='{range .items[-2:]}{.metadata.name}{"\t"}{.status.phase}{"\n"}'
 ```
 
 - [ ] **Step 6: Cleanup follow-up — verify kustomization.yaml doesn't list migration/**
@@ -1867,14 +1874,14 @@ for ns in media pihole authentik qbittorrent sabnzbd tdarr; do
   echo "=== $ns ==="
   for policy in $(kubectl get snapshotpolicy -n "$ns" -o name | sed 's|.*/||'); do
     echo "  $policy:"
-    kubectl get snapshots -n "$ns" -l kopiur.home-operations.com/policy-name="$policy" --sort-by=.metadata.creationTimestamp | tail -2
+    kubectl get snapshots -n "$ns" --selector=kopiur.home-operations.com/config="$policy" --sort-by=.metadata.creationTimestamp | tail -2
   done
 done
 ```
 
 (prowlarr/radarr/sonarr all live in media; iterate their policies)
 
-Expected: each app's most recent snapshot shows `ReadyToUse: True` with a recent creation timestamp, using `longhorn-snapclass`.
+Expected: each app's most recent snapshot shows `status.phase: Succeeded` with a recent creation timestamp, using `longhorn-snapclass`.
 
 - [ ] **Step 5: Document the migration**
 

--- a/docs/superpowers/plans/2026-08-20-finish-csi-hostpath-to-longhorn-migration.md
+++ b/docs/superpowers/plans/2026-08-20-finish-csi-hostpath-to-longhorn-migration.md
@@ -1,0 +1,1998 @@
+# Finish csi-hostpath-sc → Longhorn PVC Migration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the remaining 11 csi-hostpath-sc PVCs across 8 apps to Longhorn storage class with zero data loss, using the established Restore CR pattern.
+
+**Architecture:** One PR per app (8 PRs total). Each PR contains 3 ordered commits: (1) operator-applied Restore CR that copies data from kopiur snapshot to a fresh longhorn PVC, (2) storageClassName change in the source manifest (HelmRelease or pvc.yaml), (3) snapshot policy snapclass update to longhorn-snapclass. Apps execute in easy-first batches (media → qbittorrent/sabnzbd → tdarr → pihole/authentik).
+
+**Tech Stack:** Kubernetes 1.32, k3s, Flux v2, HelmRelease, Helm v3, Kustomize, kopiur (snapshot/restore operator), Longhorn CSI, csi-hostpath-snapclass → longhorn-snapclass, SOPS-encrypted secrets.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md`
+
+## Global Constraints
+
+1. **No data loss.** Every migration preserves data via kopiur snapshot → Restore CR → fresh longhorn PVC.
+2. **Backup health must be verified before each Restore CR.** If latest snapshot for an app is missing/failed, pause and fix kopiur/policy first.
+3. **Restore CR is operator-applied (`kubectl apply -f`), never listed in `kustomization.yaml` resources.** Listing it there causes Flux to reapply it on every reconcile and fights the HelmRelease-managed PVC.
+4. **Migration PVCs in `migration/` directories that have served their purpose must be removed from `kustomization.yaml` resources lists** after the migration succeeds (portainer #312 lesson). Imperative PVC manifests with stale storageClassName conflict with the chart-managed PVC.
+5. **All work happens on a feature branch in a worktree**, not on master. Per AGENTS.md: never offer completed work on master unless prompted.
+6. **Each PR must reference the issue/PR it closes or relates to** in the body, and link back to the spec doc.
+7. **Commit messages follow Conventional Commits:** `feat(<scope>): <description>`, `fix(<scope>): <description>`, `docs(<scope>): <description>`.
+8. **PR titles mirror the squash commit message** for clean history.
+
+## Verification Standards
+
+These commands MUST pass before marking any task complete. Run them, read the output, confirm.
+
+```bash
+# Per-app snapshot health (after Task 0 and before each migration task)
+kubectl get snapshots -n <ns> -l kopiur.home-operations.com/policy-name=<policy> --sort-by=.metadata.creationTimestamp | tail -5
+
+# Per-app Restore CR status (after Commit 1 of each migration task)
+kubectl get restore -n <ns> -o jsonpath='{.items[*].status.phase}{"\n"}'
+
+# Per-app PVC state (after Commit 1 and Commit 2)
+kubectl get pvc -n <ns> <pvc> -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+
+# Per-app HelmRelease (HelmRelease apps only)
+kubectl get helmrelease -n <ns> <hr-name>
+
+# Per-app pod health (after Commit 2)
+kubectl get pods -n <ns> -o wide
+
+# Per-app snapshot policy snapclass (after Commit 3)
+kubectl get snapshotpolicy -n <ns> <policy> -o jsonpath='{.spec.volumeSnapshotClassName}{"\n"}'
+```
+
+---
+
+## Task 0: Preflight — verify backup health across all 8 apps
+
+**Why first:** Per the constraint that backup health must be verified before each Restore CR. If snapshots are failing for any app, that app's migration must wait. This task surfaces the baseline before any work begins.
+
+**Files:** None modified — read-only verification.
+
+**Interfaces:** Produces a status report: which apps have working recent snapshots, which need backup-system fixes first.
+
+- [ ] **Step 1: Check most recent snapshot for each of the 8 namespaces**
+
+Run for each app namespace (`prowlarr`/`radarr`/`sonarr` use namespace `media`; `pihole` uses `pihole`; `authentik` uses `authentik`; `qbittorrent`, `sabnzbd`, `tdarr` use their own namespaces):
+
+```bash
+for ns in media media media pihole authentik qbittorrent sabnzbd tdarr; do
+  case "$ns" in
+    media) apps="prowlarr radarr sonarr" ;;
+    *) apps="$ns" ;;
+  esac
+  for app in $apps; do
+    echo "=== $ns / $app ==="
+    kubectl get snapshots -n "$ns" -l kopiur.home-operations.com/policy-name="$app" --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -3
+  done
+done
+```
+
+Note any app where the most recent snapshot is missing, `status: ReadyToUse: false`, or older than 2 hours.
+
+- [ ] **Step 2: Check Restore CR conflicts**
+
+Verify no Restore CRs are already in-flight that could conflict:
+
+```bash
+kubectl get restore -A 2>/dev/null
+```
+
+Expected: empty list, or only Completed-phase Restore CRs from prior migrations (gatus, headlamp, portainer, monitoring).
+
+- [ ] **Step 3: Check Flux and kopiur-system health**
+
+```bash
+kubectl get pods -n flux-system
+kubectl get pods -n kopiur-system
+```
+
+Expected: All pods Running. If any are CrashLoopBackOff or Pending, pause and fix.
+
+- [ ] **Step 4: Document the per-app snapshot status**
+
+For each of the 8 apps, write down:
+- Most recent snapshot creation timestamp
+- Most recent snapshot ReadyToUse status
+- Backup policy name (for use in Task N Restore CRs)
+
+Expected outcome: each app has a recent (≤2h old) ReadyToUse snapshot.
+
+If any app has a missing/failed/old snapshot:
+- Investigate the snapshot policy: `kubectl get snapshotpolicy -n <ns> <policy> -o yaml`
+- Check mover Jobs: `kubectl get jobs -n <ns> -l app=kopiur-mover`
+- Common cause (per past session S108): CSI hostpath provisioner timing out on restore operations; need a separate fix PR before proceeding
+- Pause this plan; do NOT proceed to migration tasks until backup health is restored
+
+- [ ] **Step 5: Commit preflight notes (no code change)**
+
+If you recorded findings in a markdown file, commit it to a feature branch for tracking:
+
+```bash
+git checkout -b feat/migration-preflight-notes
+# ...create docs/operations/2026-08-20-migration-preflight.md with findings...
+git add docs/operations/2026-08-20-migration-preflight.md
+git commit -m "docs(migration): preflight backup health check for csi-hostpath → longhorn batch"
+```
+
+(If preflight is clean with no findings worth committing, skip this step.)
+
+---
+
+## Batch 1: media namespace (prowlarr, radarr, sonarr)
+
+These are the simplest migrations: single PVC each, LinuxServer PUID 1027 PGID 100, no privileged mover namespace annotation needed. Each migration is its own PR.
+
+---
+
+### Task 1: prowlarr migration
+
+**Files:**
+- Create: `k3s/applications/prowlarr/migration/restore.yaml`
+- Modify: `k3s/applications/prowlarr/pvc.yaml:1-12`
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-prowlarr.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `prowlarr` in namespace `media`, source PVC `prowlarr-config` (2Gi)
+- Produces: longhorn PVC `prowlarr-config` bound and populated; snapshot policy using `longhorn-snapclass`
+
+- [ ] **Step 1: Create worktree for prowlarr PR**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/prowlarr-longhorn -b feat/prowlarr-longhorn origin/master
+cd .worktrees/prowlarr-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CR**
+
+Create `k3s/applications/prowlarr/migration/restore.yaml` with this content (adapted from headlamp canonical example at `k3s/applications/headlamp/migration/restore.yaml`):
+
+```yaml
+---
+# Restore CR for the prowlarr csi-hostpath-sc → longhorn migration.
+#
+# Operator-applied (NOT in kustomization.yaml). Run with `kubectl apply -f`
+# once after scaling prowlarr to 0 replicas. Matches the pattern in
+# gatus/migration/, headlamp/migration/, portainer/migration/.
+#
+# Delete manually if desired:
+#   kubectl delete restore -n media prowlarr-longhorn-migration
+#
+# Pre-conditions (operator must do before applying):
+#   - prowlarr deployment scaled to 0 replicas (releases RWO on old PVC).
+#   - Stale csi-hostpath-snapclass VolumeSnapshots cleared (they hold
+#     pvc-as-source-protection finalizers on the source PVC).
+#   - The old csi-hostpath-sc PVC `prowlarr-config` deleted (Restore's
+#     target.pvc would otherwise hit a name conflict; data is safe in kopia).
+#
+# Post-conditions:
+#   - PVC `prowlarr-config` exists, bound on `longhorn`, populated with snapshot.
+#   - prowlarr deployment scaled back to 1 replica binds to longhorn PVC.
+#   - Restored files are owned by UID 1027 GID 100 (LinuxServer prowlarr
+#     PUID/PGID), matching the policy's recorded snapshot metadata.
+#
+# credentialProjection: REQUIRED. ClusterRepository `nas` secret lives in
+# kopiur-system, not media. Without `credentialProjection.enabled: true`
+# the Restore stalls with MissingCredentialsSecret.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: prowlarr-longhorn-migration
+  namespace: media
+spec:
+  source:
+    fromPolicy:
+      name: prowlarr
+      offset: 0
+  target:
+    pvc:
+      name: prowlarr-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+
+```bash
+git add k3s/applications/prowlarr/migration/restore.yaml
+git commit -m "feat(prowlarr): add Restore CR for csi-hostpath-sc → longhorn migration"
+```
+
+- [ ] **Step 3: Apply Restore CR imperatively (operator action)**
+
+Pre-conditions:
+```bash
+kubectl scale deploy/prowlarr -n media --replicas=0
+# Wait for pod to terminate:
+kubectl wait pod -l app=prowlarr -n media --for=delete --timeout=60s
+# Clear stale VolumeSnapshots that hold pvc-as-source-protection finalizers:
+kubectl get volumesnapshot -n media -l kopiur.home-operations.com/policy-name=prowlarr
+# If any are stuck Pending without status, patch out the finalizer:
+# kubectl patch volumesnapshot <name> -n media --type merge -p '{"metadata":{"finalizers":null}}'
+# Delete the old PVC:
+kubectl delete pvc -n media prowlarr-config
+```
+
+Apply:
+```bash
+kubectl apply -f k3s/applications/prowlarr/migration/restore.yaml
+```
+
+Wait for completion:
+```bash
+kubectl get restore -n media prowlarr-longhorn-migration -w
+# Wait until phase=Completed (typically 2-10 minutes for 2Gi PVC)
+```
+
+Verify PVC:
+```bash
+kubectl get pvc -n media prowlarr-config -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+```
+
+If the Restore stalls in `Pending` or fails, see the **Failure handling** section below.
+
+- [ ] **Step 4: Write Commit 2 — pvc.yaml storageClassName change**
+
+Edit `k3s/applications/prowlarr/pvc.yaml`. Change the `prowlarr-config` PVC block's `storageClassName` from `csi-hostpath-sc` to `longhorn`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prowlarr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn   # was: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/prowlarr/pvc.yaml
+git commit -m "feat(prowlarr): switch prowlarr-config storageClassName to longhorn"
+```
+
+Flux reconciles within ~1m. Verify:
+```bash
+kubectl get pvc -n media prowlarr-config -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+```
+
+Scale prowlarr back to 1 replica:
+```bash
+kubectl scale deploy/prowlarr -n media --replicas=1
+kubectl wait pod -l app=prowlarr -n media --for=condition=Ready --timeout=120s
+```
+
+Verify the app is functional:
+```bash
+kubectl get pods -n media -l app=prowlarr
+# Expected: 1/1 Running
+```
+
+Hit the WebUI to confirm no data loss (the user's existing indexers, apps, settings should all be present):
+```bash
+# port-forward or use ingress depending on local DNS; if curl is available:
+curl -sk https://prowlarr.homelab.properties/ping | head
+```
+
+- [ ] **Step 5: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-prowlarr.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`:
+
+```yaml
+  copyMethod: Snapshot
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/prowlarr-longhorn. The prowlarr-config PVC is now on the `longhorn`
+  # StorageClass (PR prepping the move in pvc.yaml), so the CSI snapshot
+  # must use the matching Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
+```
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-prowlarr.yaml
+git commit -m "feat(kopiur): switch prowlarr snapshot policy to longhorn-snapclass"
+```
+
+Verify:
+```bash
+kubectl get snapshotpolicy -n media prowlarr -o jsonpath='{.spec.volumeSnapshotClassName}{"\n"}'
+# Expected: longhorn-snapclass
+```
+
+Wait for the next hourly snapshot and verify it succeeds:
+```bash
+# Find next scheduled time:
+kubectl get snapshotpolicy -n media prowlarr -o jsonpath='{.spec.schedule}{"\n"}'
+# Wait until that time, then:
+kubectl get snapshots -n media -l kopiur.home-operations.com/policy-name=prowlarr --sort-by=.metadata.creationTimestamp | tail -2
+# Expected: status shows ReadyToUse: True on the new snapshot
+```
+
+- [ ] **Step 6: Cleanup follow-up — verify kustomization.yaml doesn't list migration/**
+
+```bash
+cat k3s/applications/prowlarr/kustomization.yaml
+```
+
+If the resources list includes `migration/restore.yaml`, `migration/pvc.yaml`, or any other migration artifact, remove those lines. (For prowlarr specifically, the kustomization does not currently list migration/, so this should be a no-op. Verify and move on.)
+
+If a cleanup change is needed, commit:
+```bash
+git add k3s/applications/prowlarr/kustomization.yaml
+git commit -m "fix(prowlarr): remove migration files from kustomization resources"
+```
+
+- [ ] **Step 7: Push branch and open PR**
+
+```bash
+git push -u origin feat/prowlarr-longhorn
+gh pr create --base master --head feat/prowlarr-longhorn \
+  --title "feat(prowlarr): migrate prowlarr-config PVC from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Closes the csi-hostpath-sc cleanup for prowlarr. See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md.
+
+Pattern matches gatus #307, headlamp #309, portainer #310/#312, monitoring #311.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+After merge, Flux reconciles within ~1m. Verify:
+```bash
+kubectl get pvc -n media prowlarr-config
+kubectl get pods -n media -l app=prowlarr
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/prowlarr-longhorn
+git branch -d feat/prowlarr-longhorn
+```
+
+---
+
+### Task 2: radarr migration
+
+**Files:**
+- Create: `k3s/applications/radarr/migration/restore.yaml`
+- Modify: `k3s/applications/radarr/pvc.yaml:1-12`
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-radarr.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `radarr` in namespace `media`, source PVC `radarr-config` (2Gi)
+- Produces: longhorn PVC `radarr-config` bound and populated; snapshot policy using `longhorn-snapclass`
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/radarr-longhorn -b feat/radarr-longhorn origin/master
+cd .worktrees/radarr-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CR**
+
+Create `k3s/applications/radarr/migration/restore.yaml` with this content (mirror of prowlarr's restore.yaml; only the names differ):
+
+```yaml
+---
+# Restore CR for the radarr csi-hostpath-sc → longhorn migration.
+# Operator-applied. See prowlarr/migration/restore.yaml for the full header
+# rationale; same pattern, same pre/post-conditions.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: radarr-longhorn-migration
+  namespace: media
+spec:
+  source:
+    fromPolicy:
+      name: radarr
+      offset: 0
+  target:
+    pvc:
+      name: radarr-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/radarr/migration/restore.yaml
+git commit -m "feat(radarr): add Restore CR for csi-hostpath-sc → longhorn migration"
+```
+
+- [ ] **Step 3: Apply Restore CR imperatively**
+
+```bash
+kubectl scale deploy/radarr -n media --replicas=0
+kubectl wait pod -l app=radarr -n media --for=delete --timeout=60s
+# Clear stale VolumeSnapshots if any:
+kubectl get volumesnapshot -n media -l kopiur.home-operations.com/policy-name=radarr
+kubectl delete pvc -n media radarr-config
+kubectl apply -f k3s/applications/radarr/migration/restore.yaml
+kubectl get restore -n media radarr-longhorn-migration -w
+# Wait for phase=Completed
+kubectl get pvc -n media radarr-config -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+```
+
+- [ ] **Step 4: Write Commit 2 — pvc.yaml storageClassName change**
+
+Edit `k3s/applications/radarr/pvc.yaml`. Change `radarr-config` PVC block's `storageClassName` from `csi-hostpath-sc` to `longhorn`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radarr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn   # was: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/radarr/pvc.yaml
+git commit -m "feat(radarr): switch radarr-config storageClassName to longhorn"
+```
+
+Flux reconciles. Scale radarr back:
+```bash
+kubectl get pvc -n media radarr-config -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+kubectl scale deploy/radarr -n media --replicas=1
+kubectl wait pod -l app=radarr -n media --for=condition=Ready --timeout=120s
+```
+
+Verify WebUI:
+```bash
+curl -sk https://radarr.homelab.properties/ping | head
+```
+
+- [ ] **Step 5: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-radarr.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-radarr.yaml
+git commit -m "feat(kopiur): switch radarr snapshot policy to longhorn-snapclass"
+```
+
+Verify:
+```bash
+kubectl get snapshotpolicy -n media radarr -o jsonpath='{.spec.volumeSnapshotClassName}{"\n"}'
+# Expected: longhorn-snapclass
+```
+
+- [ ] **Step 6: Cleanup follow-up**
+
+```bash
+cat k3s/applications/radarr/kustomization.yaml
+```
+
+If migration/ files are listed in resources, remove them and commit. Otherwise no-op.
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/radarr-longhorn
+gh pr create --base master --head feat/radarr-longhorn \
+  --title "feat(radarr): migrate radarr-config PVC from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Same pattern as prowlarr (this PR), headlamp #309, portainer #310/#312. See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+Verify:
+```bash
+kubectl get pvc -n media radarr-config
+kubectl get pods -n media -l app=radarr
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/radarr-longhorn
+git branch -d feat/radarr-longhorn
+```
+
+---
+
+### Task 3: sonarr migration
+
+**Files:**
+- Create: `k3s/applications/sonarr/migration/restore.yaml`
+- Modify: `k3s/applications/sonarr/pvc.yaml:1-12`
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sonarr.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `sonarr` in namespace `media`, source PVC `sonarr-config` (2Gi)
+- Produces: longhorn PVC `sonarr-config` bound and populated; snapshot policy using `longhorn-snapclass`
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/sonarr-longhorn -b feat/sonarr-longhorn origin/master
+cd .worktrees/sonarr-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CR**
+
+Create `k3s/applications/sonarr/migration/restore.yaml`:
+
+```yaml
+---
+# Restore CR for the sonarr csi-hostpath-sc → longhorn migration.
+# Operator-applied. Same pattern as prowlarr/radarr (this batch), headlamp #309,
+# portainer #310/#312. See prowlarr/migration/restore.yaml for the full header.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: sonarr-longhorn-migration
+  namespace: media
+spec:
+  source:
+    fromPolicy:
+      name: sonarr
+      offset: 0
+  target:
+    pvc:
+      name: sonarr-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/sonarr/migration/restore.yaml
+git commit -m "feat(sonarr): add Restore CR for csi-hostpath-sc → longhorn migration"
+```
+
+- [ ] **Step 3: Apply Restore CR imperatively**
+
+```bash
+kubectl scale deploy/sonarr -n media --replicas=0
+kubectl wait pod -l app=sonarr -n media --for=delete --timeout=60s
+kubectl get volumesnapshot -n media -l kopiur.home-operations.com/policy-name=sonarr
+kubectl delete pvc -n media sonarr-config
+kubectl apply -f k3s/applications/sonarr/migration/restore.yaml
+kubectl get restore -n media sonarr-longhorn-migration -w
+# Wait for phase=Completed
+kubectl get pvc -n media sonarr-config -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+```
+
+- [ ] **Step 4: Write Commit 2 — pvc.yaml storageClassName change**
+
+Edit `k3s/applications/sonarr/pvc.yaml`. Change `sonarr-config` PVC block's `storageClassName` from `csi-hostpath-sc` to `longhorn`.
+
+Stage and commit:
+```bash
+git add k3s/applications/sonarr/pvc.yaml
+git commit -m "feat(sonarr): switch sonarr-config storageClassName to longhorn"
+```
+
+Scale sonarr back:
+```bash
+kubectl scale deploy/sonarr -n media --replicas=1
+kubectl wait pod -l app=sonarr -n media --for=condition=Ready --timeout=120s
+curl -sk https://sonarr.homelab.properties/ping | head
+```
+
+- [ ] **Step 5: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sonarr.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sonarr.yaml
+git commit -m "feat(kopiur): switch sonarr snapshot policy to longhorn-snapclass"
+```
+
+- [ ] **Step 6: Cleanup follow-up**
+
+Verify `k3s/applications/sonarr/kustomization.yaml` doesn't list migration/. Remove if it does, commit fix.
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/sonarr-longhorn
+gh pr create --base master --head feat/sonarr-longhorn \
+  --title "feat(sonarr): migrate sonarr-config PVC from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Same pattern as prowlarr/radarr (this batch), headlamp #309, portainer #310/#312.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+```bash
+kubectl get pvc -n media sonarr-config
+kubectl get pods -n media -l app=sonarr
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/sonarr-longhorn
+git branch -d feat/sonarr-longhorn
+```
+
+---
+
+## Batch 1 verification gate
+
+After all three of prowlarr, radarr, sonarr are merged and Flux reconciled:
+
+```bash
+kubectl get pvc -n media -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+# Expected: all three config PVCs show storageClassName=longhorn, phase=Bound
+kubectl get pods -n media -l 'app in (prowlarr,radarr,sonarr)'
+# Expected: all Running
+```
+
+If any migration fails, **stop** before starting Batch 2. Re-read Task N's failure-handling section.
+
+---
+
+## Batch 2: qbittorrent + sabnzbd (multi-PVC raw apps)
+
+These apps have 2 PVCs each (config + gluetun-config). Both must migrate in lockstep — gluetun-config must be ready before the app pod starts (it's mounted into the gluetun sidecar which fronts the main container).
+
+Each migration is its own PR, but each PR has 2 Restore CRs.
+
+---
+
+### Task 4: qbittorrent migration (2 PVCs)
+
+**Files:**
+- Create: `k3s/applications/qbittorrent/migration/restore.yaml` (containing 2 Restore CRs)
+- Modify: `k3s/applications/qbittorrent/pvc.yaml:1-12` and `:21-28` (two PVC blocks)
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-qbittorrent.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `qbittorrent` in namespace `qbittorrent`, source PVCs `qbittorrent-config` (5Gi) + `gluetun-config` (1Gi)
+- Produces: longhorn PVCs `qbittorrent-config` + `gluetun-config` bound and populated; snapshot policy using `longhorn-snapclass`
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/qbittorrent-longhorn -b feat/qbittorrent-longhorn origin/master
+cd .worktrees/qbittorrent-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CRs (both PVCs in one file)**
+
+Create `k3s/applications/qbittorrent/migration/restore.yaml` with TWO Restore CRs in the same file (separated by `---`):
+
+```yaml
+---
+# Restore CR for the qbittorrent-config csi-hostpath-sc → longhorn migration.
+# Operator-applied. Same pattern as prowlarr (this batch), headlamp #309.
+# See prowlarr/migration/restore.yaml for the full header rationale.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: qbittorrent-config-longhorn-migration
+  namespace: qbittorrent
+spec:
+  source:
+    fromPolicy:
+      name: qbittorrent
+      offset: 0
+  target:
+    pvc:
+      name: qbittorrent-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 5Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+---
+# Restore CR for the gluetun-config csi-hostpath-sc → longhorn migration.
+# gluetun-config must be ready before qbittorrent deployment scales up —
+# the gluetun sidecar's /gluetun mount must be valid or the init fails.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: gluetun-config-longhorn-migration
+  namespace: qbittorrent
+spec:
+  source:
+    fromPolicy:
+      name: qbittorrent
+      offset: 0
+  target:
+    pvc:
+      name: gluetun-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/qbittorrent/migration/restore.yaml
+git commit -m "feat(qbittorrent): add Restore CRs for qbittorrent-config + gluetun-config migration"
+```
+
+- [ ] **Step 3: Apply Restore CRs imperatively (both)**
+
+```bash
+kubectl scale deploy/qbittorrent -n qbittorrent --replicas=0
+kubectl wait pod -l app=qbittorrent -n qbittorrent --for=delete --timeout=60s
+kubectl get volumesnapshot -n qbittorrent -l kopiur.home-operations.com/policy-name=qbittorrent
+# Clear stale VolumeSnapshots with pvc-as-source-protection finalizers if any
+kubectl delete pvc -n qbittorrent qbittorrent-config
+kubectl delete pvc -n qbittorrent gluetun-config
+kubectl apply -f k3s/applications/qbittorrent/migration/restore.yaml
+```
+
+Watch both Restore CRs complete:
+```bash
+kubectl get restore -n qbittorrent -w
+# Wait until both phases are Completed
+```
+
+Verify both PVCs:
+```bash
+kubectl get pvc -n qbittorrent -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+# Expected: both show storageClassName=longhorn, phase=Bound
+```
+
+- [ ] **Step 4: Write Commit 2 — pvc.yaml storageClassName changes (both PVCs)**
+
+Edit `k3s/applications/qbittorrent/pvc.yaml`. Change BOTH `qbittorrent-config` and `gluetun-config` PVC blocks' `storageClassName` from `csi-hostpath-sc` to `longhorn`. Leave the `qbittorrent-media` PV/PVC block alone (it's smb-media, not csi-hostpath-sc).
+
+After edit:
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qbittorrent-config
+  namespace: qbittorrent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn   # was: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gluetun-config
+  namespace: qbittorrent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn   # was: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 1Gi
+---
+# (smb-media PV/PVC blocks below — unchanged)
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/qbittorrent/pvc.yaml
+git commit -m "feat(qbittorrent): switch qbittorrent-config + gluetun-config storageClassName to longhorn"
+```
+
+Verify Flux reconciled and scale qbittorrent back:
+```bash
+kubectl get pvc -n qbittorrent -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+kubectl scale deploy/qbittorrent -n qbittorrent --replicas=1
+kubectl wait pod -l app=qbittorrent -n qbittorrent --for=condition=Ready --timeout=180s
+```
+
+Verify both PVCs are mounted by the pod:
+```bash
+kubectl describe pod -l app=qbittorrent -n qbittorrent | grep -A 2 "Volumes:"
+# Expected: qbittorrent-config and gluetun-config both listed
+```
+
+Verify VPN tunnel is up:
+```bash
+kubectl logs -l app=qbittorrent -n qbittorrent -c gluetun | tail -20
+# Expected: VPN connection established lines
+```
+
+- [ ] **Step 5: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-qbittorrent.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-qbittorrent.yaml
+git commit -m "feat(kopiur): switch qbittorrent snapshot policy to longhorn-snapclass"
+```
+
+- [ ] **Step 6: Cleanup follow-up**
+
+Check `k3s/applications/qbittorrent/kustomization.yaml`:
+```bash
+grep -E "migration/" k3s/applications/qbittorrent/kustomization.yaml
+```
+
+If migration/ files are listed in resources, remove them. Commit fix if changed.
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/qbittorrent-longhorn
+gh pr create --base master --head feat/qbittorrent-longhorn \
+  --title "feat(qbittorrent): migrate qbittorrent-config + gluetun-config PVCs from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Multi-PVC migration in one PR (matches monitoring #311 pattern). See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+```bash
+kubectl get pvc -n qbittorrent
+kubectl get pods -n qbittorrent -l app=qbittorrent
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/qbittorrent-longhorn
+git branch -d feat/qbittorrent-longhorn
+```
+
+---
+
+### Task 5: sabnzbd migration (2 PVCs)
+
+**Files:**
+- Create: `k3s/applications/sabnzbd/migration/restore.yaml` (containing 2 Restore CRs)
+- Modify: `k3s/applications/sabnzbd/pvc.yaml` (two PVC blocks; skip the smb-media PV/PVC block)
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `sabnzbd` in namespace `sabnzbd`, source PVCs `sabnzbd-config` (5Gi) + `gluetun-config` (1Gi)
+- Produces: longhorn PVCs `sabnzbd-config` + `gluetun-config` bound and populated; snapshot policy using `longhorn-snapclass`
+
+**Special note:** sabnzbd-downloads is on local-path, NOT csi-hostpath-sc. Out of scope here. Leave it alone. Only `sabnzbd-config` and `gluetun-config` migrate.
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/sabnzbd-longhorn -b feat/sabnzbd-longhorn origin/master
+cd .worktrees/sabnzbd-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CRs (both PVCs in one file)**
+
+Create `k3s/applications/sabnzbd/migration/restore.yaml` with TWO Restore CRs:
+
+```yaml
+---
+# Restore CR for the sabnzbd-config csi-hostpath-sc → longhorn migration.
+# Operator-applied. Same pattern as qbittorrent (multi-PVC). See
+# qbittorrent/migration/restore.yaml for the full header.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: sabnzbd-config-longhorn-migration
+  namespace: sabnzbd
+spec:
+  source:
+    fromPolicy:
+      name: sabnzbd
+      offset: 0
+  target:
+    pvc:
+      name: sabnzbd-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 5Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+---
+# Restore CR for the gluetun-config csi-hostpath-sc → longhorn migration.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: sabnzbd-gluetun-config-longhorn-migration
+  namespace: sabnzbd
+spec:
+  source:
+    fromPolicy:
+      name: sabnzbd
+      offset: 0
+  target:
+    pvc:
+      name: gluetun-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/sabnzbd/migration/restore.yaml
+git commit -m "feat(sabnzbd): add Restore CRs for sabnzbd-config + gluetun-config migration"
+```
+
+- [ ] **Step 3: Apply Restore CRs imperatively (both)**
+
+```bash
+kubectl scale deploy/sabnzbd -n sabnzbd --replicas=0
+kubectl wait pod -l app=sabnzbd -n sabnzbd --for=delete --timeout=60s
+kubectl get volumesnapshot -n sabnzbd -l kopiur.home-operations.com/policy-name=sabnzbd
+kubectl delete pvc -n sabnzbd sabnzbd-config
+kubectl delete pvc -n sabnzbd gluetun-config
+kubectl apply -f k3s/applications/sabnzbd/migration/restore.yaml
+kubectl get restore -n sabnzbd -w
+# Wait until both phases are Completed
+kubectl get pvc -n sabnzbd -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+# Expected: sabnzbd-config and gluetun-config both show longhorn, Bound
+```
+
+- [ ] **Step 4: Write Commit 2 — pvc.yaml storageClassName changes (both PVCs)**
+
+Edit `k3s/applications/sabnzbd/pvc.yaml`. Change BOTH `sabnzbd-config` and `gluetun-config` PVC blocks' `storageClassName` from `csi-hostpath-sc` to `longhorn`. Leave `sabnzbd-media` PV/PVC block alone (smb-media).
+
+Stage and commit:
+```bash
+git add k3s/applications/sabnzbd/pvc.yaml
+git commit -m "feat(sabnzbd): switch sabnzbd-config + gluetun-config storageClassName to longhorn"
+```
+
+Verify and scale sabnzbd back:
+```bash
+kubectl get pvc -n sabnzbd -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+kubectl scale deploy/sabnzbd -n sabnzbd --replicas=1
+kubectl wait pod -l app=sabnzbd -n sabnzbd --for=condition=Ready --timeout=180s
+kubectl logs -l app=sabnzbd -n sabnzbd -c gluetun | tail -20
+# Expected: VPN connection established
+```
+
+- [ ] **Step 5: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd.yaml
+git commit -m "feat(kopiur): switch sabnzbd snapshot policy to longhorn-snapclass"
+```
+
+- [ ] **Step 6: Cleanup follow-up**
+
+Check `k3s/applications/sabnzbd/kustomization.yaml`:
+```bash
+grep -E "migration/" k3s/applications/sabnzbd/kustomization.yaml
+```
+
+If migration/ files are listed in resources, remove them and commit fix.
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/sabnzbd-longhorn
+gh pr create --base master --head feat/sabnzbd-longhorn \
+  --title "feat(sabnzbd): migrate sabnzbd-config + gluetun-config PVCs from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Multi-PVC migration in one PR (matches monitoring #311 pattern). Note: sabnzbd-downloads is local-path and stays out of scope.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+```bash
+kubectl get pvc -n sabnzbd
+kubectl get pods -n sabnzbd -l app=sabnzbd
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/sabnzbd-longhorn
+git branch -d feat/sabnzbd-longhorn
+```
+
+---
+
+## Batch 2 verification gate
+
+```bash
+kubectl get pvc -n qbittorrent -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+kubectl get pvc -n sabnzbd -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+# Expected: config + gluetun-config both longhorn/Bound for each namespace; media PV/PVC stays smb-media
+kubectl get pods -n qbittorrent -l app=qbittorrent
+kubectl get pods -n sabnzbd -l app=sabnzbd
+# Expected: both Running, VPN tunnel up (check gluetun logs)
+```
+
+If any migration fails, **stop** before starting Batch 3.
+
+---
+
+## Batch 3: tdarr (multi-PVC raw app + privileged mover)
+
+Namespace `tdarr` already carries `kopiur.home-operations.com/privileged-movers: "true"` annotation (verified). The tdarr server image's entrypoint creates some root-owned files before user drop, which is why this namespace is privileged-mover enabled.
+
+---
+
+### Task 6: tdarr migration (2 PVCs)
+
+**Files:**
+- Create: `k3s/applications/tdarr/migration/restore.yaml` (containing 2 Restore CRs)
+- Modify: `k3s/applications/tdarr/pvc.yaml:1-12` and `:20-32` (two PVC blocks)
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-tdarr-node-config.yaml:10`
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-tdarr-server-data.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `tdarr-node-config` (1Gi) + `tdarr-server-data` (10Gi) in namespace `tdarr`
+- Produces: longhorn PVCs `tdarr-server-data` + `tdarr-node-config` bound and populated; both snapshot policies using `longhorn-snapclass`
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/tdarr-longhorn -b feat/tdarr-longhorn origin/master
+cd .worktrees/tdarr-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CRs (both PVCs in one file)**
+
+Create `k3s/applications/tdarr/migration/restore.yaml` with TWO Restore CRs:
+
+```yaml
+---
+# Restore CR for the tdarr-server-data csi-hostpath-sc → longhorn migration.
+# Operator-applied. tdarr namespace has privileged-movers annotation, so
+# the snapshot policy's runAsUser=1027/runAsGroup=100 mover can also read
+# root-owned files left by the tdarr-server entrypoint. The Restore inherits
+# UID/GID from the snapshot, so restored files have correct ownership.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: tdarr-server-data-longhorn-migration
+  namespace: tdarr
+spec:
+  source:
+    fromPolicy:
+      name: tdarr-server-data
+      offset: 0
+  target:
+    pvc:
+      name: tdarr-server-data
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+---
+# Restore CR for the tdarr-node-config csi-hostpath-sc → longhorn migration.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: tdarr-node-config-longhorn-migration
+  namespace: tdarr
+spec:
+  source:
+    fromPolicy:
+      name: tdarr-node-config
+      offset: 0
+  target:
+    pvc:
+      name: tdarr-node-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/tdarr/migration/restore.yaml
+git commit -m "feat(tdarr): add Restore CRs for tdarr-server-data + tdarr-node-config migration"
+```
+
+- [ ] **Step 3: Apply Restore CRs imperatively (both)**
+
+```bash
+# Scale both deployments to 0
+kubectl scale deploy/tdarr-server -n tdarr --replicas=0
+kubectl scale deploy/tdarr-node -n tdarr --replicas=0
+kubectl wait pod -l app=tdarr-server -n tdarr --for=delete --timeout=60s
+kubectl wait pod -l app=tdarr-node -n tdarr --for=delete --timeout=60s
+
+# Clear stale VolumeSnapshots if any
+kubectl get volumesnapshot -n tdarr
+# (filter on label if helpful)
+
+# Delete old PVCs
+kubectl delete pvc -n tdarr tdarr-server-data
+kubectl delete pvc -n tdarr tdarr-node-config
+
+# Apply
+kubectl apply -f k3s/applications/tdarr/migration/restore.yaml
+
+# Watch both Restore CRs
+kubectl get restore -n tdarr -w
+# Wait until both phases are Completed
+
+# Verify
+kubectl get pvc -n tdarr -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+# Expected: tdarr-server-data and tdarr-node-config both longhorn/Bound
+```
+
+- [ ] **Step 4: Write Commit 2 — pvc.yaml storageClassName changes (both PVCs)**
+
+Edit `k3s/applications/tdarr/pvc.yaml`. Change BOTH `tdarr-server-data` and `tdarr-node-config` PVC blocks' `storageClassName` from `csi-hostpath-sc` to `longhorn`. Leave `tdarr-media` PV/PVC block alone (smb-media).
+
+Stage and commit:
+```bash
+git add k3s/applications/tdarr/pvc.yaml
+git commit -m "feat(tdarr): switch tdarr-server-data + tdarr-node-config storageClassName to longhorn"
+```
+
+Verify Flux reconciled and scale tdarr back:
+```bash
+kubectl get pvc -n tdarr -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+# Server first (it must be ready before node can register):
+kubectl scale deploy/tdarr-server -n tdarr --replicas=1
+kubectl wait pod -l app=tdarr-server -n tdarr --for=condition=Ready --timeout=180s
+kubectl scale deploy/tdarr-node -n tdarr --replicas=1
+kubectl wait pod -l app=tdarr-node -n tdarr --for=condition=Ready --timeout=180s
+```
+
+Verify both pods bound both PVCs:
+```bash
+kubectl describe pod -l app=tdarr-server -n tdarr | grep -A 5 "Volumes:"
+kubectl describe pod -l app=tdarr-node -n tdarr | grep -A 5 "Volumes:"
+```
+
+- [ ] **Step 5: Write Commit 3 — both snapshot policies snapclass update**
+
+Edit both `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-tdarr-server-data.yaml` AND `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-tdarr-node-config.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass` in each.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-tdarr-server-data.yaml k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-tdarr-node-config.yaml
+git commit -m "feat(kopiur): switch tdarr-server-data + tdarr-node-config snapshot policies to longhorn-snapclass"
+```
+
+- [ ] **Step 6: Cleanup follow-up**
+
+Check `k3s/applications/tdarr/kustomization.yaml`. Note: tdarr already has a `migration/` directory from the previous local-path → csi-hostpath-sc migration (files: `pvc-copy-stage1.yaml`, `pvc-copy-stage2.yaml`, `pvc-hostpath.yaml`). These are stale now but Flux is no longer applying them since they were never listed in resources.
+
+```bash
+grep -E "migration/" k3s/applications/tdarr/kustomization.yaml
+```
+
+If migration/ files are listed in resources, remove them and commit fix. Otherwise no-op.
+
+Also clean up the stale migration files themselves (optional, see PR #312 precedent):
+```bash
+ls k3s/applications/tdarr/migration/
+# If old stage1/stage2/hostpath PVCs exist, leave them in tree as record (matches gatus/headlamp/portainer pattern) — but ensure they're NOT in kustomization.yaml resources
+```
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/tdarr-longhorn
+gh pr create --base master --head feat/tdarr-longhorn \
+  --title "feat(tdarr): migrate tdarr-server-data + tdarr-node-config PVCs from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Multi-PVC migration in one PR. Namespace already has privileged-movers annotation.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+```bash
+kubectl get pvc -n tdarr
+kubectl get pods -n tdarr
+# Expected: tdarr-server Running, tdarr-node Running, both PVCs longhorn/Bound
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/tdarr-longhorn
+git branch -d feat/tdarr-longhorn
+```
+
+---
+
+## Batch 3 verification gate
+
+```bash
+kubectl get pvc -n tdarr -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase
+kubectl get pods -n tdarr
+# Both server and node Running; both PVCs longhorn/Bound
+```
+
+---
+
+## Batch 4: pihole + authentik (HelmRelease-managed apps)
+
+These apps use HelmReleases. The storage class lives in chart values, so Commit 2 edits `helmrelease.yaml` instead of `pvc.yaml`. Suspending the HelmRelease before applying the Restore CR is critical.
+
+---
+
+### Task 7: pihole migration
+
+**Files:**
+- Create: `k3s/applications/pihole/migration/restore.yaml`
+- Modify: `k3s/applications/pihole/helmrelease.yaml` (find `storageClass: "csi-hostpath-sc"` line)
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `pihole` in namespace `pihole`, source PVC `pihole` (1Gi)
+- Produces: longhorn PVC `pihole` bound and populated; HelmRelease `persistence.storageClass: longhorn`; snapshot policy using `longhorn-snapclass`
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/pihole-longhorn -b feat/pihole-longhorn origin/master
+cd .worktrees/pihole-longhorn
+```
+
+- [ ] **Step 2: Write Commit 1 — Restore CR**
+
+Create `k3s/applications/pihole/migration/restore.yaml`. The snapshot policy uses privileged mover (runAsUser=0/runAsGroup=0) because pihole's chart-init creates `/etc/pihole/logrotate` as root before user drop. Namespace has privileged-movers annotation. Restore inherits from snapshot:
+
+```yaml
+---
+# Restore CR for the pihole csi-hostpath-sc → longhorn migration.
+# Operator-applied. Matches headlamp #309 pattern (HelmRelease-managed app).
+# See headlamp/migration/restore.yaml for the full header rationale.
+#
+# pihole-specific notes:
+# - Snapshot policy uses privileged mover (runAsUser=0) — namespace carries
+#   kopiur.home-operations.com/privileged-movers: "true". The chart-init
+#   creates /etc/pihole/logrotate as root before user drop, so the mover
+#   must run as root to read it.
+# - The Restore inherits UID/GID from the snapshot metadata. Restored files
+#   are owned correctly for pihole-FTL.db / gravity.db which pihole opens
+#   as pihole:pihole (UID/GID 999:999 in chart values).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: pihole-longhorn-migration
+  namespace: pihole
+spec:
+  source:
+    fromPolicy:
+      name: pihole
+      offset: 0
+  target:
+    pvc:
+      name: pihole
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/pihole/migration/restore.yaml
+git commit -m "feat(pihole): add Restore CR for csi-hostpath-sc → longhorn migration"
+```
+
+- [ ] **Step 3: Apply Restore CR imperatively (with HelmRelease suspend)**
+
+```bash
+# Suspend the HelmRelease FIRST so the controller doesn't fight us:
+kubectl patch helmrelease pihole -n pihole --type merge -p '{"spec":{"suspend":true}}'
+
+# Scale deployment to 0 (releases RWO on old PVC)
+kubectl scale deploy/pihole -n pihole --replicas=0
+kubectl wait pod -l app=pihole -n pihole --for=delete --timeout=60s
+
+# Clear stale VolumeSnapshots if any
+kubectl get volumesnapshot -n pihole -l kopiur.home-operations.com/policy-name=pihole
+# Patch out pvc-as-source-protection finalizers if any are stuck
+
+# Delete the old PVC
+kubectl delete pvc -n pihole pihole
+
+# Apply the Restore CR
+kubectl apply -f k3s/applications/pihole/migration/restore.yaml
+
+# Watch
+kubectl get restore -n pihole -w
+# Wait for phase=Completed
+
+# Verify
+kubectl get pvc -n pihole pihole -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+```
+
+- [ ] **Step 4: Write Commit 2 — helmrelease.yaml storageClass change**
+
+Edit `k3s/applications/pihole/helmrelease.yaml`. Find the `storageClass: "csi-hostpath-sc"` line (the one inside the `persistence:` block, not any other storageClass reference). Change it to `storageClass: "longhorn"`.
+
+Add a comment explaining the migration, mirroring the headlamp PR comment style:
+
+```yaml
+    persistence:
+      enabled: true
+      size: "1Gi"
+      # -- Migrated from csi-hostpath-sc to longhorn in
+      # feat/pihole-longhorn. The Restore CR in migration/restore.yaml
+      # creates a new 'pihole' PVC on longhorn and populates it from
+      # the latest kopia snapshot; the chart's PVC template then matches
+      # what's already there and Helm doesn't recreate it.
+      storageClass: "longhorn"
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/pihole/helmrelease.yaml
+git commit -m "feat(pihole): switch persistence storageClass to longhorn"
+```
+
+Un-suspend the HelmRelease so it reconciles:
+```bash
+kubectl patch helmrelease pihole -n pihole --type merge -p '{"spec":{"suspend":false}}'
+```
+
+Watch Flux reconcile:
+```bash
+kubectl get helmrelease -n pihole pihole -w
+# Wait for Ready: True
+```
+
+Scale pihole back up:
+```bash
+kubectl scale deploy/pihole -n pihole --replicas=1
+kubectl wait pod -l app=pihole -n pihole --for=condition=Ready --timeout=180s
+```
+
+Verify DNS works (the app's primary function):
+```bash
+# From any host, query a domain through pihole:
+dig @192.168.1.201 example.com +short
+# Expected: a public IP (e.g., 93.184.216.34)
+```
+
+Verify admin UI loads:
+```bash
+curl -sk https://pihole.homelab.properties/admin/ | head
+```
+
+- [ ] **Step 5: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
+git commit -m "feat(kopiur): switch pihole snapshot policy to longhorn-snapclass"
+```
+
+- [ ] **Step 6: Cleanup follow-up**
+
+Check `k3s/applications/pihole/kustomization.yaml` for stale migration/ entries. Commit fix if needed.
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin feat/pihole-longhorn
+gh pr create --base master --head feat/pihole-longhorn \
+  --title "feat(pihole): migrate pihole PVC from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "HelmRelease-managed migration (matches headlamp #309, portainer #310/#312). Pihole namespace has privileged-movers annotation for the chart-init root-owned logrotate file.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 8: Wait for PR merge and Flux reconcile**
+
+```bash
+kubectl get pvc -n pihole pihole
+kubectl get pods -n pihole -l app=pihole
+dig @192.168.1.201 example.com +short
+```
+
+- [ ] **Step 9: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/pihole-longhorn
+git branch -d feat/pihole-longhorn
+```
+
+---
+
+### Task 8: authentik migration (HelmRelease + StatefulSet)
+
+**Files:**
+- Create: `k3s/applications/authentik/migration/restore.yaml`
+- Modify: `k3s/applications/authentik/helmrelease.yaml` (find postgresql storageClass line)
+- Modify: `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-authentik.yaml:10`
+
+**Interfaces:**
+- Consumes: snapshot policy `authentik` in namespace `authentik`, source PVC `data-authentik-postgresql-0` (2Gi, bitnami StatefulSet)
+- Produces: longhorn PVC `data-authentik-postgresql-0` bound and populated; HelmRelease postgresql storageClass → longhorn; snapshot policy using `longhorn-snapclass`
+
+**Critical:** The PVC name `data-authentik-postgresql-0` is fixed by the bitnami/postgresql StatefulSet's volumeClaimTemplate. The Restore CR's `target.pvc.name` MUST be exactly `data-authentik-postgresql-0` or the StatefulSet will not bind.
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git fetch origin master
+git worktree add .worktrees/authentik-longhorn -b feat/authentik-longhorn origin/master
+cd .worktrees/authentik-longhorn
+```
+
+- [ ] **Step 2: Locate authentik's chart storageClass settings**
+
+```bash
+grep -n "storageClass\|postgresql\|persistence" k3s/applications/authentik/helmrelease.yaml
+```
+
+Note the line(s) where `csi-hostpath-sc` is referenced. The authentik chart exposes postgresql as a sub-chart with its own persistence block. The bitnami/postgresql StatefulSet creates the PVC with name `<releasename>-postgresql-0` by default; with `auth: authentik`, that becomes `authentik-postgresql-0` — but the snapshot policy uses `data-authentik-postgresql-0` (note the `data-` prefix). Verify the actual PVC name in the cluster:
+
+```bash
+kubectl get pvc -n authentik
+```
+
+If the PVC name in the cluster is `data-authentik-postgresql-0`, the Restore CR uses that name. If it's different (e.g., the chart was renamed), adjust accordingly.
+
+- [ ] **Step 3: Write Commit 1 — Restore CR**
+
+Create `k3s/applications/authentik/migration/restore.yaml`:
+
+```yaml
+---
+# Restore CR for the authentik-postgresql csi-hostpath-sc → longhorn migration.
+# Operator-applied. Matches headlamp #309 pattern.
+#
+# authentik-specific notes:
+# - Uses bitnami/postgresql StatefulSet. PVC name `data-authentik-postgresql-0`
+#   is fixed by the volumeClaimTemplate (immutable). The Restore's
+#   target.pvc.name MUST match exactly or the StatefulSet will fail to bind.
+# - Bitnami postgres runs as UID/GID 1001. Namespace carries
+#   kopiur.home-operations.com/privileged-movers: "true" so the snapshot
+#   can read the few root-owned files the Bitnami chart-init creates before
+#   user drop (same as pihole).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: authentik-postgresql-longhorn-migration
+  namespace: authentik
+spec:
+  source:
+    fromPolicy:
+      name: authentik
+      offset: 0
+  target:
+    pvc:
+      # MUST match StatefulSet volumeClaimTemplate name exactly
+      name: data-authentik-postgresql-0
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/authentik/migration/restore.yaml
+git commit -m "feat(authentik): add Restore CR for csi-hostpath-sc → longhorn migration"
+```
+
+- [ ] **Step 4: Apply Restore CR imperatively (with HelmRelease suspend)**
+
+```bash
+# Suspend HelmRelease FIRST
+kubectl patch helmrelease authentik -n authentik --type merge -p '{"spec":{"suspend":true}}'
+
+# Scale postgresql StatefulSet to 0
+kubectl scale statefulset/authentik-postgresql -n authentik --replicas=0
+kubectl wait pod -l app.kubernetes.io/name=postgresql -n authentik --for=delete --timeout=120s
+
+# Also scale the main authentik deployment so the app doesn't try to query DB
+kubectl scale deploy/authentik -n authentik --replicas=0 2>/dev/null
+kubectl scale deploy/authentik-worker -n authentik --replicas=0 2>/dev/null
+
+# Clear stale VolumeSnapshots if any
+kubectl get volumesnapshot -n authentik -l kopiur.home-operations.com/policy-name=authentik
+
+# Delete the old PVC
+kubectl delete pvc -n authentik data-authentik-postgresql-0
+
+# Apply the Restore CR
+kubectl apply -f k3s/applications/authentik/migration/restore.yaml
+
+# Watch
+kubectl get restore -n authentik -w
+# Wait for phase=Completed
+
+# Verify
+kubectl get pvc -n authentik data-authentik-postgresql-0 -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}{"\n"}'
+# Expected: longhorn<TAB>Bound
+```
+
+- [ ] **Step 5: Write Commit 2 — helmrelease.yaml storageClass change**
+
+Edit `k3s/applications/authentik/helmrelease.yaml`. Find the postgresql storageClass reference (likely `postgresql.primary.persistence.storageClass: csi-hostpath-sc` or similar). Change to `longhorn`.
+
+Add a comment mirroring headlamp's pattern:
+```yaml
+    # Migrated from csi-hostpath-sc to longhorn in feat/authentik-longhorn.
+    # The Restore CR in migration/restore.yaml creates a new
+    # data-authentik-postgresql-0 PVC on longhorn and populates it from the
+    # latest kopia snapshot; the StatefulSet's volumeClaimTemplate then
+    # matches what's already there.
+    storageClass: longhorn
+```
+
+Stage and commit:
+```bash
+git add k3s/applications/authentik/helmrelease.yaml
+git commit -m "feat(authentik): switch postgresql storageClass to longhorn"
+```
+
+Un-suspend and reconcile:
+```bash
+kubectl patch helmrelease authentik -n authentik --type merge -p '{"spec":{"suspend":false}}'
+kubectl get helmrelease -n authentik authentik -w
+# Wait for Ready: True
+```
+
+Scale everything back up:
+```bash
+kubectl scale statefulset/authentik-postgresql -n authentik --replicas=1
+kubectl wait pod -l app.kubernetes.io/name=postgresql -n authentik --for=condition=Ready --timeout=300s
+kubectl scale deploy/authentik -n authentik --replicas=1
+kubectl scale deploy/authentik-worker -n authentik --replicas=1
+kubectl wait pod -l app.kubernetes.io/name=authentik -n authentik --for=condition=Ready --timeout=300s
+```
+
+Verify authentik works:
+```bash
+curl -sk https://authentik.homelab.properties/-/health/ready/
+curl -sk https://authentik.homelab.properties/-/health/live/
+# Both should return 200
+```
+
+Log in to authentik via WebUI and confirm users/groups intact.
+
+- [ ] **Step 6: Write Commit 3 — snapshot policy snapclass update**
+
+Edit `k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-authentik.yaml`. Change `volumeSnapshotClassName: csi-hostpath-snapclass` to `longhorn-snapclass`.
+
+Stage and commit:
+```bash
+git add k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-authentik.yaml
+git commit -m "feat(kopiur): switch authentik snapshot policy to longhorn-snapclass"
+```
+
+- [ ] **Step 7: Cleanup follow-up — handle stale migration/ files**
+
+authentik's `migration/` directory contains old artifacts from the local-path → csi-hostpath-sc migration (`postgresql-pvc-copy-stage1.yaml`, `postgresql-pvc-copy-stage2.yaml`, `postgresql-pvc-intermediate.yaml`).
+
+```bash
+ls k3s/applications/authentik/migration/
+grep -E "migration/" k3s/applications/authentik/kustomization.yaml
+```
+
+If any migration/ files are listed in `kustomization.yaml` resources, remove them. The old PVCs themselves should be safe to leave in tree as record (matches gatus/headlamp/portainer pattern) but verify they don't conflict — if their storageClassName is csi-hostpath-sc, they will conflict with the new longhorn PVC.
+
+Specifically: `postgresql-pvc-intermediate.yaml` likely declares a PVC with storageClassName: csi-hostpath-sc. If listed in kustomization resources, Flux will try to apply it and conflict with the StatefulSet-managed longhorn PVC. Remove from resources list (and consider removing the file entirely since the intermediate PVC no longer exists in cluster).
+
+If cleanup changes are needed:
+```bash
+git add k3s/applications/authentik/kustomization.yaml
+# Possibly: git rm k3s/applications/authentik/migration/postgresql-pvc-intermediate.yaml
+git commit -m "fix(authentik): remove stale migration files from kustomization resources"
+```
+
+- [ ] **Step 8: Push and open PR**
+
+```bash
+git push -u origin feat/authentik-longhorn
+gh pr create --base master --head feat/authentik-longhorn \
+  --title "feat(authentik): migrate data-authentik-postgresql-0 PVC from csi-hostpath-sc to longhorn (preserve data)" \
+  --body "Most complex migration: bitnami/postgresql StatefulSet with immutable volumeClaimTemplate. The Restore CR's target.pvc.name MUST be exactly data-authentik-postgresql-0.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 9: Wait for PR merge and Flux reconcile**
+
+```bash
+kubectl get pvc -n authentik
+kubectl get pods -n authentik
+curl -sk https://authentik.homelab.properties/-/health/ready/
+```
+
+- [ ] **Step 10: Clean up worktree**
+
+```bash
+cd /home/jeff/workspaces/homelab
+git worktree remove .worktrees/authentik-longhorn
+git branch -d feat/authentik-longhorn
+```
+
+---
+
+## Task 9: Postflight — verify all migrations complete
+
+**Why last:** Confirms the migration as a whole succeeded. If anything is still on csi-hostpath-sc that should be on longhorn, this task surfaces it.
+
+- [ ] **Step 1: Confirm zero csi-hostpath-sc PVCs remain in target namespaces**
+
+```bash
+kubectl get pvc -A -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,SC:.spec.storageClassName,STATUS:.status.phase | grep csi-hostpath-sc
+```
+
+Expected output: empty. The only csi-hostpath-sc PVCs remaining should be the smb-media-related ones (none) or any PVCs that are intentionally NOT in scope (none for these 8 apps).
+
+- [ ] **Step 2: Confirm all snapshot policies use longhorn-snapclass**
+
+```bash
+kubectl get snapshotpolicy -A -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,SNAPCLASS:.spec.volumeSnapshotClassName | grep csi-hostpath-snapclass
+```
+
+Expected output: empty.
+
+- [ ] **Step 3: Confirm all 8 apps are healthy**
+
+For each app, run:
+```bash
+kubectl get pods -n <ns> -l app=<app>
+# Expected: Running
+```
+
+Plus app-specific smoke tests:
+- prowlarr: `curl -sk https://prowlarr.homelab.properties/ping`
+- radarr: `curl -sk https://radarr.homelab.properties/ping`
+- sonarr: `curl -sk https://sonarr.homelab.properties/ping`
+- qbittorrent: `kubectl logs -n qbittorrent -l app=qbittorrent -c gluetun | grep "VPN is up"`
+- sabnzbd: `kubectl logs -n sabnzbd -l app=sabnzbd -c gluetun | grep "VPN is up"`
+- tdarr: WebUI loads, both server and node visible
+- pihole: `dig @192.168.1.201 example.com +short`
+- authentik: `curl -sk https://authentik.homelab.properties/-/health/ready/`
+
+- [ ] **Step 4: Confirm next-hour snapshots succeed**
+
+For each of the 8 apps, find the snapshot policy schedule and wait for the next hourly snapshot:
+
+```bash
+for ns in media pihole authentik qbittorrent sabnzbd tdarr; do
+  echo "=== $ns ==="
+  for policy in $(kubectl get snapshotpolicy -n "$ns" -o name | sed 's|.*/||'); do
+    echo "  $policy:"
+    kubectl get snapshots -n "$ns" -l kopiur.home-operations.com/policy-name="$policy" --sort-by=.metadata.creationTimestamp | tail -2
+  done
+done
+```
+
+(prowlarr/radarr/sonarr all live in media; iterate their policies)
+
+Expected: each app's most recent snapshot shows `ReadyToUse: True` with a recent creation timestamp, using `longhorn-snapclass`.
+
+- [ ] **Step 5: Document the migration**
+
+Commit a summary doc:
+
+```bash
+cd /home/jeff/workspaces/homelab
+git checkout master
+git pull origin master
+git checkout -b docs/migration-completion
+mkdir -p docs/operations
+cat > docs/operations/2026-08-20-csi-hostpath-longhorn-completion.md <<'EOF'
+# csi-hostpath-sc → Longhorn migration completion
+
+Date: 2026-08-20
+
+All 11 csi-hostpath-sc PVCs across 8 apps migrated to Longhorn with no data loss:
+
+- prowlarr (PR #<num>) — single PVC
+- radarr (PR #<num>) — single PVC
+- sonarr (PR #<num>) — single PVC
+- qbittorrent (PR #<num>) — 2 PVCs (config + gluetun)
+- sabnzbd (PR #<num>) — 2 PVCs (config + gluetun)
+- tdarr (PR #<num>) — 2 PVCs (server-data + node-config)
+- pihole (PR #<num>) — HelmRelease-managed
+- authentik (PR #<num>) — HelmRelease + bitnami StatefulSet
+
+Pattern: kopiur Restore CR + storageClassName change + snapshot policy snapclass update, per app, in 3 ordered commits.
+
+Out of scope (deferred):
+- 4 local-path PVCs (prometheus, loki, tempo, sabnzbd-downloads) — need separate migration to csi-hostpath-sc first
+EOF
+git add docs/operations/2026-08-20-csi-hostpath-longhorn-completion.md
+git commit -m "docs(migration): record csi-hostpath-sc → longhorn migration completion"
+git push -u origin docs/migration-completion
+gh pr create --base master --head docs/migration-completion \
+  --title "docs(migration): record csi-hostpath-sc → longhorn migration completion" \
+  --body "Records the 8-PR migration completed in this session. See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+After merge, clean up:
+```bash
+git checkout master
+git pull origin master
+git branch -d docs/migration-completion
+```
+
+---
+
+## Failure handling (applies to any task)
+
+### Restore CR stalls in `Pending` with `MissingCredentialsSecret`
+
+Cause: `credentialProjection.enabled: true` is missing or the ClusterRepository secret lookup is wrong.
+
+Fix:
+1. Delete the Restore CR: `kubectl delete restore -n <ns> <name>`
+2. Verify ClusterRepository `nas` is healthy: `kubectl get clusterrepository nas -o yaml`
+3. Verify the source snapshot policy's `credentialProjection.enabled: true`
+4. Re-apply the Restore CR with the field set correctly
+
+### Restore CR fails with `snapshot not found`
+
+Cause: snapshot policy's `policy.onMissingSnapshot` is `Fail` (correct setting) but no snapshot exists.
+
+Fix:
+1. Delete the Restore CR
+2. Trigger a one-off snapshot: `kubectl create -f - <<EOF\napiVersion: kopiur.home-operations.com/v1alpha1\nkind: Snapshot\nmetadata:\n  name: <name>-oneshot\n  namespace: <ns>\nspec:\n  policyName: <policy>\nEOF`
+3. Wait for snapshot to succeed
+4. Re-apply the Restore CR
+
+### Commit 2 causes Flux conflict / HelmRelease stuck
+
+Cause: per portainer #312, usually means `migration/` files listed in `kustomization.yaml` resources conflict with the HelmRelease-managed PVC.
+
+Fix:
+1. Don't panic. The PVC is already restored (Commit 1 succeeded). The chart-managed PVC just can't bind.
+2. Remove `migration/` entries from `k3s/applications/<app>/kustomization.yaml`
+3. Flux re-reconciles; chart's PVC template now matches the existing longhorn PVC
+4. Verify: `kubectl get pvc -n <ns> <pvc>`
+
+### Pod won't start on longhorn PVC (UID/GID mismatch)
+
+Symptom: Pod CrashLoopBackOff with "Permission denied" errors reading files in the mounted PVC.
+
+Fix:
+1. Exec into a debug pod with the longhorn PVC mounted: `kubectl debug -n <ns> -it --image=busybox --target=<container>`
+2. Inspect file ownership: `ls -la /<mount-path>`
+3. Compare to what the chart expects (e.g., UID 999 for pihole, UID 1027 for LinuxServer apps)
+4. If ownership is wrong, the snapshot policy recorded wrong UID/GID. Either:
+   - Adjust `mover.securityContext.runAsUser/runAsGroup` in the Restore CR to match what the chart wants, re-apply
+   - Or run a chown job manually after restore: `kubectl create job -n <ns> chown-fix --image=busybox -- chown -R <uid>:<gid> /<mount-path>`
+
+### Restore fails mid-mover (data partially restored)
+
+Cause: mover Job crashed (network, kopia repository corruption, mover bug).
+
+Fix:
+1. Delete the Restore CR: `kubectl delete restore -n <ns> <name>`
+2. Delete the partial longhorn PVC: `kubectl delete pvc -n <ns> <pvc>`
+3. Investigate mover Job logs: `kubectl logs -n <ns> -l job-name=kopiur-mover-<restore-name>`
+4. Fix root cause
+5. Re-apply the Restore CR (idempotent — creates a fresh PVC and re-runs the mover)
+
+---
+
+## Self-review (run after writing the plan)
+
+1. **Spec coverage:** Each of the 8 apps in the spec has a dedicated task (Tasks 1-8). The preflight (Task 0) and postflight (Task 9) cover backup health verification before/after. Each task implements the 3-commit pattern from the spec.
+
+2. **Placeholder scan:** All Restore CRs have full content (no "TBD"/"TODO"). All commits have explicit step content.
+
+3. **Type consistency:** Restore CR structure is identical across all tasks (only `name`, `namespace`, `policy name`, `pvc name`, `capacity` differ). Snapshot policy field names (`volumeSnapshotClassName`) match. PVC field names (`storageClassName`) match.
+
+4. **Ambiguity check:** Authentik's StatefulSet PVC name is explicitly called out as critical (`data-authentik-postgresql-0` must match exactly). Multi-PVC apps have explicit lockstep language (both PVCs in one file, both must be ready). HelmRelease apps have explicit `suspend:true` / `suspend:false` lifecycle.
+
+5. **Failure paths:** Dedicated section covers all known failure modes (stalls, missing snapshots, Flux conflicts, UID/GID mismatch, partial restore).
+
+6. **Cleanup follow-ups:** Each raw-app task has a Step 6 that checks `kustomization.yaml` resources. Authentik has an explicit cleanup step for stale migration/ files (which is known to be a problem per the `conflicting PVC definitions` finding).

--- a/docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md
+++ b/docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md
@@ -1,0 +1,295 @@
+---
+title: Finish csi-hostpath-sc → Longhorn PVC migration (8 apps, 11 PVCs)
+date: 2026-08-20
+status: approved
+---
+
+# Finish csi-hostpath-sc → Longhorn PVC migration
+
+## Context
+
+The csi-hostpath-sc StorageClass is failing in this cluster: backups have been failing silently for up to 2d17h, the CSI hostpath provisioner times out on snapshot restores, and the local-path → csi-hostpath-sc migration (PR #298) is now in a state where every PVC still on csi-hostpath-sc is at risk.
+
+The Longhorn CSI driver is installed (PR #306). Five apps have already been successfully migrated to `longhorn`: gatus (#307), headlamp (#309), portainer (#310, fix #312), monitoring/alertmanager + monitoring/grafana (#311). This spec finishes the remaining 11 PVCs across 8 apps.
+
+Goal: move every csi-hostpath-sc PVC to Longhorn with no data loss, applying the established pattern.
+
+## Scope
+
+**In scope (11 PVCs across 8 apps):**
+
+| App | Namespace | PVC(s) | Pattern | Privileged mover |
+|-----|-----------|--------|---------|------------------|
+| prowlarr | media | prowlarr-config (2Gi) | Raw PVC | No |
+| radarr | media | radarr-config (2Gi) | Raw PVC | No |
+| sonarr | media | sonarr-config (2Gi) | Raw PVC | No |
+| qbittorrent | qbittorrent | qbittorrent-config (5Gi), gluetun-config (1Gi) | Raw PVC | No |
+| sabnzbd | sabnzbd | sabnzbd-config (5Gi), gluetun-config (1Gi) | Raw PVC | No |
+| tdarr | tdarr | tdarr-server-data (10Gi), tdarr-node-config (1Gi) | Raw PVC | Yes |
+| pihole | pihole | pihole (1Gi) | HelmRelease | Yes |
+| authentik | authentik | data-authentik-postgresql-0 (2Gi) | HelmRelease + StatefulSet | Yes |
+
+**Out of scope (deferred to separate future work):**
+
+- 4 local-path PVCs that need local-path → csi-hostpath-sc first:
+  - monitoring/prometheus-kube-prometheus-stack-prometheus-db (20Gi, StatefulSet)
+  - sabnzbd/sabnzbd-downloads (200Gi)
+  - telemetry/storage-loki-0 (20Gi, StatefulSet)
+  - telemetry/storage-tempo-0 (5Gi, StatefulSet)
+
+- Kopiur system-level fixes (CSI hostpath provisioner timeout on sabnzbd restore)
+- smb-media PVCs (already on a different StorageClass, not snapshot-eligible by design)
+
+## Constraints / non-negotiables
+
+1. **No data loss.** Every migration preserves the existing data via kopiur snapshot.
+2. **Backup health verified before each Restore CR.** Per past session (S108), backup snapshots have been failing silently. Verify a recent successful snapshot exists before applying each Restore CR; pause and fix the backup system first if not.
+3. **Match established pattern.** Restore CR + storageClassName change + snapshot policy snapclass change. Don't invent a new mechanism.
+4. **Migration files NOT in kustomization resources.** Per portainer #312 lesson, imperative PVC manifests in `migration/` must not be Flux-managed if they conflict with the HelmRelease-managed PVC.
+
+## Architecture
+
+8 PRs total, one per app. Each PR has 3 ordered commits applied in sequence:
+
+```
+Per-app flow (3 commits in 1 PR):
+
+  ┌─ Commit 1: migration/restore.yaml (operator-applied)
+  │   - Restore CR pulls latest kopiur snapshot
+  │   - Creates new PVC on longhorn
+  │   - Pre-conditions: HelmRelease suspended, deployment scaled to 0,
+  │     stale VolumeSnapshots cleared, old PVC deleted
+  │   - Apply with: kubectl apply -f migration/restore.yaml
+  │   - Verify: kubectl get restore -n <ns> → phase: Completed
+  │
+  ├─ Commit 2: storageClassName → longhorn
+  │   - HelmRelease apps: edit k3s/applications/<app>/helmrelease.yaml
+  │   - Raw PVC apps: edit k3s/applications/<app>/pvc.yaml
+  │   - Flux reconciles → chart's PVC template matches existing PVC
+  │   - Deploy / scale back to 1 replica
+  │
+  └─ Commit 3: volumeSnapshotClassName → longhorn-snapclass
+      - Edit k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-<app>.yaml
+      - Next scheduled snapshot uses longhorn-snapclass
+
+  Optional follow-up cleanup PR per app:
+    - If kustomization.yaml lists migration/* files, remove them
+    - Portainer #312 lesson: imperative PVC manifests conflict with Flux's
+      HelmRelease-managed PVC
+```
+
+## Per-app specifics
+
+### A. HelmRelease-managed apps
+
+**pihole, authentik**
+
+- Storage class lives in `helmrelease.yaml` values (e.g., `persistence.storageClass: csi-hostpath-sc`)
+- Commit 2 edits the HelmRelease value
+- After Flux reconcile: Helm chart's rendered PVC template matches the existing longhorn PVC, no recreate
+
+**authentik special handling:**
+- Uses bitnami/postgresql StatefulSet
+- PVC name `data-authentik-postgresql-0` is fixed by `volumeClaimTemplate`, immutable
+- Restore CR's `target.pvc.name` MUST match exactly: `data-authentik-postgresql-0`
+- Namespace `authentik` already has `kopiur.home-operations.com/privileged-movers: "true"`
+- Restore CR mover `securityContext.runAsUser: 1001, runAsGroup: 1001` matches the Bitnami postgres UID/GID recorded in snapshots
+
+### B. Raw deployment + PVC manifest apps
+
+**prowlarr, radarr, sonarr, qbittorrent, sabnzbd, tdarr**
+
+- PVC defined directly in `k3s/applications/<app>/pvc.yaml`
+- Commit 2 edits `pvc.yaml` directly
+- Flux applies the manifest directly, no Helm reconcile dance
+
+**Multi-PVC apps:**
+- qbittorrent: 2 PVCs (qbittorrent-config, gluetun-config)
+- sabnzbd: 2 PVCs (sabnzbd-config, gluetun-config)
+- tdarr: 2 PVCs (tdarr-server-data, tdarr-node-config)
+- Each PVC needs its own Restore CR (single Restore CR per source PVC)
+- Both PVCs migrate in lockstep — gluetun-config must be ready before app pod starts
+
+### Restore CR template (per PVC source, per namespace)
+
+```yaml
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: <app>-<pvc>-longhorn-migration
+  namespace: <ns>
+spec:
+  source:
+    fromPolicy:
+      name: <policy-name>      # exact snapshot policy name
+      offset: 0
+  target:
+    pvc:
+      name: <exact-pvc-name>   # must match chart/pvc.yaml name
+      storageClassName: longhorn
+      accessModes: [ReadWriteOnce]
+      capacity: <same-as-current>
+  credentialProjection:
+    enabled: true              # ClusterRepository 'nas' secret lives in kopiur-system
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}             # preserves UID/GID from backup
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail
+```
+
+### Per-app Restore CR count
+
+| App | Restore CRs | PVC names |
+|-----|-------------|-----------|
+| prowlarr | 1 | prowlarr-config |
+| radarr | 1 | radarr-config |
+| sonarr | 1 | sonarr-config |
+| pihole | 1 | pihole |
+| qbittorrent | 2 | qbittorrent-config, gluetun-config |
+| sabnzbd | 2 | sabnzbd-config, gluetun-config |
+| tdarr | 2 | tdarr-server-data, tdarr-node-config |
+| authentik | 1 | data-authentik-postgresql-0 |
+| **Total** | **11** | |
+
+## Data flow
+
+```
+kopiur snapshot (csi-hostpath-snapclass VolumeSnapshot)
+    │
+    │ 1. operator: kubectl apply -f migration/restore.yaml
+    ▼
+Restore CR (kopiur operator)
+    │
+    │ 2. resolves source: latest Snapshot CR from SnapshotPolicy
+    │ 3. creates target PVC on longhorn StorageClass
+    │ 4. launches mover Job:
+    │    - mounts source snapshot (CSI)
+    │    - mounts target PVC (RWO longhorn)
+    │    - reads kopia repository, writes restored data
+    │    - inherits UID/GID from snapshot metadata
+    ▼
+target PVC: <name> bound on longhorn, populated with snapshot data
+    │
+    │ 5. operator: kubectl scale deploy/<app> --replicas=1 (or HelmRelease update)
+    │ 6. commit 2 lands: storageClassName → longhorn in HelmRelease or pvc.yaml
+    │ 7. Flux reconciles: chart's PVC template matches existing PVC
+    ▼
+app running on longhorn PVC, identical data, RWO bound by pod
+    │
+    │ 8. commit 3 lands: volumeSnapshotClassName → longhorn-snapclass
+    ▼
+next hourly snapshot uses longhorn VolumeSnapshotClass
+```
+
+## Pre-flight verification (per app, before Commit 1)
+
+1. `kubectl get snapshots -n <ns> -l kopiur.home-operations.com/policy-name=<policy>` → most recent has `status: ReadyToUse: true`
+2. If no recent successful snapshot → **pause**, fix kopiur/policy first
+3. `kubectl get pvc -n <ns> <pvc> -o jsonpath='{.spec.storageClassName}'` → confirm `csi-hostpath-sc`
+4. `kubectl get volumesnapshot -n <ns>` → check for stale snapshots holding `pvc-as-source-protection` finalizers; clear before applying Restore CR (gatus #307 lesson)
+5. `kubectl get restore -n <ns>` → confirm no other Restore CR is in-flight in this namespace
+
+## Per-commit verification
+
+| After commit | Verification |
+|--------------|--------------|
+| Commit 1 (Restore CR applied) | `kubectl get restore -n <ns> -o jsonpath='{.items[*].status.phase}'` → `Completed`<br>`kubectl get pvc -n <ns> <name> -o jsonpath='{.spec.storageClassName}{"\t"}{.status.phase}'` → `longhorn\tBound` |
+| Commit 2 (storageClassName change) | `kubectl get helmrelease -n <ns> <name>` → `Ready: True`<br>or for raw apps: `kubectl get pvc -n <ns> <name> -o jsonpath='{.spec.storageClassName}'` → `longhorn`<br>App pod running and healthy: `kubectl get pods -n <ns>` |
+| Commit 3 (snapshot policy update) | `kubectl get snapshotpolicy -n <ns> <name> -o jsonpath='{.spec.volumeSnapshotClassName}'` → `longhorn-snapclass`<br>Wait for next hourly snapshot, verify it succeeds |
+
+## Error handling
+
+### Restore CR fails or stalls
+
+1. `kubectl delete restore -n <ns> <name>` (clears operator locks)
+2. Investigate: stale finalizers? missing snapshot? mover Job crash?
+3. Fix root cause
+4. Re-apply same Restore CR (idempotent)
+
+### Pod won't start on longhorn PVC
+
+- Check UID/GID on restored files via debug pod
+- Compare to what chart's initContainer chowns to
+- Adjust `mover.inheritSecurityContextFrom.snapshot: {}` or run a chown job manually
+
+### Commit 2 causes Flux conflict
+
+- Usually means `migration/` files listed in `kustomization.yaml` resources
+- Follow up with cleanup PR removing `migration/` from resources list (portainer #312 lesson)
+
+## Rollback path
+
+- Data is in kopiur snapshot for at least 24h (`keepHourly: 24`)
+- Old csi-hostpath-sc PVC is deleted before Restore runs — cannot revert in-place
+- Recovery: delete longhorn PVC, re-apply Restore CR with `offset: 1` (previous snapshot), or restore from backup
+- For raw-deployment apps: temporarily revert `pvc.yaml` `storageClassName: csi-hostpath-sc` and restore PVC manually from snapshot via a fresh Restore to csi-hostpath-sc
+
+## Batch ordering (Easy-first)
+
+### Batch 1 — media namespace (3 PRs)
+- PR 1: `feat(prowlarr): migrate prowlarr-config PVC to longhorn`
+- PR 2: `feat(radarr): migrate radarr-config PVC to longhorn`
+- PR 3: `feat(sonarr): migrate sonarr-config PVC to longhorn`
+- Risk: minimal — single PVC, LinuxServer PUID 1027, no privileged mover
+- Verification gate: each app's WebUI loads, no data loss
+
+### Batch 2 — qbittorrent + sabnzbd (2 PRs)
+- PR 4: `feat(qbittorrent): migrate qbittorrent-config + gluetun-config to longhorn`
+- PR 5: `feat(sabnzbd): migrate sabnzbd-config + gluetun-config to longhorn`
+- Risk: medium — multi-PVC, must lockstep both
+- Verification gate: torrent client connects, downloads work, VPN tunnel up
+
+### Batch 3 — tdarr (1 PR)
+- PR 6: `feat(tdarr): migrate tdarr-server-data + tdarr-node-config to longhorn`
+- Risk: medium — multi-PVC + privileged mover namespace
+- Namespace already has `kopiur.home-operations.com/privileged-movers: "true"`
+- Verification gate: tdarr-server boots, tdarr-node registers, scan a test library
+
+### Batch 4 — pihole + authentik (2 PRs)
+- PR 7: `feat(pihole): migrate pihole PVC to longhorn`
+  - HelmRelease `persistence.storageClass` change
+  - Namespace already has privileged-movers annotation
+  - Verification: DNS resolves, admin UI loads
+- PR 8: `feat(authentik): migrate data-authentik-postgresql-0 PVC to longhorn`
+  - **Most complex**: bitnami/postgresql StatefulSet, immutable volumeClaimTemplate
+  - Verification: authentik login works, postgresql DB intact
+
+## Optional cleanup follow-ups (per app)
+
+For raw-deployment apps: verify `k3s/applications/<app>/kustomization.yaml` doesn't list stale `migration/` files. If it does, separate fix PR removing them from the resources list.
+
+## Risks tracked
+
+- Backup snapshots may still be failing silently — verify before each Restore CR
+- HelmRelease PVC recreation race during storage class change — watch Flux logs
+- StatefulSet PVC name mismatch breaks migration — Restore CR's `target.pvc.name` must be exact
+- CSI hostpath provisioner timeout on snapshot restores — affects backup system, not the migration flow itself, but blocks step 1 (need working snapshot)
+
+## Out of scope (deferred)
+
+- 4 local-path PVCs (Prometheus DB, Loki, Tempo, sabnzbd-downloads) — separate future migration
+- Kopiur system-level fixes
+- smb-media PVCs (different StorageClass by design)
+
+## Related references
+
+- Past migrations:
+  - gatus: PR #307
+  - headlamp: PR #309
+  - portainer: PR #310, cleanup PR #312
+  - monitoring: PR #311 (alertmanager + grafana, multi-PVC in one PR)
+- Established pattern references:
+  - `k3s/applications/headlamp/migration/restore.yaml` — canonical Restore CR example
+  - `k3s/applications/portainer/migration/restore.yaml` — second canonical example
+- Lessons-learned docs in repo memory (claude-mem):
+  - `csi-hostpath-to-longhorn-restore-cr.md` — credentialProjection + inheritSecurityContextFrom required
+  - `kopiur-privileged-mover.md` — apps with chart-init root-owned files need namespace annotation
+  - `kopiur-repo-per-namespace.md` — kopiur-repo PV/PVC must exist per namespace


### PR DESCRIPTION
Captures the brainstorming/planning artifacts from the csi-hostpath → longhorn migration work that ran in this repo over the past 24 hours.

Three commits:
- `docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md` — design spec
- `docs/superpowers/plans/2026-08-20-finish-csi-hostpath-to-longhorn-migration.md` — implementation plan (9 tasks; 5 done, 4 pending)
- `docs(migration): fix kopiur Snapshot label and status field in plan` — preflight finding correction

Per superpowers workflow: docs/superpowers/specs and docs/superpowers/plans are committed alongside the work they describe so the historical record is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)