### PR TITLE
fix(sabnzbd): shrink oversized sabnzbd-config PVC (20Gi -> 2Gi)

### DIFF
--- a/k3s/applications/sabnzbd/migration/restore-config-shrink.yaml
+++ b/k3s/applications/sabnzbd/migration/restore-config-shrink.yaml
@@ -1,0 +1,60 @@
+---
+# Shrink Restore CR for sabnzbd-config: 20Gi -> 2Gi.
+#
+# Context: sabnzbd-config was sized at 20Gi during the 2026-08-21 Kopia
+# recovery (see docs/superpowers/plans/2026-08-21-restore-sabnzbd-config-from-kopia-backup.md)
+# because that snapshot carried ~12.5GiB of media data misplaced by a since-fixed
+# sabnzbd complete_dir bug. The bug was fixed the same day; every snapshot since
+# has been ~27-32MB (real config only). At 20Gi provisioned, Longhorn's CSI
+# snapshot-restore path was cloning across the full provisioned extent on every
+# hourly backup (~6 minutes of full-disk-saturating I/O for 27MB of real data),
+# which correlates with recurring KubeAPIErrorBudgetBurn alerts on this
+# single-node cluster (etcd and Longhorn share the one aging root SSD).
+#
+# Sourced via fromPolicy (latest snapshot), not a pinned snapshotRef — unlike
+# the 2026-08-21 recovery there is no blank/corrupted intermediate state to
+# route around; the policy's own current snapshots are exactly what we want.
+#
+# Operator-applied (NOT in kustomization.yaml — Flux will not reconcile it
+# on every sync). Run with `kubectl apply -f` once after scaling sabnzbd
+# to 0 replicas and deleting the current 20Gi sabnzbd-config PVC.
+#
+# Pre-conditions:
+#   - sabnzbd deployment scaled to 0
+#   - The 20Gi sabnzbd-config PVC deleted (Restore's target.pvc would
+#     otherwise hit a name conflict)
+#
+# Post-conditions:
+#   - PVC sabnzbd-config exists, bound on longhorn, 2Gi, populated with the
+#     current real config (sabnzbd.ini, admin/, logs/).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: sabnzbd-config-shrink
+  namespace: sabnzbd
+spec:
+  source:
+    fromPolicy:
+      name: sabnzbd-config
+      offset: 0
+  target:
+    pvc:
+      name: sabnzbd-config
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      capacity: 2Gi
+  credentialProjection:
+    enabled: true
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}
+    cache:
+      capacity: 1Gi
+      storageClassName: local-path
+      mode: Ephemeral
+  failurePolicy:
+    backoffLimit: 2
+    activeDeadlineSeconds: 600
+  policy:
+    onMissingSnapshot: Fail

--- a/k3s/applications/sabnzbd/pvc.yaml
+++ b/k3s/applications/sabnzbd/pvc.yaml
@@ -9,7 +9,11 @@ spec:
   storageClassName: longhorn   # was: csi-hostpath-sc
   resources:
     requests:
-      storage: 20Gi   # was: 5Gi — snapshot data includes misplaced Downloads/complete, see docs/superpowers/plans/2026-08-21-restore-sabnzbd-config-from-kopia-backup.md Task 5
+      storage: 2Gi   # was: 20Gi — over-provisioned for a stale Downloads/complete
+      # contamination bug fixed 2026-08-21; real usage is ~27-32MB. The 20Gi
+      # provisioned extent forced a ~6min full-volume Longhorn clone on every
+      # hourly backup, contributing to recurring KubeAPIErrorBudgetBurn alerts.
+      # See docs/superpowers/plans/2026-08-30-shrink-sabnzbd-config-pvc.md.
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary
- sabnzbd-config was provisioned at 20Gi during the 2026-08-21 Kopia recovery,
  sized for a since-fixed bug (sabnzbd writing Downloads/complete inside
  /config). Real usage has been ~27-32MB ever since.
- Longhorn's CSI snapshot-restore clones across the full *provisioned* extent,
  not used bytes, so every hourly backup forced a ~6min full-disk-saturating
  clone/rebuild on the node's single aging SSD (shared with embedded etcd) -
  the root cause of a recurring KubeAPIErrorBudgetBurn alert.
- Restored via kopiur Restore CR (fromPolicy, latest snapshot) into a fresh
  2Gi PVC, following the same pattern as the prior sabnzbd-config migrations.

## Test plan
- [x] Restore CR completed, PVC verified bound on longhorn at 2Gi with real config content
- [x] sabnzbd WebUI/API responds post-restore
- [ ] User confirms indexers/categories/history/queue intact in WebUI
- [ ] Next hourly sabnzbd-config backup job duration checked (~30-40s expected, down from 6m14s)