### PR TITLE
infra(opentelemetry-collector): harden security context and close unused hostPorts

### DIFF
--- a/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/opentelemetry-collector/helmrelease.yaml
@@ -124,6 +124,38 @@ spec:
     # clusterMetrics + kubeletMetrics presets need it, and the preset
     # permissions are what we actually want.
 
+    # Hardening: the chart's podSecurityContext/securityContext both default
+    # to {} (fully open). We leave runAsNonRoot/runAsUser/runAsGroup unset
+    # here deliberately — the hostMetrics + kubeletMetrics presets mount host
+    # /proc, /sys, and kubelet cert/token paths that commonly require root
+    # (or a specific host-matching UID/GID) to read, and this branch can't be
+    # live-tested against Flux before merge. Forcing runAsNonRoot: true risks
+    # a silent permission-denied on those host-path scrapers. The other four
+    # fields are safe with any UID, including root, so we set those now.
+    podSecurityContext: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+
+    # Audit finding: chart defaults enable Jaeger/Zipkin receivers with real
+    # hostPort bindings reachable from the LAN, but no pipeline in this
+    # config references jaeger or zipkin receivers (only `otlp`, used by the
+    # traces pipeline above). Disable the unused hostPort bindings without
+    # touching receiver config. otlp/otlp-http stay enabled (chart defaults).
+    ports:
+      jaeger-compact:
+        enabled: false
+      jaeger-thrift:
+        enabled: false
+      jaeger-grpc:
+        enabled: false
+      zipkin:
+        enabled: false
+
     # Tune for a single-node testbed. CPU limits stay unset (Go GC
     # throttling is a footgun on this class of workload).
     resources:


### PR DESCRIPTION
## Summary

Config audit found two red findings on the `opentelemetry-collector` HelmRelease (telemetry namespace, DaemonSet mode):

- No `securityContext`/`podSecurityContext` set at all in Helm values.
- Four unused Jaeger/Zipkin receiver ports (jaeger-compact 6831/UDP, jaeger-thrift 14268/TCP, jaeger-grpc 14250/TCP, zipkin 9411/TCP) exposed as real `hostPort` bindings reachable from the LAN, even though no pipeline in `config.service.pipelines` references those receivers (only `otlp` is used, for the traces pipeline).

Changes:
- Added container `securityContext`: `allowPrivilegeEscalation: false`, `seccompProfile: RuntimeDefault`, `capabilities.drop: [ALL]`.
- Left `podSecurityContext` at `{}` (pod-level `runAsNonRoot`/`runAsUser` NOT set). Reasoning: this DaemonSet runs the `hostMetrics` and `kubeletMetrics` presets, which mount host `/proc`, `/sys`, and kubelet cert/token paths. Forcing a non-default non-root UID could break read access to those host paths, and this branch can't be live-tested against Flux before merge to confirm otherwise. The other four hardening fields are safe under any UID (including root), so those are applied now; the non-root UID question is left for a follow-up once it can be verified against a running pod.
- Added `ports.jaeger-compact/jaeger-thrift/jaeger-grpc/zipkin.enabled: false` to close the unused hostPort bindings via the chart's own toggle, without touching receiver config. `otlp`/`otlp-http` (4317/4318) remain enabled, unchanged.

Validated with `helm template open-telemetry/opentelemetry-collector --version 0.172.0` against the extracted values — renders cleanly, container securityContext shows the new hardening fields, and the rendered pod spec's `ports:` list now contains only `otlp` and `otlp-http` (no jaeger/zipkin entries).

## Test plan

- [ ] Flux reconciles the HelmRelease cleanly (no `install`/`upgrade` failure)
- [ ] Collector DaemonSet pod comes up `Ready` on the node
- [ ] Traces pipeline still works: an OTLP trace sent to the collector still lands in Tempo (no regression from the container securityContext change)
- [ ] `kubectl get pods -n telemetry -o wide` / node-level `netstat`/`ss` shows no listeners on 6831/udp, 14268/tcp, 14250/tcp, 9411/tcp, while 4317/tcp and 4318/tcp are still bound

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>