### PR TITLE
fix(sabnzbd): auto-fix host_whitelist via init container on restart

### DIFF
--- a/k3s/applications/sabnzbd/deployment.yaml
+++ b/k3s/applications/sabnzbd/deployment.yaml
@@ -7,15 +7,16 @@
 # stale and gatus then receives a 503 from gluetun's HTTP proxy when
 # reaching the app via the ingress hostname (`sabnzbd.homelab.properties`).
 #
-# Imperative fix after every fresh sabnzbd pod start:
-#   kubectl exec -n sabnzbd deploy/sabnzbd -c sabnzbd -- \
-#     sed -i 's/^host_whitelist.*/host_whitelist = sabnzbd.homelab.properties, sabnzbd-*, */' \
-#       /config/sabnzbd.ini
-#   kubectl rollout restart deploy/sabnzbd -n sabnzbd
+# This used to require an imperative fix after every fresh sabnzbd pod
+# start (`kubectl exec` + `sed` + rollout restart). It's now handled
+# automatically by the `fix-host-whitelist` init container below, which
+# rewrites `host_whitelist` in `/config/sabnzbd.ini` idempotently before
+# the main container starts, the same way qbittorrent's `seed-config`
+# init container guards its WebUI auth setting on restart.
 #
-# The new value is captured by the hourly sabnzbd-config SnapshotPolicy
-# (longhorn-snapclass after the csi-hostpath → longhorn migration), so
-# subsequent restores will inherit the correct whitelist.
+# The corrected value is captured by the hourly sabnzbd-config
+# SnapshotPolicy (longhorn-snapclass after the csi-hostpath → longhorn
+# migration), so subsequent restores will inherit the correct whitelist.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,6 +55,30 @@ spec:
           hostPath:
             path: /dev/net/tun
             type: CharDevice
+      initContainers:
+        - name: fix-host-whitelist
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              CONF=/config/sabnzbd.ini
+              WHITELIST="sabnzbd.homelab.properties, sabnzbd-*, *"
+              if [ -f "$CONF" ]; then
+                echo "Enforcing host_whitelist in $CONF..."
+                if grep -q '^host_whitelist' "$CONF"; then
+                  sed -i "s|^host_whitelist.*|host_whitelist = $WHITELIST|" "$CONF"
+                else
+                  sed -i "/^\[misc\]/a host_whitelist = $WHITELIST" "$CONF"
+                fi
+                chown 1027:100 "$CONF"
+                echo "Done."
+              else
+                echo "Config not yet created; sabnzbd will generate it on first boot."
+              fi
+          volumeMounts:
+            - name: sabnzbd-config
+              mountPath: /config
       containers:
         - name: gluetun
           image: qmcgaw/gluetun:v3.41.3


### PR DESCRIPTION
## What was found

sabnzbd's `host_whitelist` config in `/config/sabnzbd.ini` auto-populates with the pod hostname at first startup. On every subsequent pod restart that value goes stale (new pod hostname), and gatus starts getting 503s from gluetun's HTTP proxy when hitting the app via its ingress hostname. This was previously self-documented in `k3s/applications/sabnzbd/deployment.yaml` as a manual runbook step: `kubectl exec` + `sed` into the running pod, then a rollout restart.

## What changed

Added a `fix-host-whitelist` init container to the sabnzbd Deployment, mirroring the `seed-config` init container qbittorrent already uses to guard against its own restart footgun (unauthenticated WebUI on localhost). The new init container idempotently rewrites `host_whitelist` in `/config/sabnzbd.ini` (via grep+sed, or inserting into `[misc]` if the key isn't present yet) before the main sabnzbd container starts serving traffic. No-ops if the config file doesn't exist yet (first boot, before sabnzbd has created it).

## Why

Eliminates the manual post-restart runbook step entirely — this now self-heals on every pod restart instead of requiring an operator to notice and fix it by hand.

## Test plan

- [ ] Cannot be verified live from this environment. On next sabnzbd pod restart, confirm the init container runs successfully and `host_whitelist` in `/config/sabnzbd.ini` contains `sabnzbd.homelab.properties, sabnzbd-*, *` with no gatus 503s afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)