### PR TITLE
fix(metallb): disable unused frr-k8s BGP backend

### DIFF
--- a/k3s/infrastructure/controllers/metallb/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/metallb/helmrelease.yaml
@@ -24,6 +24,12 @@ spec:
     remediation:
       retries: 3
   values:
+    # This cluster only uses L2Advertisement (no BGPAdvertisement/BGPPeer
+    # resources exist), so the frr-k8s BGP backend DaemonSet is unused dead
+    # weight. Disable it to drop the extra 5-container pod, its resource
+    # usage, and attack surface. L2 mode does not require frr-k8s.
+    frrk8s:
+      enabled: false
     controller:
       resources:
         requests:


### PR DESCRIPTION
## What

Audit finding: metallb's `frr-k8s` component (a 5-container BGP-backend DaemonSet) runs as a chart default in `k3s/infrastructure/controllers/metallb/helmrelease.yaml`, even though this cluster only uses L2Advertisement mode.

## Verification

Ran live against the cluster:

```
$ kubectl get l2advertisements,bgpadvertisements,bgppeers -A
NAMESPACE        NAME                                 IPADDRESSPOOLS     IPADDRESSPOOL SELECTORS   INTERFACES
metallb-system   l2advertisement.metallb.io/homelab   ["homelab-pool"]
```

Only one `L2Advertisement` exists; zero `BGPAdvertisement`/`BGPPeer` resources. frr-k8s is BGP-only and is not required for L2 mode.

Confirmed the correct values key against the pinned chart version (0.16.1):

```
$ helm show values metallb/metallb --version 0.16.1 | sed -n '368,373p'
frrk8s:
  # -- If set, enables frrk8s as a backend. This is mutually exclusive to frr mode.
  enabled: true
  ...
```

## Change

Set `frrk8s.enabled: false` in the HelmRelease `values:` block.

## Why

Removes an unused 5-container BGP DaemonSet: extra attack surface and resource usage for a stack that is never exercised.

Not merging — leaving this for review/merge by the user.