### PR TITLE
fix(dcgm-exporter): correct postRenderer patch target name

### DIFF
--- a/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/dcgm-exporter/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
         patches:
           - target:
               kind: DaemonSet
-              name: dcgm-exporter
+              name: kube-system-dcgm-exporter
             patch: |
               - op: replace
                 path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds


### PR DESCRIPTION
## Summary
- The JSON6902 postRenderer patch added in #256/#257 has been silently no-op'ing since it landed: `target.name` was `dcgm-exporter`, but the live DaemonSet is `kube-system-dcgm-exporter`.
- Cause: `metadata.namespace` (flux-system) differs from `spec.targetNamespace` (kube-system) with no `spec.releaseName` set, so Flux auto-generates the Helm release name as `<targetNamespace>-<helmReleaseName>`, which flows into the chart's fullname-templated DaemonSet name. This Flux version silently skips a target-not-found patch rather than erroring, so the HelmRelease has reported healthy throughout.
- Fix is minimal: only `target.name` changes (`dcgm-exporter` -> `kube-system-dcgm-exporter`). The patch ops themselves (probe `initialDelaySeconds` -> 0, `startupProbe` addition, `resources.limits.cpu` removal per #284) are unchanged and were already correct.
- Deliberately NOT setting `spec.releaseName` instead — that would rename the live Helm release, which Helm/Flux implements as a delete-and-recreate of the release (and likely the DaemonSet).

## Test plan
- [ ] Flux reconciles the HelmRelease cleanly (no errors, `Ready` condition healthy)
- [ ] `kubectl get daemonset kube-system-dcgm-exporter -n kube-system -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds} {.spec.template.spec.containers[0].startupProbe}'` shows `initialDelaySeconds` = `0` and a non-empty `startupProbe`
- [ ] `kubectl get daemonset kube-system-dcgm-exporter -n kube-system -o jsonpath='{.spec.template.spec.containers[0].resources.limits}'` shows no `cpu` key

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>