### PR TITLE
feat(goldilocks): enable tracking on all declared namespaces

### DIFF
--- a/k3s/platform/namespaces/authentik.yaml
+++ b/k3s/platform/namespaces/authentik.yaml
@@ -10,5 +10,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: authentik
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
   annotations:
     kopiur.home-operations.com/privileged-movers: "true"

--- a/k3s/platform/namespaces/cert-manager.yaml
+++ b/k3s/platform/namespaces/cert-manager.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/external-dns.yaml
+++ b/k3s/platform/namespaces/external-dns.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: external-dns
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/flux-system.yaml
+++ b/k3s/platform/namespaces/flux-system.yaml
@@ -32,6 +32,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
+    goldilocks.fairwinds.com/enabled: "true"
   annotations:
     # Excluded from garbage collection on purpose.
     #

--- a/k3s/platform/namespaces/gatus.yaml
+++ b/k3s/platform/namespaces/gatus.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gatus
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/goldilocks.yaml
+++ b/k3s/platform/namespaces/goldilocks.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: goldilocks
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/headlamp.yaml
+++ b/k3s/platform/namespaces/headlamp.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: headlamp
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/kopiur-system.yaml
+++ b/k3s/platform/namespaces/kopiur-system.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kopiur-system
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/media.yaml
+++ b/k3s/platform/namespaces/media.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: media
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/monitoring.yaml
+++ b/k3s/platform/namespaces/monitoring.yaml
@@ -12,5 +12,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
   annotations:
     kopiur.home-operations.com/privileged-movers: "true"

--- a/k3s/platform/namespaces/pihole.yaml
+++ b/k3s/platform/namespaces/pihole.yaml
@@ -10,5 +10,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: pihole
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
   annotations:
     kopiur.home-operations.com/privileged-movers: "true"

--- a/k3s/platform/namespaces/portainer.yaml
+++ b/k3s/platform/namespaces/portainer.yaml
@@ -10,5 +10,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: portainer
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
   annotations:
     kopiur.home-operations.com/privileged-movers: "true"

--- a/k3s/platform/namespaces/qbittorrent.yaml
+++ b/k3s/platform/namespaces/qbittorrent.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: qbittorrent
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/sabnzbd.yaml
+++ b/k3s/platform/namespaces/sabnzbd.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: sabnzbd
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/sense-exporter.yaml
+++ b/k3s/platform/namespaces/sense-exporter.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: sense-exporter
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/tdarr.yaml
+++ b/k3s/platform/namespaces/tdarr.yaml
@@ -10,5 +10,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tdarr
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
   annotations:
     kopiur.home-operations.com/privileged-movers: "true"

--- a/k3s/platform/namespaces/telemetry.yaml
+++ b/k3s/platform/namespaces/telemetry.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: telemetry
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/platform/namespaces/unpoller.yaml
+++ b/k3s/platform/namespaces/unpoller.yaml
@@ -5,3 +5,4 @@ metadata:
   name: unpoller
   labels:
     app.kubernetes.io/name: unpoller
+    goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Summary
- Labels all 18 repo-declared namespaces with goldilocks.fairwinds.com/enabled=true
- Follow-up to the Goldilocks + VPA controller PR (#340); only opened after confirming
  the recommender/dashboard are healthy on the live cluster and no VPA
  admission webhook was installed

## Test plan
- [ ] Live-cluster precondition checks passed before this PR was opened (see plan Task 5, Step 1)
- [ ] `kustomize build k3s/clusters/homelab` succeeds
- [ ] `flux-local diff` shows only the expected label additions
- [ ] After merge: watch cluster stability (kine/lease contention) as VerticalPodAutoscaler objects get created across all namespaces; if unstable, the fix is removing labels from lower-priority namespaces, not a redesign