### PR TITLE
fix(sabnzbd): recover sabnzbd-config from kopia backup, complete longhorn migration

### DIFF
--- a/k3s/applications/sabnzbd/migration/restore-config.yaml
+++ b/k3s/applications/sabnzbd/migration/restore-config.yaml
@@ -1,0 +1,64 @@
+---
+# Recovery Restore CR for sabnzbd-config, pinned to the last known-good
+# pre-incident snapshot.
+#
+# Context: Task 5 of the csi-hostpath->longhorn migration deleted the
+# source sabnzbd-config PVC and its Restore CR failed (multi-source
+# SnapshotPolicy bug, fixed in PR #318) and was never retried. sabnzbd's
+# manifest then dynamically provisioned a brand-new empty PVC and the app
+# has been running as a blank install since 2026-08-21T21:41:35Z.
+#
+# This restores from `nas-disc-37aa4b30bc50cd5f`, a Discovered Snapshot CR
+# (deletionPolicy: Retain) recorded 2026-08-21T20:06:31Z, ~90 minutes
+# before the wipe — the newest snapshot known to hold real config data.
+# Pinned explicitly via snapshotRef, NOT fromPolicy: the SnapshotPolicy's
+# own scheduled snapshots since the wipe are of the blank state and would
+# silently restore nothing useful.
+#
+# Target capacity is 20Gi (not the original plan's 5Gi) because this
+# snapshot is ~12.5GiB — sabnzbd's complete_dir setting has historically
+# written completed downloads into /config/Downloads/complete instead of
+# the dedicated /downloads PVC, so the config snapshot carries that media
+# along with it. See Task 5 in the plan doc for the cleanup/fix.
+#
+# Operator-applied (NOT in kustomization.yaml — Flux will not reconcile it
+# on every sync). Run with `kubectl apply -f` once after scaling sabnzbd
+# to 0 replicas and deleting the current blank sabnzbd-config PVC.
+#
+# Pre-conditions:
+#   - sabnzbd deployment scaled to 0
+#   - The blank csi-hostpath-sc PVC `sabnzbd-config` deleted (Restore's
+#     target.pvc would otherwise hit a name conflict)
+#
+# Post-conditions:
+#   - PVC `sabnzbd-config` exists, bound on `longhorn`, populated with the
+#     real pre-incident config (sabnzbd.ini, admin/, logs/, Downloads/).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: sabnzbd-config-longhorn-migration
+  namespace: sabnzbd
+spec:
+  source:
+    snapshotRef:
+      name: nas-disc-37aa4b30bc50cd5f
+      namespace: sabnzbd
+  target:
+    pvc:
+      name: sabnzbd-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 20Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 3600

--- a/k3s/applications/sabnzbd/pvc.yaml
+++ b/k3s/applications/sabnzbd/pvc.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: csi-hostpath-sc
+  storageClassName: longhorn   # was: csi-hostpath-sc
   resources:
     requests:
-      storage: 5Gi
+      storage: 20Gi   # was: 5Gi — snapshot data includes misplaced Downloads/complete, see docs/superpowers/plans/2026-08-21-restore-sabnzbd-config-from-kopia-backup.md Task 5
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd-config.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-sabnzbd-config.yaml
@@ -14,7 +14,7 @@ spec:
         name: sabnzbd-config
       sourcePathOverride: /config
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
## Summary
- Restores sabnzbd-config data lost when Task 5 of the csi-hostpath->longhorn
  migration deleted the source PVC before its Restore CR ever succeeded
  (multi-source SnapshotPolicy bug, fixed in #318, but the retry never happened)
- Restore CR pinned explicitly to the last known-good pre-incident snapshot
  (nas-disc-37aa4b30bc50cd5f, 2026-08-21T20:06:31Z) via snapshotRef, since the
  policy's own post-incident scheduled snapshots are of the blank state
- Completes the deferred half of #321/#320's sabnzbd migration: sabnzbd-config
  now on longhorn (20Gi, sized for the misplaced Downloads/complete data
  currently embedded in /config — see follow-up cleanup task in
  docs/superpowers/plans/2026-08-21-restore-sabnzbd-config-from-kopia-backup.md)

## Test plan
- [x] Restore CR completed, PVC verified bound on longhorn (20Gi) with real config content (sabnzbd.ini dated May 31, 18 config sections, admin/logs from before the incident)
- [x] sabnzbd API responds post-restore (`{"version":"5.0.4"}`)
- [x] kustomize build of k3s/applications renders sabnzbd-config as longhorn/20Gi matching the live PVC (no drift)
- [ ] User confirms indexers/categories/history visible in WebUI