### PR TITLE
fix(infrastructure): include system-upgrade-controller in controllers kustomization

### DIFF
--- a/k3s/infrastructure/controllers/kustomization.yaml
+++ b/k3s/infrastructure/controllers/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - alloy
   - kopiur
   - snapshot-controller
+  - system-upgrade-controller
   - csi-hostpath
   - longhorn
   - goldilocks


### PR DESCRIPTION
## Summary

One-line fix: add `system-upgrade-controller` to the umbrella `k3s/infrastructure/controllers/kustomization.yaml` `resources` list.

## Root cause

The umbrella kustomization explicitly enumerates sub-kustomizations rather than auto-globbing. #344 added the new directory but didn't add it here, so Flux's `infra-controllers` Kustomization reconciled against an unchanged tree and the new HelmRepository/HelmRelease/Plan were never applied to the cluster. The PR was merged successfully but produced zero of the new resources on the live cluster.

## Evidence on live cluster before fix

- `kubectl -n flux-system get hr` shows 13 HelmReleases, none matching `system-upgrade-controller`
- `kubectl -n flux-system get helmrepository` shows no `rancher-charts`
- `kubectl api-resources | grep plan` returns nothing
- `kustomize build k3s/infrastructure/controllers/` shows the umbrella build never included the new directory

## Fix

Add `- system-upgrade-controller` to the umbrella resources list alphabetically between `snapshot-controller` and `csi-hostpath`. Verified locally with `kustomize build k3s/infrastructure/controllers/` — now produces the expected `HelmRelease/system-upgrade-controller` and `HelmRepository/rancher-charts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)