### PR TITLE
feat(pihole): migrate pihole PVC from csi-hostpath-sc to longhorn (preserve data)

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -81,17 +81,19 @@ spec:
       existingSecret: "pihole-admin-password"
       passwordKey: "password"
 
-    # -- PVC persistence: csi-hostpath-sc, 1Gi, for /etc/pihole
-    # Changed from local-path → csi-hostpath-sc when pihole was onboarded
-    # to kopiur backups. Only csi-hostpath-sc PVCs can be snapshotted
-    # (csi-hostpath-snapclass is bound 1:1 to this storage class).
-    # Helm won't migrate the existing PVC; that's an imperative job.
+    # -- PVC persistence: longhorn, 1Gi, for /etc/pihole
+    # Migrated from csi-hostpath-sc to longhorn in feat/pihole-longhorn.
+    # The Restore CR in migration/restore.yaml creates a fresh longhorn PVC
+    # and populates it from the latest kopia snapshot BEFORE this chart value
+    # change ships. When the HelmRelease next reconciles after the PR merges,
+    # the chart's PVC template matches what's already there and Helm does not
+    # recreate the PVC.
     persistentVolumeClaim:
       enabled: true
       accessModes:
         - ReadWriteOnce
       size: "1Gi"
-      storageClass: "csi-hostpath-sc"
+      storageClass: "longhorn"
 
     # -- Probes: initialDelaySeconds: 30 — FTL is up in ~5s, the chart's
     #    default is 60s. 30s leaves a small buffer for first-boot gravity DB

--- a/k3s/applications/pihole/migration/restore.yaml
+++ b/k3s/applications/pihole/migration/restore.yaml
@@ -1,0 +1,68 @@
+---
+# Restore CR for the pihole csi-hostpath-sc → longhorn migration.
+# Operator-applied (NOT in kustomization.yaml — kustomization.yaml intentionally
+# lists only HelmRelease-managed artifacts; listing this Restore there causes
+# Flux to reapply it on every reconcile and fights the HelmRelease's
+# chart-managed PVC). Run with `kubectl apply -f` once after suspending
+# the HelmRelease and scaling pihole to 0 replicas. Matches the headlamp #309
+# and gatus #307 pattern.
+#
+# Pre-conditions (operator must do before applying):
+#   - HelmRelease `pihole` suspended (`kubectl patch helmrelease pihole -n pihole
+#     --type merge -p '{"spec":{"suspend":true}}'`). The Helm controller would
+#     otherwise recreate the csi-hostpath-sc PVC the moment we delete it.
+#   - pihole deployment scaled to 0 replicas (releases RWO on the old PVC).
+#   - Stale csi-hostpath-snapclass VolumeSnapshots cleared (they hold
+#     pvc-as-source-protection finalizers on the source PVC).
+#   - The old csi-hostpath-sc PVC `pihole` deleted (Restore's target.pvc would
+#     otherwise hit a name conflict; data is safe in kopia).
+#
+# Post-conditions:
+#   - PVC `pihole` exists, bound on `longhorn`, populated from the latest kopia
+#     snapshot via snapshot policy `pihole`.
+#   - Files retain original ownership: /etc/pihole/logrotate is `root:root 0640`
+#     (chart-init writes it before the user drop), and pihole-FTL.db / gravity.db
+#     are `pihole:pihole`. The snapshot policy uses `runAsUser: 0` / `runAsGroup:
+#     0` (privileged mover), which the Restore inherits via
+#     inheritSecurityContextFrom.snapshot, so restored files keep their original
+#     ownership. The pihole container runs as root (uid=0) so it can read
+#     logrotate.
+#
+# credentialProjection: REQUIRED. ClusterRepository `nas` secret lives in
+# kopiur-system, not pihole. Without `credentialProjection.enabled: true`
+# the Restore stalls with MissingCredentialsSecret.
+#
+# DNS impact: while pihole is scaled to 0, the network's DNS resolver at
+# 192.168.1.201 returns SERVFAIL for ~1–3 minutes during the swap. Pods in the
+# cluster are unaffected because they use 8.8.8.8 via podDnsConfig.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: pihole-longhorn-migration
+  namespace: pihole
+spec:
+  source:
+    fromPolicy:
+      name: pihole
+      offset: 0
+  target:
+    pvc:
+      name: pihole
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 1Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
@@ -56,4 +56,3 @@ spec:
       capacity: 1Gi
       storageClassName: local-path
       mode: Ephemeral
-

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-pihole.yaml
@@ -14,7 +14,11 @@ spec:
         name: pihole
       sourcePathOverride: /etc/pihole
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/pihole-longhorn. The pihole PVC is now on the `longhorn` StorageClass
+  # (PR prepping the move in helmrelease.yaml), so the CSI snapshot must use
+  # the matching Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:
@@ -52,3 +56,4 @@ spec:
       capacity: 1Gi
       storageClassName: local-path
       mode: Ephemeral
+


### PR DESCRIPTION
HelmRelease-managed migration (matches headlamp #309, portainer #310/#312, tdarr #328). Namespace has privileged-movers annotation for chart-init root-owned logrotate file.

DNS impact: during restore swap (~3 min) the network's resolver at 192.168.1.201 returns SERVFAIL. Pods in the cluster are unaffected (podDnsConfig → 8.8.8.8). Verified post-restore: dig @192.168.1.201 returns real IPs and /admin/login returns 200.

Pattern matches tdarr #328, headlamp #309, portainer #310/#312. Constraint #9 enforced (Restore CR Completed before scaling back up). Constraint #10 enforced (size 232M / 51 files / ownership preserved — busybox stat shows 'UNKNOWN' for pihole user but actual UID/GID 1000:1000 preserved correctly; verified from inside the pihole pod directly).

Note on plan Task 7: example YAML uses `persistence:` block, but this chart version (pihole 2.38.0) actually uses `persistentVolumeClaim:` at the top of values:. The actual edit landed in the correct block.

See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)