### PR TITLE
fix(headlamp): enable OIDC_SCOPES in headlamp binary args

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -52,6 +52,14 @@ spec:
         externalSecret:
           enabled: true
           name: headlamp-oidc-secret
+          # Required when the secret contains an OIDC_SCOPES key. The chart
+          # gates the `-oidc-scopes=$(OIDC_SCOPES)` arg on this flag
+          # (default false) and silently omits it otherwise, so the binary
+          # falls back to its built-in default of `openid profile email`.
+          # Without offline_access in the authorize URL, authentik never
+          # issues a refresh token, and Headlamp forces re-auth every
+          # session-ttl (24h) once the access token expires.
+          hasScopes: true
     clusterRoleBinding:
       clusterRoleName: cluster-admin
     resources:


### PR DESCRIPTION
## Summary

One-line fix that stops Headlamp from "ghost signouting" every 24h.

## Root cause

The Headlamp chart 0.45.0 gates the `-oidc-scopes=$(OIDC_SCOPES)` arg behind `config.oidc.externalSecret.hasScopes`, which defaults to `false`. The chart's `deployment.yaml` line 360:

```yaml
{{- if $oidc.externalSecret.hasScopes }}
- "-oidc-scopes=$(OIDC_SCOPES)"
{{- end }}
```

The values.yaml comment explains the default behavior: "When false (default), the `-oidc-scopes` argument is omitted so that a missing key does not produce an empty or unresolved argument." Fair safety behavior, but it makes the silent omission very hard to notice.

Our `headlamp-oidc-secret` has the `OIDC_SCOPES` key with value `openid email profile offline_access`, and the helm value `oidc.scopes` is also set. The env var gets populated correctly (visible via `kubectl exec printenv`), but the binary is invoked **without** the `-oidc-scopes` arg and falls back to its built-in default of `openid profile email`.

## Evidence

- **Live Deployment args** on the running headlamp pod (before fix): `-oidc-client-id`, `-oidc-client-secret`, `-oidc-idp-issuer-url` are present, but `-oidc-scopes` is missing.
- **20+ `authorize_application` events for Headlamp, all-time** (queried `authentik_events_event`): every one has `http_request.args.scope = "openid profile email"` (or re-ordered) — never `offline_access`. The granted scopes match.
- **Refresh token table** (`authentik_providers_oauth2_refreshtoken`): zero rows for the headlamp-provider, ever.
- **`session-ttl=86400`** in the headlamp args explains the 24h delay before the first `failed to refresh token: refresh token is not set` error fires after each login.

## Why this is not #6793

#6793 (the open upstream PR) addresses `invalid_grant` errors from **concurrent** token refresh races. That bug only matters if a refresh token exists in the first place. Our logs show `refresh token is not set` — Headlamp never got one, because `offline_access` never reached the IdP. Two different bugs; this fix doesn't address #6793.

## Render validation

```bash
$ helm template headlamp /tmp/headlamp-chart/headlamp/ \
    --set config.oidc.clientID=headlamp \
    --set 'config.oidc.scopes=openid email profile offline_access' \
    --set config.oidc.issuerURL=https://auth.homelab.properties/application/o/headlamp/ \
    --set 'config.oidc.externalSecret.enabled=true' \
    --set 'config.oidc.externalSecret.name=headlamp-oidc-secret' \
    --set 'config.oidc.externalSecret.hasScopes=true' \
  | grep oidc-scopes
            - "-oidc-scopes=$(OIDC_SCOPES)"
```

## Post-merge verification (after `flux reconcile`)

1. `kubectl -n headlamp get deploy headlamp -o jsonpath='{.spec.template.spec.containers[0].args}'` should now include `-oidc-scopes=$(OIDC_SCOPES)`.
2. Trigger a re-login through Headlamp; the next `authorize_application` event in `authentik_events_event` should have `scope: openid email profile offline_access`.
3. After login, `SELECT count(*) FROM authentik_providers_oauth2_refreshtoken WHERE provider_id = (headlamp-provider id)` should be `> 0`.
4. Wait 25h (past `session-ttl=86400`); the access token expires but Headlamp should silently refresh instead of forcing re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)