### PR TITLE
feat(goldilocks): add Goldilocks + VPA recommender

### DIFF
--- a/k3s/infrastructure/configs/monitoring/kustomization.yaml
+++ b/k3s/infrastructure/configs/monitoring/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - probe-portainer.yaml
   - probe-tdarr.yaml
   - probe-headlamp.yaml
+  - probe-goldilocks.yaml
   - probe-authentik.yaml
   - authentik-middleware.yaml
   - scrapeconfig-synology.yaml

--- a/k3s/infrastructure/configs/monitoring/probe-goldilocks.yaml
+++ b/k3s/infrastructure/configs/monitoring/probe-goldilocks.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: goldilocks
+  namespace: monitoring
+spec:
+  interval: 60s
+  module: http_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://goldilocks.homelab.properties

--- a/k3s/infrastructure/controllers/goldilocks/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/goldilocks/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: goldilocks
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: goldilocks
+      version: "11.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: fairwinds-stable
+        namespace: flux-system
+      interval: 12h
+  targetNamespace: goldilocks
+  install:
+    createNamespace: true
+    # The vpa sub-chart bundles the VerticalPodAutoscaler CRD; Helm only
+    # applies CRDs on first install by default, so a future chart bump that
+    # touches the CRD needs CreateReplace to actually land (same pattern as
+    # snapshot-controller's helmrelease.yaml).
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    vpa:
+      enabled: true
+      # Goldilocks' own values.yaml only overrides `updater.enabled: false`
+      # on the vpa sub-chart — admissionController still defaults to `true`
+      # there (verified via `helm show values fairwinds-stable/vpa --version
+      # 4.12.5`). Left enabled, it registers a cluster-wide mutating webhook
+      # on every Pod create — the exact "Auto" behavior (plus an extra
+      # single point of failure) this deployment deliberately avoids by
+      # staying recommend-only.
+      admissionController:
+        enabled: false
+    dashboard:
+      # Chart default is 2 replicas; no HA benefit on a single-node cluster.
+      replicaCount: 1
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          # Goldilocks has no built-in auth. Reuses the existing
+          # authentik-forwardauth Middleware defined in the monitoring
+          # namespace via Traefik's cross-namespace middleware reference
+          # syntax (<namespace>-<name>@kubernetescrd).
+          traefik.ingress.kubernetes.io/router.middlewares: monitoring-authentik-forwardauth@kubernetescrd
+        hosts:
+          - host: goldilocks.homelab.properties
+            paths:
+              - path: /
+                type: Prefix
+        tls:
+          - secretName: goldilocks-tls
+            hosts:
+              - goldilocks.homelab.properties

--- a/k3s/infrastructure/controllers/goldilocks/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/goldilocks/helmrepository.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: fairwinds-stable
+  namespace: flux-system
+spec:
+  # Renovate bumps chart versions; 24h was too long and caused HelmChart
+  # reconcile to stall when the index.yaml was republished between fetches
+  # (see PRs #250, #251). 1h aligns with Renovate's weekly schedule.
+  interval: 1h
+  url: https://charts.fairwinds.com/stable

--- a/k3s/infrastructure/controllers/goldilocks/kustomization.yaml
+++ b/k3s/infrastructure/controllers/goldilocks/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - snapshot-controller
   - csi-hostpath
   - longhorn
+  - goldilocks
   - flux2

--- a/k3s/platform/namespaces/goldilocks.yaml
+++ b/k3s/platform/namespaces/goldilocks.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: goldilocks

--- a/k3s/platform/namespaces/kustomization.yaml
+++ b/k3s/platform/namespaces/kustomization.yaml
@@ -18,4 +18,5 @@ resources:
   - telemetry.yaml
   - gatus.yaml
   - kopiur-system.yaml
+  - goldilocks.yaml
   - flux-system.yaml


### PR DESCRIPTION
## Summary
- Deploys Fairwinds Goldilocks + the VPA recommender (no updater, no admission-controller — recommend-only, matches this repo's existing krr-based right-sizing workflow but continuous)
- Dashboard at https://goldilocks.homelab.properties, behind the existing authentik forward-auth Middleware
- Uptime probe added alongside the other app probes
- Namespace opt-in labels intentionally NOT included in this PR — tracked as a gated follow-up once this is confirmed healthy on the live cluster

## Test plan
- [ ] `kustomize build k3s/clusters/homelab` succeeds
- [ ] `flux-local test` / `flux-local diff` clean
- [ ] CI `Flux Validate` workflow green