### PR TITLE
fix(loki): disable gateway hard anti-affinity to unblock rolling updates on single-node cluster

### DIFF
--- a/k3s/infrastructure/controllers/loki/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrelease.yaml
@@ -96,6 +96,17 @@ spec:
     gateway:
       enabled: true
       replicas: 1
+      # The chart's default gateway.affinity is a *required* pod
+      # anti-affinity (one gateway pod per node). With replicas=1 and the
+      # Deployment default maxUnavailable=0/maxSurge=25%->1, that deadlocks
+      # every rolling update on this single-node cluster: the surge pod can
+      # never schedule alongside the old one (only one node to avoid), and
+      # the old one won't terminate until the surge pod is Ready. Hit during
+      # the chart 18.7.6 -> 18.11.0 bump (PR #301); required manually
+      # deleting the old pod to unblock. Emptying affinity removes the
+      # constraint entirely, which is safe here since there's only ever one
+      # gateway replica anyway.
+      affinity: {}
 
     # Allow kube-prometheus-stack Prometheus to scrape Loki's metrics.
     serviceMonitor:


### PR DESCRIPTION
The loki chart's default `gateway.affinity` is a required pod anti-affinity (one gateway pod per node). Combined with the Deployment's default `maxUnavailable: 0` / `maxSurge: 25%` (→1 for a single replica), this deadlocks every rolling update on this single-node cluster: the surge pod can never schedule alongside the old one, and the old one won't terminate until the surge pod is Ready.

Hit during the chart 18.7.6 → 18.11.0 bump (#301) — required manually deleting the old `loki-gateway` pod to unblock the rollout. This PR sets `gateway.affinity: {}` to remove the constraint entirely, which is safe here since there's only ever one gateway replica.

Verified with `helm template` against chart 18.11.0 that the rendered Deployment no longer has a `podAntiAffinity` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)