### PR TITLE
fix(authentik): use homelab-proxy-outpost's own token, not the embedded outpost's

### DIFF
--- a/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
+++ b/k3s/infrastructure/configs/authentik/authentik-secret.sops.yaml
@@ -9,7 +9,7 @@ stringData:
     AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:IrpDGTHpRl7yX6gxw5oaKfcRx53NOkeaTJHpZs1pjMGFPl1x0+V2PYcV9vUtHYmhqts=,iv:VRinO8nTIFSLke4MLgV1flpasnxd9mpb3zfEnJ5dr/E=,tag:AM3PCmHXt2xQ1q7Cpv0K6A==,type:str]
     grafana-oidc-client-secret: ENC[AES256_GCM,data:pKCLAom7CZfSCC2TNZYsL+K9IyDm+EQfIL4f8t5W6j8=,iv:PUV9G6TuBaoNWjqJSv/lPPSvYFOMwKst34GfjwKmUOA=,tag:s9SgVWrh8WzK6T0uBQNMMw==,type:str]
     headlamp-oidc-client-secret: ENC[AES256_GCM,data:7g4wFCQH2yWzT86SvcmKYsbsMkWV1wFWAsspbLQkMRA=,iv:sUkFVHYDCz2Ydn0hqoQ8Gp0VVPgrPpA5h6pu1ek1IgA=,tag:kYEUpJyG3b5q/jIyls06VA==,type:str]
-    outpost-token: ENC[AES256_GCM,data:JtTHAkgrSvrCKR6ZeouNUJqVWlyqMzwYpTbJlW4f/DUQMKt+YT49Uj3EdCsVcfYeTb25AcfRBz578VwJ,iv:M6zLcpPbcLckcWjqej4x605HEnaQAsoScTDAQ391fHM=,tag:0kDx2fy9Xc4VE+A3eY9scQ==,type:str]
+    outpost-token: ENC[AES256_GCM,data:tKxLg2aAFEf2FJYSGH3bWySwnF56QTXhySWuMmQoAEJg2N8C/p2Y0XF9f92O8FZPZ2KXdTXcIY5MUqYn,iv:lz9aMCTwOxjfyih/SAp4iSXRXGEPDDUNcqsvZyoXjy0=,tag:x/+TDAPElyN0EAGzUaZQQg==,type:str]
     portainer-oidc-client-secret: ENC[AES256_GCM,data:jN3po/eCYxKrnF7FN2/fIZ7NUs6nAoOOAW7HC+/PYv2cCkVyPpzPstuFVFt4PedD/QAYs062Rx6LuJMC521WbA==,iv:dtcr+qXU5wp8dWEpsUcPALahOYPAphohHE/CCHS1Sw8=,tag:cBGVJrnCPvxoulG8iuBdRA==,type:str]
     gatus-oidc-client-secret: ENC[AES256_GCM,data:l0GD1+u2ZZsp9W+4d6XSri4xwtCQiyNh9OTU8pOdid1et7twc1grZVhxT4sJAjeIz5fjB/rO/fZEjlz3oSiW,iv:eMBliiIIO6K0gt8oKmPE6gC2SNMjMHbME8HmnpYi1rA=,tag:Oe07KPGWOh3YSISXat3RDg==,type:str]
     postgresql-password: ENC[AES256_GCM,data:IPNLtvh0FnV/YdsCVMVLE/N43jsLCZ0kmxpP3uK+DNY=,iv:8hIf62jJNLJalt4naTFqoIh4Ajm0a65FJZgSW/6BZkU=,tag:W4/JPUsKplqOYzJV1YiD1Q==,type:str]
@@ -25,7 +25,7 @@ sops:
             QmRHNlA5ZisvQVZic1BuZEd3ejZWRmMKcI/udsiu17DuluFvvxF/xtKLxjLJIHOV
             WzAghp7ZyU9YvKhoGExBndGoDiuJM35jjLY7XQAACENxWihagIa8Ug==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-08-07T01:33:59Z"
-    mac: ENC[AES256_GCM,data:i+k2CI7VHWJeNfEDzaYwBOhTyEx1ZzxlC3abMz+e+GTqI5OqVFbSxRBs9t4xVsDExD+Tl73nlLtYITxKHWxmV86vGgafN3ngUWQpRWN01sl275JsJ5eZ8NqEom8ZjNgcETC7IKdrCBPE/Zi7JsPyyseBY6r6ALSKcpX1Mq1ZyU8=,iv:Vj3zo0Rjo0NObqdUGEVMR6As1fCq9CW6USyYF6SKYDE=,tag:guNFDQekud1VvpeFxHaukg==,type:str]
+    lastmodified: "2026-08-24T17:48:33Z"
+    mac: ENC[AES256_GCM,data:XAaXLcyjUke7XnBdOv1aVXZmyYsoAAtjVdX9vRAb78+DW9omn0PrSJF5oR0rlKq/+kcftA1X8QQpNv+ORPal+V2LZXqZvJSyU5kpve1v2V+YTluLDwbNNK6EWdNEUvtAHwTyVJWN9+wQOBaxCCgtPkVr6HHKPxw9f6WBMDM4bk0=,iv:Q4xQGGSaly6+QdhO4oF45WbTXsAh5Ku38ineWfBflk8=,tag:rxmJWng4OlvPahig+eKW5w==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
+++ b/k3s/infrastructure/configs/authentik/blueprints-configmap.yaml
@@ -122,15 +122,24 @@ data:
           name: Alertmanager
           slug: alertmanager
           provider: !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-provider]]
-      - model: authentik_core.token
+      - model: authentik_providers_proxy.proxyprovider
         state: present
         identifiers:
-          identifier: outpost-token
+          name: goldilocks-provider
         attrs:
-          identifier: outpost-token
-          key: !Env AUTHENTIK_ENV__OUTPOST_TOKEN
-          intent: api
-          user: !Find [authentik_core.user, [username, akadmin]]
+          name: goldilocks-provider
+          mode: forward_single
+          external_host: https://goldilocks.homelab.properties
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: goldilocks
+        attrs:
+          name: Goldilocks
+          slug: goldilocks
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, goldilocks-provider]]
       - model: authentik_outposts.outpost
         state: present
         identifiers:
@@ -138,10 +147,10 @@ data:
         attrs:
           name: homelab-proxy-outpost
           type: proxy
-          token: !Find [authentik_core.token, [identifier, outpost-token]]
           providers:
             - !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-provider]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, alertmanager-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, goldilocks-provider]]
           config:
             authentik_host: https://auth.homelab.properties
             authentik_host_insecure: false

--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -54,10 +54,6 @@ spec:
       targetPath: authentik.env.HEADLAMP_OIDC_CLIENT_SECRET
     - kind: Secret
       name: authentik-secret
-      valuesKey: outpost-token
-      targetPath: authentik.env.OUTPOST_TOKEN
-    - kind: Secret
-      name: authentik-secret
       valuesKey: portainer-oidc-client-secret
       targetPath: authentik.env.PORTAINER_OIDC_CLIENT_SECRET
     - kind: Secret


### PR DESCRIPTION
## Summary

`https://goldilocks.homelab.properties/` was returning HTTP 500. Root cause traced through several layers:

- The `authentik-secret`'s `outpost-token` value was the **autogenerated service-account token for authentik's built-in Embedded Outpost**, not for `homelab-proxy-outpost`. The standalone `authentik-outpost` Deployment authenticated with it and so self-identified as the embedded outpost (`"embedded": true` in its logs), which assumes a `localhost` backchannel to `authentik-server`. Run as its own pod, that backchannel doesn't exist, so its websocket sync failed with `Connection refused` forever and its proxy listener (ports 9000/9443) never started.
- This was silent for ~42 hours because the `authentik-forwardauth` Traefik middleware had zero consumers until Goldilocks's ingress went live — Goldilocks was simply the first thing to exercise the broken outpost.
- Along the way, discovered `prometheus.homelab.properties` and `alertmanager.homelab.properties` have **no forward-auth middleware on their ingresses at all** and are currently wide open — worth a follow-up, out of scope here.
- Once the token was fixed, the outpost came up healthy but returned 400 `no app for hostname` for goldilocks, because `homelab-proxy-outpost` never had a ProxyProvider registered for it (only prometheus/alertmanager were).

## Changes

- Swap `authentik-secret`'s `outpost-token` for `homelab-proxy-outpost`'s real autogenerated token.
- Remove the blueprint's `authentik_core.token` entry and the outpost's `token:` attribute — `Outpost` has no such field in this authentik version, so it was a silent no-op. Every outpost's token is autogenerated and keyed to its own UUID. Also drops the now-dead `OUTPOST_TOKEN` env wiring in the HelmRelease.
- Register `goldilocks.homelab.properties` as a proxy provider on `homelab-proxy-outpost`, mirroring the existing prometheus/alertmanager pattern.

## Verification

- `yamllint`, `kustomize build`, and `flux-local test` (6/6) all pass; `flux-local diff` shows only the intended removals.
- Applied live for end-to-end verification: outpost logs `"embedded": false`, loads all three applications (`alertmanager`, `prometheus`, `goldilocks`), and `https://goldilocks.homelab.properties/` now `302`s to the authentik login page instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
