### PR TITLE
fix(infrastructure): pin system-upgrade-controller to cattle-system namespace

### DIFF
--- a/k3s/infrastructure/configs/system-upgrade-controller/plans.yaml
+++ b/k3s/infrastructure/configs/system-upgrade-controller/plans.yaml
@@ -7,15 +7,15 @@
 # server).
 #
 # To force an upgrade outside the window:
-#   kubectl create job --from=plan/server-plan -n system-upgrade manual-upgrade
-# (controller refuses if a job of that name exists; retry until it accepts.)
+#   kubectl -n cattle-system create job --from=plan/server-plan manual-upgrade
+# (controller refuses if a job of that name still exists; retry until it accepts.)
 #
 # Field reference: https://github.com/rancher/system-upgrade-controller/blob/main/pkg/apis/upgrade.cattle.io/v1/types.go
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
   name: server-plan
-  namespace: system-upgrade
+  namespace: cattle-system
 spec:
   # Drain and replace the control-plane kubeconfig secret in-flight.
   concurrency: 1
@@ -25,7 +25,9 @@ spec:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
-  serviceAccountName: system-upgrade
+  # Created by the chart in cattle-system; the chart's ClusterRoleBinding
+  # grants cluster-admin so the upgrade Job can manipulate node state.
+  serviceAccountName: system-upgrade-controller
   # Mark the node unschedulable before the upgrade pod runs (drain is
   # default-skipped since this is a single-server cluster — there are no
   # pods to evict; k3s-system pods are DaemonSet-managed and ignored).

--- a/k3s/infrastructure/controllers/system-upgrade-controller/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/system-upgrade-controller/helmrelease.yaml
@@ -20,11 +20,18 @@ spec:
         kind: HelmRepository
         name: rancher-charts
         namespace: flux-system
-  # The upstream controller manifest
-  # (https://github.com/rancher/system-upgrade-controller/blob/main/manifests/system-upgrade-controller.yaml)
-  # lives in the `system-upgrade` namespace and the chart defaults match.
-  # The `system-upgrade` ServiceAccount there is what Plan resources use.
-  targetNamespace: system-upgrade
+  # The rancher-charts `system-upgrade-controller` chart hardcodes the
+  # `cattle-system` namespace in its ServiceAccount / Deployment /
+  # ClusterRoleBinding templates — `targetNamespace` is ignored. The
+  # chart's installed SA there is named `system-upgrade-controller` and
+  # is what Plan resources reference.
+  #
+  # The bare upstream manifest (rancher/system-upgrade-controller
+  # manifests/system-upgrade-controller.yaml) uses `system-upgrade` and
+  # was what #344 originally targeted — but that is the deprecated
+  # direct-deploy manifest, not the chart. The chart is what Flux needs
+  # to drive upgrades.
+  targetNamespace: cattle-system
   install:
     createNamespace: true
     # Chart ships the Plan CRDs (upgrade.cattle.io/v1); same CRD strategy


### PR DESCRIPTION
## Why

#347 unblocked the index fetch. Helm install then surfaced:

```
namespaces "cattle-system" not found
```

The rancher-charts chart hardcodes `cattle-system` in its SA/Deployment/CRB templates; `targetNamespace: system-upgrade` is ignored. Chart installs SA `system-upgrade-controller`, not `system-upgrade`.

## Fix

- HelmRelease `targetNamespace: cattle-system`
- Plan `namespace: cattle-system`, `serviceAccountName: system-upgrade-controller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)