### PR TITLE
infra: disable unneeded SA token mounts on 9 media/auth workloads

### DIFF
--- a/k3s/applications/prowlarr/deployment.yaml
+++ b/k3s/applications/prowlarr/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: prowlarr
         app.kubernetes.io/name: prowlarr
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       containers:

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: qbittorrent
         app.kubernetes.io/name: qbittorrent
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       volumes:

--- a/k3s/applications/radarr/deployment.yaml
+++ b/k3s/applications/radarr/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: radarr
         app.kubernetes.io/name: radarr
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       containers:

--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         app: sabnzbd
         app.kubernetes.io/name: sabnzbd
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       volumes:

--- a/k3s/applications/sense-exporter/deployment.yaml
+++ b/k3s/applications/sense-exporter/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: sense-exporter
     spec:
+      automountServiceAccountToken: false
       containers:
         # NordVPN tunnel — all outbound traffic from this pod (including
         # api.sense.com HTTPS + websocket polling from the exporter below)

--- a/k3s/applications/sonarr/deployment.yaml
+++ b/k3s/applications/sonarr/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: sonarr
         app.kubernetes.io/name: sonarr
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       containers:

--- a/k3s/applications/tdarr/deployment-node.yaml
+++ b/k3s/applications/tdarr/deployment-node.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: tdarr-node
     spec:
       runtimeClassName: nvidia
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       containers:

--- a/k3s/applications/tdarr/deployment-server.yaml
+++ b/k3s/applications/tdarr/deployment-server.yaml
@@ -19,6 +19,7 @@ spec:
         app: tdarr-server
         app.kubernetes.io/name: tdarr-server
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 100
       containers:

--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: authentik-outpost
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: proxy
           image: ghcr.io/goauthentik/proxy:2026.8.0


### PR DESCRIPTION
## Summary
- Adds `automountServiceAccountToken: false` to 9 workloads flagged in the 2026-08-28/29 config audit (PR #357): radarr, sonarr, prowlarr, sense-exporter, qbittorrent, sabnzbd, tdarr-node, tdarr-server, authentik-outpost
- None of these containers call the Kubernetes API — the default SA token was mounted for no reason (matches the pattern already used correctly in `unpoller`)

## Test plan
- [ ] `flux diff kustomization` (or equivalent) shows only the expected one-line addition per manifest
- [ ] After apply, `kubectl exec` into each pod confirms no `/var/run/secrets/kubernetes.io/serviceaccount` mount
- [ ] Each app still starts and passes its liveness/readiness probes post-rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dSXEdv47e2SB5TkWy2GSq