### PR TITLE
fix(authentik): harden securityContext, drop unused native-outpost RBAC

### DIFF
--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -112,6 +112,27 @@ spec:
           storageClass: local-path
 
     server:
+      # Hardening: chart's server.securityContext/containerSecurityContext
+      # both default to {} (fully open) despite the values existing.
+      # ghcr.io/goauthentik/server runs as uid/gid 1000 by default (per the
+      # chart's own commented example above), so pin that explicitly rather
+      # than relying on the image default.
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      containerSecurityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+      # readOnlyRootFilesystem intentionally left unset: the server writes
+      # runtime state (media uploads, generated certs/templates) to its own
+      # filesystem and this branch can't be live-tested against Flux before
+      # merge to confirm every write path is already covered by a mounted
+      # volume.
       resources:
         requests:
           cpu: 600m
@@ -132,6 +153,22 @@ spec:
               - auth.homelab.properties
 
     worker:
+      # Hardening: same rationale as server.securityContext above.
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      containerSecurityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+      # readOnlyRootFilesystem intentionally left unset: the worker runs
+      # blueprint reconciliation and background tasks that can write to its
+      # own filesystem (e.g. GeoIP DBs, temp files); same live-test caveat
+      # as server above.
       # Tell the worker where to discover custom blueprints. The
       # ConfigMap is already mounted at /blueprints/custom (see volumes
       # below); without this env var, the worker doesn't scan the
@@ -157,3 +194,20 @@ spec:
       volumeMounts:
         - name: custom-blueprints
           mountPath: /blueprints/custom
+
+    # Audit finding: serviceAccount.create: true (the chart default) pulls in
+    # the authentik-remote-cluster subchart, which grants the worker's
+    # ServiceAccount a namespaced Role with CRUD on secrets/services/
+    # configmaps/deployments/ingresses/middlewares/httproutes/servicemonitors
+    # (see charts/authentik-remote-cluster/templates/role.yaml at chart
+    # version 2.1.0). That RBAC exists so authentik's own "Kubernetes"
+    # outpost integration can render outposts as native k8s objects, but our
+    # actual outpost is the hand-rolled Deployment in outpost-deployment.yaml
+    # — the managed-outpost path is never used. Disabling create removes the
+    # ServiceAccount + Role/RoleBinding + ClusterRole/ClusterRoleBinding
+    # entirely (chart dependency condition: serviceAccount.create); the
+    # worker deployment template falls back to no serviceAccountName (i.e.
+    # the namespace's default SA) when this is false, so no other server/
+    # worker functionality depends on it.
+    serviceAccount:
+      create: false

--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -17,9 +17,28 @@ spec:
         app: authentik-outpost
     spec:
       automountServiceAccountToken: false
+      # Pod-level hardening. lifecycle/container/proxy.Dockerfile (goauthentik/
+      # authentik @ main) sets `USER 1000` with no matching group creation, so
+      # the image runs as uid 1000 with no dedicated gid; pin runAsGroup to
+      # match. The image also sets `ENV TMPDIR=/dev/shm/`, i.e. its own
+      # temp-file writes are already redirected off the rootfs onto the
+      # container's default tmpfs shm mount, so readOnlyRootFilesystem below
+      # doesn't need an extra emptyDir.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
         - name: proxy
           image: ghcr.io/goauthentik/proxy:2026.8.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: AUTHENTIK_HOST
               value: "http://authentik-server.authentik.svc.cluster.local"


### PR DESCRIPTION
## Summary

Homelab audit follow-up, all in the `authentik` component:

1. **`outpost-deployment.yaml`** (hand-written Deployment, no chart excuse): added pod-level `runAsNonRoot: true` / `runAsUser`/`runAsGroup: 1000` (matches `USER 1000` in `lifecycle/container/proxy.Dockerfile` upstream) and container-level `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true`. No extra `emptyDir` was needed — the image sets `TMPDIR=/dev/shm/`, so its temp writes already land off the rootfs.
2. **`helmrelease.yaml`**: the authentik chart's `server`/`worker` blocks expose real `securityContext`/`containerSecurityContext` values knobs that render `{}` by default. Set both to the same hardening profile (non-root uid/gid 1000, cap-drop ALL, seccomp RuntimeDefault, no-privilege-escalation).
3. **`helmrelease.yaml`**: set `serviceAccount.create: false`. This is the chart's dependency condition for the `authentik-remote-cluster` subchart, which otherwise grants the worker's ServiceAccount a namespaced Role with CRUD on secrets/services/configmaps/deployments/ingresses/middlewares/httproutes/servicemonitors, plus a ClusterRole. That RBAC backs authentik's own "Kubernetes" managed-outpost integration, which this repo doesn't use — the real outpost is the hand-rolled Deployment from fix #1. Confirmed via `helm template` that disabling it removes all four RBAC objects and the worker deployment cleanly falls back to no explicit `serviceAccountName` (chart template has an `else if .Values.serviceAccount.create` guard).

## Verification

- `python3 -c "import yaml; ..."` — both touched files parse as valid YAML.
- `helm template authentik authentik/authentik --version 2026.8.0 -f <extracted values>` — renders without error; confirmed no `Role`/`ClusterRole`/`RoleBinding`/`ClusterRoleBinding` in output, and server/worker pods carry the new `securityContext`.

## Assumptions / open items

- `readOnlyRootFilesystem` intentionally left **unset** on the chart-managed server/worker pods (fix #2). Both processes write runtime state to their own filesystem (media uploads, GeoIP DB, generated certs/templates) and this branch can't be live-tested against Flux before merge to confirm every write path already has a mounted volume — same caution pattern used for opentelemetry-collector in #366.
- Outpost proxy image UID (1000) verified directly from upstream's `lifecycle/container/proxy.Dockerfile` (`USER 1000`) rather than guessed.
- Not merging — leaving for review per instructions.