### PR TITLE
fix(pihole): bump pinned image tag to 2026.07.2 (security fix)

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -24,12 +24,15 @@ spec:
         namespace: flux-system
       interval: 12h
   values:
-    # Pi-hole v6 (appVersion: 2026.05.0) — chart version 2.35.0
+    # Pi-hole v6 (appVersion: 2026.07.2) — chart version 2.38.0
     replicaCount: 1
 
-    # -- Pi-hole container image: pin to specific version for Dependabot tracking
+    # -- Pi-hole container image: pin to specific version for Dependabot tracking.
+    # 2026.07.2 fixes GHSA-h8w9-qx2v-wrww (local privilege escalation from the
+    # pihole user to root via /etc/pihole/logrotate). No FTL-side config/API
+    # changes vs 2026.05.0.
     image:
-      tag: "2026.05.0"
+      tag: "2026.07.2"
 
     # -- Upstream DNS: plain DNS to Cloudflare
     DNS1: "1.1.1.1"


### PR DESCRIPTION
## Summary
- Bumps pihole's pinned `image.tag` from `2026.05.0` to `2026.07.2`, matching the chart's own appVersion (chart is already on 2.38.0). Renovate tracks the chart version, not this nested tag, so it silently drifted — flagged in the 2026-08-28/29 config audit (PR #357).
- 2026.07.2 fixes [GHSA-h8w9-qx2v-wrww](https://github.com/pi-hole/docker-pi-hole/security/advisories/GHSA-h8w9-qx2v-wrww), a local privilege escalation from the `pihole` user to root via `/etc/pihole/logrotate`. No FTL-side config/API changes vs 2026.05.0.

## Test plan
- [ ] Flux reconciles clean
- [ ] Pod comes up Ready, web UI still reachable at https://pihole.homelab.properties
- [ ] DNS resolution still works (spot-check a query against 192.168.1.201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dSXEdv47e2SB5TkWy2GSq