### PR TITLE
infra(kopiur): stagger hourly snapshot schedules to fixed offsets

### DIFF
--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-alertmanager.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-alertmanager.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: alertmanager
   schedule:
-    cron: "H * * * *"
+    cron: "0 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-authentik.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-authentik.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: authentik
   schedule:
-    cron: "H * * * *"
+    cron: "4 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-gatus.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-gatus.yaml
@@ -8,5 +8,5 @@ spec:
   policyRef:
     name: gatus
   schedule:
-    cron: "H * * * *"
+    cron: "8 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-grafana.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-grafana.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: grafana
   schedule:
-    cron: "H * * * *"
+    cron: "11 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-headlamp.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-headlamp.yaml
@@ -8,7 +8,10 @@ spec:
   policyRef:
     name: headlamp
   schedule:
-    # Jenkins-style H substitution hashes a stable per-policy minute; load
-    # self-distributes without manual offset bookkeeping.
-    cron: "H * * * *"
+    # Fixed offset instead of H-hash: with only 16 policies across 60 minutes,
+    # the hash clustered 5 of them within a 5-minute window (2026-08-30,
+    # 01:14-01:19 UTC), triggering a disk I/O spike that burned the apiserver
+    # error budget (#363). All 16 hourly SnapshotSchedules now use explicit
+    # minutes spaced ~4 min apart instead.
+    cron: "15 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-pihole.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-pihole.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: pihole
   schedule:
-    cron: "H * * * *"
+    cron: "19 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-portainer.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-portainer.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: portainer
   schedule:
-    cron: "H * * * *"
+    cron: "23 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-prowlarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-prowlarr.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: prowlarr
   schedule:
-    cron: "H * * * *"
+    cron: "26 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent-gluetun.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent-gluetun.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: qbittorrent-gluetun
   schedule:
-    cron: "H * * * *"
+    cron: "34 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-qbittorrent.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: qbittorrent-config
   schedule:
-    cron: "H * * * *"
+    cron: "30 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-radarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-radarr.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: radarr
   schedule:
-    cron: "H * * * *"
+    cron: "38 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd-gluetun.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd-gluetun.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: sabnzbd-gluetun
   schedule:
-    cron: "H * * * *"
+    cron: "45 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sabnzbd.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: sabnzbd-config
   schedule:
-    cron: "H * * * *"
+    cron: "41 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sonarr.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-sonarr.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: sonarr
   schedule:
-    cron: "H * * * *"
+    cron: "49 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-tdarr-node-config.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-tdarr-node-config.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: tdarr-node-config
   schedule:
-    cron: "H * * * *"
+    cron: "53 * * * *"
     runOnCreate: false

--- a/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-tdarr-server-data.yaml
+++ b/k3s/infrastructure/configs/kopiur-policies/snapshotschedule-tdarr-server-data.yaml
@@ -9,5 +9,5 @@ spec:
   policyRef:
     name: tdarr-server-data
   schedule:
-    cron: "H * * * *"
+    cron: "56 * * * *"
     runOnCreate: false


### PR DESCRIPTION
## Summary
- Fixes #363: the `H * * * *` Jenkins-hash on all 16 hourly Kopiur `SnapshotSchedule`s clustered 5 of them within a 5-minute window (01:14-01:19 UTC), spiking concurrent Longhorn clone + Kopia backup I/O and briefly taking the apiserver unresponsive (`KubeAPIErrorBudgetBurn` PagerDuty alert)
- Replaces `H` with explicit fixed minutes spaced ~3.75 min apart (60÷16), so no two schedules fire within 3 minutes of each other
- Also drops the stale "self-distributes" comment on `snapshotschedule-headlamp.yaml` that no longer reflects reality

## Test plan
- [ ] After Flux reconciles, `kubectl get snapshotschedule -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.spec.schedule.cron}{"\n"}{end}'` shows the new fixed minutes
- [ ] Watch the next few hourly firings (`status.lastSchedule`) land at their assigned minute, spaced apart
- [ ] Monitor node disk write latency / apiserver error budget over the next 24h to confirm no recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dSXEdv47e2SB5TkWy2GSq