### PR TITLE
infra(k3s): fix k3s_version pin drift (v1.36.3 -> v1.36.4)

### DIFF
--- a/k3s/bootstrap/ansible/inventory/group_vars/all.yml
+++ b/k3s/bootstrap/ansible/inventory/group_vars/all.yml
@@ -58,7 +58,7 @@ k3s_sysctl_params:
 
 # K3s version installed on all nodes — pin to a specific release.
 # Find the latest: https://github.com/k3s-io/k3s/releases
-k3s_version: "v1.36.3+k3s1"
+k3s_version: "v1.36.4+k3s1"
 
 # Use embedded etcd instead of SQLite. K3s migrates existing SQLite data into
 # etcd in place on restart (state.db is renamed aside afterward, not reused) —


### PR DESCRIPTION
## Summary
- Bumps `k3s_version` in `group_vars/all.yml` from `v1.36.3+k3s1` to `v1.36.4+k3s1` to match what's actually running on the node.

## Why
The pin had drifted behind the live cluster — system-upgrade-controller's drift detection had already auto-upgraded the node to `v1.36.4+k3s1` (per #350-#354) without the Ansible var being updated to match.

This matters now because #360 (enable embedded etcd) requires re-running `bootstrap-k3s.yml`, which restarts k3s to apply `cluster-init: true`. Left unfixed, that same run would also see the stale version pin and re-trigger the k3s install script targeting `v1.36.3+k3s1` — silently downgrading the binary as a side effect of the datastore migration restart, bundling two unrelated changes into one operation.

Should merge before running `bootstrap-k3s.yml` to enable etcd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUdnLPnBxtQR3TEM37XpBZ