### PR TITLE
fix(goldilocks): set resources.limits for controller, dashboard, vpa-recommender

### DIFF
--- a/k3s/infrastructure/controllers/goldilocks/helmrelease.yaml
+++ b/k3s/infrastructure/controllers/goldilocks/helmrelease.yaml
@@ -41,9 +41,43 @@ spec:
       # staying recommend-only.
       admissionController:
         enabled: false
+      recommender:
+        # Chart default is `resources.limits: {}` (unbounded). Pinned to the
+        # chart's own request floor (50m/500Mi, verified via `helm show
+        # values fairwinds-stable/vpa --version 4.12.5`) with a memory limit
+        # added; no CPU limit, matching this repo's general policy of not
+        # throttling controller CPU.
+        resources:
+          requests:
+            cpu: 50m
+            memory: 500Mi
+          limits:
+            memory: 500Mi
+    controller:
+      # Chart default is `resources.limits: {}` (unbounded). Pinned to the
+      # chart's own request floor (25m/256Mi, verified via `helm show values
+      # fairwinds-stable/goldilocks --version 11.0.0`) with a memory limit
+      # added; no CPU limit, matching this repo's general policy of not
+      # throttling controller CPU.
+      resources:
+        requests:
+          cpu: 25m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
     dashboard:
       # Chart default is 2 replicas; no HA benefit on a single-node cluster.
       replicaCount: 1
+      # Chart default is `resources.limits: {}` (unbounded). Pinned to the
+      # chart's own request floor (25m/256Mi) with a memory limit added; no
+      # CPU limit, matching this repo's general policy of not throttling
+      # controller CPU.
+      resources:
+        requests:
+          cpu: 25m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
       ingress:
         enabled: true
         ingressClassName: traefik


### PR DESCRIPTION
## Summary
- Homelab audit found that none of goldilocks' 3 running pods (`goldilocks-controller`, `goldilocks-dashboard`, and the bundled `vpa-recommender`) set `resources.limits`, leaving them unbounded (chart default behavior).
- Pinned each pod to the chart's own request floor — verified via `helm show values fairwinds-stable/goldilocks --version 11.0.0` and `helm show values fairwinds-stable/vpa --version 4.12.5` — and added a matching memory limit. No CPU limit, per this repo's existing convention for controllers (see `snapshot-controller`, `nvidia-device-plugin`, `alloy` HelmReleases).
- `vpa.updater` and `vpa.admissionController` remain disabled (unchanged), so those pods still don't run.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — HelmRelease is valid YAML
- [x] `helm template` against the pulled `goldilocks` chart (v11.0.0) with the HelmRelease's `values:` block extracted — confirmed all three deployments (`vpa-recommender`, `goldilocks-controller`, `goldilocks-dashboard`) render `resources.limits.memory` and `resources.requests` as expected, with no other pods rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dSXEdv47e2SB5TkWy2GSq