### PR TITLE
tune(resources): right-size CPU requests from KRR scan

### DIFF
--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -179,7 +179,7 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 500m
+              cpu: 20m
               memory: 2Gi
             limits:
               cpu: 2000m

--- a/k3s/applications/radarr/deployment.yaml
+++ b/k3s/applications/radarr/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 1000m
+              cpu: 100m
               memory: 900Mi
             limits:
               cpu: 1000m

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -163,7 +163,7 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 500m
+              cpu: 450m
               memory: 2200Mi
             limits:
               cpu: 3000m

--- a/k3s/applications/sonarr/deployment.yaml
+++ b/k3s/applications/sonarr/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 200m
+              cpu: 20m
               memory: 800Mi
             limits:
               cpu: 1000m

--- a/k3s/applications/tdarr/deployment-node.yaml
+++ b/k3s/applications/tdarr/deployment-node.yaml
@@ -56,7 +56,7 @@ spec:
               value: "1"
           resources:
             requests:
-              cpu: 2000m
+              cpu: 500m
               memory: 4Gi
             limits:
               cpu: 4000m

--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -118,7 +118,7 @@ spec:
     server:
       resources:
         requests:
-          cpu: 200m
+          cpu: 600m
           memory: 1Gi
         limits:
           memory: 1500Mi

--- a/k3s/infrastructure/configs/monitoring/helmrelease.yaml
+++ b/k3s/infrastructure/configs/monitoring/helmrelease.yaml
@@ -87,8 +87,8 @@ spec:
         probeSelectorNilUsesHelmValues: false
         resources:
           requests:
-            cpu: 51m
-            memory: 966Mi
+            cpu: 100m
+            memory: 1250Mi
           limits:
             memory: 2Gi
         storageSpec:

--- a/k3s/infrastructure/controllers/loki/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/loki/helmrelease.yaml
@@ -117,6 +117,9 @@ spec:
       # file — `null` renders no affinity block at all, `{}` still renders
       # the hard anti-affinity.
       affinity: null
+      resources:
+        requests:
+          cpu: 10m
 
     # Allow kube-prometheus-stack Prometheus to scrape Loki's metrics.
     serviceMonitor:


### PR DESCRIPTION
## Summary

KRR pass (simple strategy, 7d Prometheus history, P95 CPU / max+15% memory) scored the cluster **59/100** with node CPU **requests at 97% of allocatable** — the root cause of the rolling-update scheduling deadlocks seen on this single-node cluster (surge pods can't fit while old pods hold their reservations).

Applies the two approved scopes from the scan; **limits intentionally untouched**, memory cuts deferred.

## CPU request cuts (~3.2 cores freed)

| Workload | req now | new | KRR P95 |
|---|---|---|---|
| tdarr-node | 2000m | 500m | 495m |
| radarr | 1000m | 100m | 101m |
| qbittorrent | 500m | 20m | 13m |
| sonarr | 200m | 20m | 14m |
| sabnzbd | 500m | 450m | 427m |
| loki-gateway (nginx) | 50m | 10m | 10m |

Expected effect: node CPU requests drop ~97% → ~57%, permanently unblocking surge scheduling for rolling updates.

Note on loki: added a scoped `gateway.resources` override rather than changing `defaults.resources.requests.cpu`, because the defaults block also feeds the loki StatefulSet and lokiCanary, which were not in scope.

## Under-provisioned fixes

| Workload | change | reason |
|---|---|---|
| prometheus | cpu 51m→100m, mem 966Mi→1250Mi | observed peak 1209Mi — OOM risk |
| authentik-server | cpu 200m→600m | P95 577m — throttling during bursts |

## Deferred / follow-ups

- Memory right-sizing for media stack (incl. qbittorrent limit bump: rec 3276Mi > current limit 3072Mi)
- image-reflector-controller: P95 spike (16m request vs 1.33 cores) needs investigation before right-sizing
- ~35 WARNINGs are sidecars/exporters at KRR's 10m/100Mi floor values — individually trivial, skipped

## Validation

- `yamllint -c .yamllint.yaml k3s/applications k3s/infrastructure` ✅ (only pre-existing otel comment-indentation warning)
- `flux-local test --path k3s/clusters/homelab --skip-invalid-kustomization-paths` ✅ 6 passed