### PR TITLE
infra(k3s): enable embedded etcd, migrating off SQLite

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -60,6 +60,13 @@ k3s_sysctl_params:
 # Find the latest: https://github.com/k3s-io/k3s/releases
 k3s_version: "v1.36.3+k3s1"
 
+# Use embedded etcd instead of SQLite. K3s migrates existing SQLite data into
+# etcd in place on restart (state.db is renamed aside afterward, not reused) —
+# see BOOTSTRAP.md Part 2 for details. Fixes the kine/SQLite leader-election
+# lease-contention ceiling tracked in #355. No firewall changes needed:
+# ports 2379/2380 are only required for multi-server etcd peer traffic.
+k3s_init_cluster: true
+
 # K3s built-in components to disable — these are replaced by external controllers.
 # servicelb (klipper-lb) must be disabled when MetalLB is installed to prevent
 # both controllers competing for LoadBalancer services.


### PR DESCRIPTION
## Summary
- Sets `k3s_init_cluster: true` in `k3s/bootstrap/ansible/inventory/group_vars/all.yml`.
- The `k3s-server` role already templates `cluster-init: true` into `config.yaml` and restarts k3s via its handler when this flag is set — this PR is just flipping the var, no role/task changes needed.
- On the next `bootstrap-k3s.yml` run, K3s detects the existing SQLite datastore and migrates it into embedded etcd in place (`state.db` is renamed aside afterward, not reused — see the correction in #359 / `BOOTSTRAP.md`).

## Why
Root-cause fix for #355: single-node k3s + kine/SQLite has a hard ceiling on simultaneous `coordination.k8s.io` lease writes, causing chronic leader-election crash-loops across multiple controllers (cert-manager, csi-driver-smb, flux, kopiur, longhorn, snapshot-controller, system-upgrade-controller). Embedded etcd removes this ceiling. #356/#358 already mitigated Longhorn's contribution; this addresses the shared root cause.

No firewall changes needed — ports 2379/2380 are only required for multi-server etcd peer traffic, and this stays single-node (the 3-node HA hardware isn't provisioned yet).

## Test plan
- [ ] Merge, then on the control machine: `cd k3s/bootstrap/ansible && ansible-playbook -i inventory/hosts.yml playbooks/bootstrap-k3s.yml`
- [ ] Confirm migration succeeded: `kubectl get pods -n kube-system -l component=etcd` (or check `/var/lib/rancher/k3s/server/db/` for `state.db.migrated` and an `etcd/` dir on the node)
- [ ] `kubectl get nodes` shows Ready
- [ ] Spot-check a few previously-flaky controllers (flux, longhorn CSI sidecars, cert-manager) for restart-count stabilization over the following days
- [ ] Update #355 with the outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUdnLPnBxtQR3TEM37XpBZ