### PR TITLE
fix(infrastructure): add controller resource limits, bump job kubectl image

### DIFF
--- a/k3s/infrastructure/controllers/system-upgrade-controller/controller.yaml
+++ b/k3s/infrastructure/controllers/system-upgrade-controller/controller.yaml
@@ -23,7 +23,13 @@ data:
   SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: "900"
   SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: "99"
   SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: "Always"
-  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: "rancher/kubectl:v1.30.3"
+  # Upstream's compiled-in default is v1.30.3 regardless of controller
+  # version (pkg/upgrade/job/job.go), which is 6 minors behind this
+  # cluster's k3s v1.36.4 server -- outside kubectl's supported +/-1
+  # skew. This is what runs `kubectl cordon <node>` as an init
+  # container in every upgrade Job (cordon: true on the Plan). Bumped
+  # by hand to the closest published rancher/kubectl tag.
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: "rancher/kubectl:v1.36.2"
   # Only set if you have Windows nodes to upgrade; ignored otherwise.
   SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE_WINDOWS: ""
   SYSTEM_UPGRADE_JOB_PRIVILEGED: "true"
@@ -88,6 +94,15 @@ spec:
         - name: system-upgrade-controller
           image: rancher/system-upgrade-controller:v0.20.1
           imagePullPolicy: IfNotPresent
+          # Not in upstream's manifest. Observed idle usage on this
+          # cluster is ~1m CPU / 15Mi memory; sized with headroom for
+          # reconcile spikes while a Plan is applying.
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534

--- a/k3s/infrastructure/controllers/system-upgrade-controller/kustomization.yaml
+++ b/k3s/infrastructure/controllers/system-upgrade-controller/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 # System-upgrade-controller — vendored from upstream raw manifests,
-# pinned to release v0.20.1 (controller.yaml, clusterrole.yaml,
-# clusterrolebinding.yaml, and crd.yaml here are byte-identical to
+# pinned to release v0.20.1 (clusterrole.yaml, clusterrolebinding.yaml,
+# and crd.yaml here are byte-identical to
 # https://github.com/rancher/system-upgrade-controller's manifests/
 # and pkg/crds/yaml/generated/upgrade.cattle.io_plans.yaml at that
 # tag). Note: upstream's own checked-in manifests/system-upgrade-
@@ -14,6 +14,17 @@
 # image (`docker pull rancher/system-upgrade-controller:v0.20.1`
 # resolves) with RBAC/deployment shape identical to v0.14.0's, so the
 # image tag was bumped by hand here without any other manifest changes.
+#
+# controller.yaml is NOT byte-identical to upstream — two deliberate
+# deviations, both because upstream's own defaults were stale, not
+# because anything here is wrong: the controller container now sets
+# `resources` (upstream ships none at all), and
+# SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE is bumped to rancher/kubectl:v1.36.2
+# (upstream's compiled-in default, v1.30.3, is hardcoded in
+# pkg/upgrade/job/job.go regardless of controller version and is 6
+# minors behind this cluster's k3s server — outside kubectl's
+# supported skew). Re-check both against upstream's current defaults
+# when next bumping the controller version.
 #
 # Why raw manifest + not the rancher-charts Helm chart (which is what
 # #344 used): chart 110.0.0 ships no Plan CRDs and hardcodes


### PR DESCRIPTION
## Summary
Follow-up to #352. That PR was supposed to include this commit too, but the squash-merge only picked up the first of its two commits — the resource-limits/kubectl-image commit was pushed to the branch but never made it into the merged squash commit. Reapplying it here from current `master`.

- Adds `resources` requests/limits to the controller container (had none; matches this repo's existing memory-only-limit convention — cpu request, memory request+limit, no cpu limit).
- Bumps `SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE` from `rancher/kubectl:v1.30.3` to `v1.36.2`. Traced into upstream's Go source (`pkg/upgrade/job/job.go`) and confirmed this image runs `kubectl cordon <node>` as an init container in every upgrade Job (`cordon: true` on the Plan) — not unused config. v1.30.3 is upstream's compiled-in default regardless of controller version, and is 6 minors behind this cluster's k3s v1.36.4 server, outside kubectl's supported skew. v1.36.2 is the closest published `rancher/kubectl` tag.
- Updates `kustomization.yaml`'s comment to document that `controller.yaml` is no longer byte-identical to upstream, and why.

## Test plan
- [x] `kubectl kustomize k3s/infrastructure/controllers/system-upgrade-controller` builds cleanly
- [x] `yamllint` passes
- [x] `kubectl apply --dry-run=server` against the live cluster succeeds for every resource
- [ ] Flux reconciles cleanly after merge; controller pod stays healthy with the new resource limits

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01D2MX5ALrKbJunRXcX1FLwq