### PR TITLE
feat(authentik): migrate data-authentik-postgresql-0 PVC from csi-hostpath-sc to longhorn (preserve data)

### DIFF
--- a/k3s/applications/authentik/migration/restore.yaml
+++ b/k3s/applications/authentik/migration/restore.yaml
@@ -1,0 +1,50 @@
+---
+# Restore CR for the authentik-postgresql csi-hostpath-sc → longhorn migration.
+# Operator-applied. Matches headlamp #309 pattern.
+#
+# authentik-specific notes:
+# - Uses bitnami/postgresql StatefulSet. PVC name `data-authentik-postgresql-0`
+#   is fixed by the volumeClaimTemplate (immutable). The Restore's
+#   target.pvc.name MUST match exactly or the StatefulSet will fail to bind.
+# - Bitnami postgres runs as UID/GID 1001. Namespace carries
+#   kopiur.home-operations.com/privileged-movers: "true" so the snapshot
+#   can read the few root-owned files the Bitnami chart-init creates before
+#   user drop (same as pihole).
+# - The HelmRelease that owns this workload lives at
+#   k3s/infrastructure/configs/authentik/helmrelease.yaml, NOT under
+#   k3s/applications/authentik/ (that directory is unwired from Flux and only
+#   holds historical local-path → csi-hostpath-sc migration artifacts). This
+#   Restore CR is kept alongside those historical files for consistency with
+#   the other apps' migration/ convention, but is applied imperatively only.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: authentik-postgresql-longhorn-migration
+  namespace: authentik
+spec:
+  source:
+    fromPolicy:
+      name: authentik
+      offset: 0
+  target:
+    pvc:
+      # MUST match StatefulSet volumeClaimTemplate name exactly
+      name: data-authentik-postgresql-0
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -95,16 +95,16 @@ spec:
             memory: 512Mi
         persistence:
           size: 2Gi
-          # -- csi-hostpath-sc is the only SC in this cluster that supports
-          # VolumeSnapshots, which is required for kopiur backup coverage.
-          # Migration from local-path was performed imperatively (the chart
-          # value change alone wouldn't move the existing PVC); the imperative
-          # flow uses an intermediate `authentik-postgresql-hostpath` PVC on
-          # csi-hostpath-sc, an rsync stage-1 (with postgres quiesced), then
-          # the chart-managed `data-authentik-postgresql-0` PVC recreated on
-          # csi-hostpath-sc and an rsync stage-2 into it. Manifests in
-          # `k3s/applications/authentik/migration/`.
-          storageClass: csi-hostpath-sc
+          # -- Migrated from csi-hostpath-sc to longhorn in
+          # feat/authentik-longhorn. The Restore CR in
+          # k3s/applications/authentik/migration/restore.yaml creates a new
+          # data-authentik-postgresql-0 PVC on longhorn and populates it from
+          # the latest kopia snapshot; the StatefulSet's volumeClaimTemplate
+          # then matches what's already there. (Prior history: migrated from
+          # local-path to csi-hostpath-sc imperatively via an intermediate
+          # PVC + two rsync stages, manifests still in
+          # `k3s/applications/authentik/migration/` for the record.)
+          storageClass: longhorn
 
     redis:
       enabled: true

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-authentik.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotpolicy-authentik.yaml
@@ -14,7 +14,11 @@ spec:
         name: data-authentik-postgresql-0
       sourcePathOverride: /bitnami/postgresql/data
   copyMethod: Snapshot
-  volumeSnapshotClassName: csi-hostpath-snapclass
+  # Migrated from csi-hostpath-snapclass to longhorn-snapclass in
+  # feat/authentik-longhorn. data-authentik-postgresql-0 is now on the
+  # `longhorn` StorageClass, so the CSI snapshot must use the matching
+  # Longhorn VolumeSnapshotClass.
+  volumeSnapshotClassName: longhorn-snapclass
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
Most complex migration in the batch: bitnami/postgresql StatefulSet with an immutable volumeClaimTemplate. The Restore CR's `target.pvc.name` is exactly `data-authentik-postgresql-0` to match.

Completes Task 8 of docs/superpowers/plans/2026-08-20-finish-csi-hostpath-to-longhorn-migration.md. See docs/superpowers/specs/2026-08-20-finish-csi-hostpath-to-longhorn-migration-design.md for the design.

**Note on plan correction:** the plan document referenced `k3s/applications/authentik/helmrelease.yaml`, but authentik's live HelmRelease actually lives at `k3s/infrastructure/configs/authentik/helmrelease.yaml` — `k3s/applications/authentik/` only holds historical (unwired) local-path→csi-hostpath-sc migration artifacts. This PR edits the correct file.

**Verification performed:**
- Preflight: snapshot policy single-source confirmed, latest snapshot `Succeeded` and resolved to `data-authentik-postgresql-0` only, no stale Restore CRs, no controller-load warning signs, `privileged-movers` namespace annotation already present.
- Restore CR reached `Completed`; PVC `data-authentik-postgresql-0` bound on `longhorn`.
- Content verification: restored size (231.3M) matches source snapshot (`242330154` bytes ≈ 231MB); `PG_VERSION`, populated `base/`, and config files with pre-migration (2026-05-09) mtimes confirmed via throwaway busybox pod — not a blank DB.
- HelmRelease suspended during the PVC swap, un-suspended after (no forced reconcile against stale master values, to avoid an immutable-field conflict before this PR merges).
- postgresql StatefulSet + server/worker/outpost all scaled back and `Ready`; `/-/health/ready/` and `/-/health/live/` both return 200 (checked in-cluster, since this shell has no route to the external ingress hostname).

Pattern matches gatus #307, headlamp #309, portainer #310/#312, monitoring #311, tdarr #328, pihole #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)