### PR TITLE
infra(headlamp): harden main container securityContext

### DIFF
--- a/k3s/applications/headlamp/helmrelease.yaml
+++ b/k3s/applications/headlamp/helmrelease.yaml
@@ -24,6 +24,17 @@ spec:
         namespace: flux-system
       interval: 12h
   values:
+    # capabilities.drop and readOnlyRootFilesystem are opt-in in the chart's
+    # default values.yaml (commented out). Enabling both here; the chart
+    # auto-provisions a writable emptyDir (headlamp-tmp) mounted at /tmp
+    # when readOnlyRootFilesystem is true, so no extra volume config is
+    # needed on our side. runAsNonRoot/privileged/runAsUser/runAsGroup are
+    # left unset since the chart already defaults those correctly.
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
     service:
       type: ClusterIP
       port: 80


### PR DESCRIPTION
## Summary
- Config audit flagged headlamp's HelmRelease (red/high severity) for missing capability-drop + readOnlyRootFilesystem on the main container's securityContext.
- Both are opt-in knobs already commented out in the chart's default values.yaml (chart version 0.45.0) — not a case where the chart lacks the option.
- Sets `capabilities.drop: [ALL]` and `readOnlyRootFilesystem: true` under `values.securityContext`. The chart auto-provisions a writable emptyDir (`headlamp-tmp`) mounted at `/tmp` when `readOnlyRootFilesystem` is true, so no extra volume config is needed on our side.
- initContainers' securityContext (`runAsUser: 0`, needed to chown plugin files) is untouched — unrelated and required as-is.

## Test plan
- [ ] Flux reconciles the HelmRelease cleanly (`flux get hr headlamp -n headlamp`)
- [ ] headlamp pod comes up `Ready` with no CrashLoopBackOff / permission errors
- [ ] Dashboard still loads and functions at https://headlamp.homelab.properties after merge

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>