### PR TITLE
fix(infrastructure): use CronJob to trigger server-plan upgrades

### DIFF
--- a/k3s/infrastructure/configs/system-upgrade-controller/kustomization.yaml
+++ b/k3s/infrastructure/configs/system-upgrade-controller/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - plan.yaml
+  - trigger.yaml

--- a/k3s/infrastructure/configs/system-upgrade-controller/plan.yaml
+++ b/k3s/infrastructure/configs/system-upgrade-controller/plan.yaml
@@ -2,7 +2,13 @@
 # Plan resource for system-upgrade-controller.
 #
 # Follows the k3s stable release channel and upgrades the single
-# control-plane node weekly inside a Sun 04:00-05:00 UTC window.
+# control-plane node when triggered. Triggered weekly by the
+# `server-plan-trigger` CronJob in this directory (controller binary
+# installed via the vendored upstream manifest is v0.14.0, whose
+# `Plan` spec does not include `window` or `cron` — the upstream
+# repo's vendored CRD predates those fields, which is why the schedule
+# has to live in a CronJob, not on the Plan).
+#
 # No agent Plan because this cluster has no agents (apps run on the
 # server).
 #
@@ -10,12 +16,11 @@
 # the upstream vendored manifest; its ClusterRoleBinding grants
 # cluster-admin so the upgrade Job can manipulate node state.
 #
-# To force an upgrade outside the window:
+# To force an upgrade outside the trigger window:
 #   kubectl -n system-upgrade create job --from=plan/server-plan manual-upgrade
 # (controller refuses if a job of that name still exists; retry.)
 #
-# Field reference:
-# https://github.com/rancher/system-upgrade-controller/blob/master/pkg/apis/upgrade.cattle.io/v1/types.go
+# Field reference (v0.14.0): https://raw.githubusercontent.com/rancher/system-upgrade-controller/v0.14.0/pkg/apis/upgrade.cattle.io/v1/types.go
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
@@ -24,9 +29,6 @@ metadata:
 spec:
   # Drain and replace the control-plane kubeconfig secret in-flight.
   concurrency: 1
-  # matchExpressions is more idiomatic than matchLabels and matches the
-  # upstream k3s example
-  # (https://github.com/rancher/system-upgrade-controller/blob/master/examples/k3s-upgrade.yaml).
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
@@ -37,19 +39,9 @@ spec:
   # evict; k3s-system pods are DaemonSet-managed and ignored.
   cordon: true
   upgrade:
-    # The tag is irrelevant — the `channel` field below drives the
-    # actual k3s release selected.
+    # The tag is irrelevant — `channel` below drives the actual k3s
+    # release selected.
     image: rancher/k3s-upgrade
   # Stable k3s release channel URL — controller polls this on each
   # reconcile and pins the latest version advertised at that time.
   channel: https://update.k3s.io/v1-release/channels/stable
-  # Schedule: Sundays 04:00-05:00 UTC. Plan has no `cron` field — it
-  # uses a time window per the CRD types. The 1-hour window gives the
-  # controller room to start the upgrade Job without missing the
-  # deadline.
-  window:
-    days:
-      - sun
-    startTime: "04:00"
-    endTime: "05:00"
-    timeZone: "UTC"

--- a/k3s/infrastructure/configs/system-upgrade-controller/trigger.yaml
+++ b/k3s/infrastructure/configs/system-upgrade-controller/trigger.yaml
@@ -1,0 +1,98 @@
+---
+# CronJob that creates a manual-upgrade Job from `server-plan` weekly.
+#
+# Why this exists: the v0.14.0 system-upgrade-controller that this repo
+# pinned (via the upstream raw manifest) does not expose `window` or
+# `cron` on the Plan CRD — the upstream `pkg/crds/yaml/generated/`
+# artifact predates those fields and is unregenerated. Pinning the
+# controller to a newer release (v0.20.x) would require either baking
+# the v0.20.x image into the manifest (effective upstream re-pin) or
+# patching the vendored CRD by hand (risky for an OAPI v3 schema).
+#
+# A cluster-native CronJob that calls `kubectl create job --from=plan/...`
+# avoids both: it triggers the Plan the same way an operator would, and
+# the controller then runs the upgrade on the matched node.
+#
+# Manual-trigger rationale: we generate a unique Job name every
+# invocation so the controller never rejects with "job already exists".
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: server-plan-trigger
+  namespace: system-upgrade
+spec:
+  # Weekly Sun 04:00 UTC. Single-server cluster: ~30-60s unavailability
+  # during the binary swap is acceptable at this hour.
+  schedule: "0 4 * * SUN"
+  # Default is 3 — keep two so we have a recent history without filling
+  # the namespace with old jobs.
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  # Don't auto-suspend when missed (e.g. controller down). We still want
+  # the trigger on the next window.
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 900
+      template:
+        spec:
+          # The Plan controller listens for jobs in the Plan's
+          # namespace; this Pod just creates one and exits.
+          # Uses `kubectl create job --from=plan/server-plan` which is
+          # the canonical way to trigger an on-demand upgrade.
+          # bitnami/kubectl is already trusted in this repo via the
+          # Flux `helm-controller` image pattern and stays under
+          # 20 MB. The namespace-default SA has no power; the explicit
+          # `kubectl` ServiceAccount is unused here — this Pod only
+          # needs `create` on `jobs.batch` in `system-upgrade`.
+          serviceAccountName: trigger-sa
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: registry.k8s.io/kubectl:v1.32.2
+              args:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  JOB="manual-upgrade-$(date -u +%Y%m%d%H%M%S)"
+                  kubectl -n system-upgrade create job "$JOB" --from=plan/server-plan
+                  echo "created upgrade job $JOB"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+---
+# Dedicated ServiceAccount for the trigger pod. Just needs to create
+# jobs.batch in the system-upgrade namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trigger-sa
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: trigger-sa
+  namespace: system-upgrade
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trigger-sa
+  namespace: system-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: trigger-sa
+    namespace: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trigger-sa


### PR DESCRIPTION
## Why

After #349 merged, the controller pod came up and the Plan CRD was installed, but `infra-configs` still failed with:

```
Plan/server-plan dry-run failed: .spec.window: field not declared in schema
```

The vendored upstream `manifests/system-upgrade-controller.yaml` pins `rancher/system-upgrade-controller:v0.14.0`, which has only `channel`/`version` on Plan spec — no `window` or `cron`. The upstream `pkg/crds/yaml/generated/upgrade.cattle.io_plans.yaml` predates those fields (unregenerated for years), so pinning any controller version that has them would require also re-vendoring the CRD. Single-field gain isn't worth a seven-step re-pin.

## Fix

Move the schedule into a CronJob that triggers the Plan the way an operator would by hand:

- Drop `window` from the Plan (must match what's in the v0.14.0-era CRD)
- Add `trigger.yaml` with: `CronJob/server-plan-trigger` + a `ServiceAccount`/`Role`/`RoleBinding` scoped to `create jobs.batch` in `system-upgrade`
- CronJob uses `kubectl create job --from=plan/server-plan` with a unique name so the controller never rejects with "job already exists"

## Behavior

- Plan pins the k3s stable release channel (still does the version-selection work)
- CronJob runs Sundays 04:00 UTC
- CronJob → `kubectl create job` → controller sees the manual-upgrade job → drains the node, swaps the binary, restarts k3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)