### PR TITLE
fix(infrastructure): use repo root URL for rancher-charts HelmRepository

### DIFF
--- a/k3s/infrastructure/controllers/system-upgrade-controller/helmrepository.yaml
+++ b/k3s/infrastructure/controllers/system-upgrade-controller/helmrepository.yaml
@@ -9,4 +9,9 @@ spec:
   # weekly schedule so a Renovate-triggered chart bump is visible within
   # the same reconciliation cycle it lands.
   interval: 1h
-  url: https://charts.rancher.io/index.yaml
+  # Rancher publishes the index at https://charts.rancher.io/index.yaml,
+  # but Flux v2 HelmRepository appends an /index.yaml of its own, so the
+  # spec.url must be the repository root. With index.yaml here, the
+  # source-controller fetches charts.rancher.io/index.yaml/index.yaml
+  # and the reconcile fails with 404.
+  url: https://charts.rancher.io


### PR DESCRIPTION
## Summary

Drop the trailing `/index.yaml` from `url:`. One-line change.

## Why

Once #346 made the Plan reconcileable, the HelmRelease dry-run surfaced:

```
failed to fetch https://charts.rancher.io/index.yaml/index.yaml : 404
```

Flux HelmRepository appends `/index.yaml` to whatever you set in `spec.url`. The rancher-charts registry advertises the index at `https://charts.rancher.io/index.yaml` (correct for direct fetch), but the Flux source controller treats that URL as a directory and appends again, producing `…/index.yaml/index.yaml`.

## Fix

Use the repository root as Flux expects:

```yaml
url: https://charts.rancher.io
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)