### PR TITLE
fix(longhorn): reduce CSI sidecar replica count from 3 to 1

### DIFF
--- a/k3s/infrastructure/controllers/longhorn/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/longhorn/helmrelease.yaml
@@ -37,3 +37,13 @@ spec:
       # Same disk csi-hostpath-sc already writes into — no dedicated block
       # device required, Longhorn stores replicas as files on this path.
       defaultDataPath: /var/lib/longhorn
+    csi:
+      # Chart default is 3 per sidecar. On this single-node cluster all
+      # replicas land on the same node, so extra replicas give zero HA
+      # benefit while tripling leader-election lease writes against kine's
+      # SQLite contention ceiling (#355). Revisit once the 3-node cluster
+      # is up.
+      attacherReplicaCount: 1
+      provisionerReplicaCount: 1
+      resizerReplicaCount: 1
+      snapshotterReplicaCount: 1


### PR DESCRIPTION
## Summary
- Longhorn's 4 CSI sidecars (attacher/provisioner/resizer/snapshotter) default to 3 replicas each, all unset in our HelmRelease. On this single-node cluster that's zero HA benefit but triples lease-write contention against the kine/SQLite ceiling tracked in #355.
- Sets `csi.{attacher,provisioner,resizer,snapshotter}ReplicaCount: 1`, mirroring the existing `persistence.defaultClassReplicaCount: 1` rationale.

## Verification
- Confirmed the chart schema (`helm show values longhorn/longhorn --version 1.12.1`): all four keys default to `~` → chart default `3`.
- Rendered the chart with the new values (`helm template`) — the replica counts flow through as env vars (`CSI_ATTACHER_REPLICA_COUNT=1`, etc.) into `longhorn-driver-deployer`, which creates the actual sidecar Deployments at runtime.

Closes #356

## Test plan
- [ ] Flux reconciles the HelmRelease
- [ ] `kubectl get deploy -n longhorn-system | grep csi-` shows 1/1 replicas for attacher/provisioner/resizer/snapshotter
- [ ] Restart counts on those pods stop climbing over the following days

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUdnLPnBxtQR3TEM37XpBZ