### PR TITLE
fix(monitoring): stop paging PagerDuty on warning-severity alerts

### DIFF
--- a/k3s/infrastructure/configs/monitoring/alertmanager-pagerduty-secret.sops.yaml
+++ b/k3s/infrastructure/configs/monitoring/alertmanager-pagerduty-secret.sops.yaml
@@ -4,19 +4,19 @@ metadata:
     name: alertmanager-pagerduty-config
     namespace: monitoring
 stringData:
-    alertmanager.yaml: ENC[AES256_GCM,data:3OWQlD0SFbjoezDos0IuwBy9Ia9VTzSJ/oqb1/9tZRsH0q8OXse/hbARabKaOgabK7xcGzIaddU6F+ijHErnSVhLtnl5vvcIcsTpKBkw/7X1KfP9A77Dkiw5lq3Xto0fXh/P08329FzsVhkEB63wKp7UxRjbaYCWdBg4PUqiiUdp5RYpoJsu+ukmE4fi5DSyqarF+8IFGpsicRi0fr61hDTulWLaJnQXjUm0WBFNHfmd2KsIDKXPAaiDGiCIBx+fFmfu/wGGUmTp2dmwqzfZhrX7/GLOQR74WWhjvVmeHjhWSHOlkJ9FeN4k7t44y8HmHUs0tPZEHTGkmwjr1w9M9vUJ6QEz1DHAkdZ4QgTOMluk4tvkqpjAwntuwuIiZyb5PGNtlmFvgYy940WiRairjqw8A/OAJKSC3g6Fye5rzjj86Ds0GKxwE4umk9y5R6RqnW9hvhEpwZgajgRFXzF2uGKPipnDJBkiybyXsN8UbxpQ6JGoqW4MeXUzmw7fLeQSsDy7+73LAZeXEcEpRMr5RMbkmZ5ECx+ro/mLryi2ydSyG/XKN5UoPSTlX+tbryxD6i2TzY7gkSMnYeMK3BpRj6wyO9kFSLDu8wrF1u/OmNC/+le2GF5HSo4X+x6pSlBBbAk8R6uMkHmuS8zGqGCNN6g4Jntkgg6WYwmEhaVt+xDX3OLxiApEmbIk0UquGZI2vWvZc+39kZkyA16GVmtd/aH6clgFz9ZgI0lVlt/DbVEUSF+bwFEnBrKmlp32Y1zg+RmoLH7TVlWiXhr7QlKWVT4HhI31DxqSqQ0AMaYZWBqPKmTpo8erKxhR6ewIxflLC5RLgQgFx5mxQFOrNZpTU7k8jwveo5hK2ydFhMLuVqlHCdpy15TSCzt1HXNyv1M3RtMPvrj5ClWCNds6APTaOWnblmGvzd0MkOmcYqk872d+lEGbwXAdehA81BxvjK9rUbrB+/D7F9pvVVaTcJnOYl4R5Ct68PETCU/wQ8ZMlnZHowbKX8PkvKCXEUKX1oO+2TqVjG8lvD5rXybDGn0Ruu+5,iv:ubPl/m0xD2/C2gnRNfz9mLsHijnZOqlU7/cPGFBGb1k=,tag:a2Ist/U3q93S/0EuwiB6hw==,type:str]
+    alertmanager.yaml: ENC[AES256_GCM,data:YcVa6Munx5j9SOHK7MGNJ+ZwZ8SBv7zWSsTcCqkGPgM/W4BBvYKU1ObKBimTT4gXWub9qCHmzc8nypw0Q4d4nyzQhHRxAHclW6Fxi370u1Q8L52OJ/2HwVXQICc2YoIx0Ixuf1uUBe41NgTHyIctLWQpoVkfY/RdAxGX5j+pZbNStv7UXTDRELiMw74mGift4Qs8ZxZlseDi0jDKo1MFF9MI/qPLzMiYY2PIE7gZrPeQCh9YojSMbfqdKP4XNWnsIxxFGcALcNMYO8TjTx9inPsuJxuwT+yOw23e6KthZkqBoPDEDW1jn8VKW2Wutj1xIj68VV0NKVnsH9QRLTxwMK+XeMG2+2V4FzbK+R2cLKX4V5oko2/W99laDi+BJskgy6ATa0zJUw0mCUb2hdTwvU0JgcUR3LCIEb49OJM8B/A2szWqtIpSpzyGMvwtnS5KyD4ZOHh1Ol0rJZIj1k9vYzPsm4lNS5aaDqYmSqGjHHwim8l9Q2OBlAgo4hJgSZUVntfdyMDbeOoQg1Yg45x6XcjxQ1Wd+8T7tZ/x4JXWIiyskCY1SSmLe/ScHdnwff7WRK4+j7B7P+o9XBQzFcgRJ9TCOmYk+o8cQHXDW/sN8O75h6kwxi9fVM7VDM5RD50WQFgYNspdovOp30D5hMbUtFGImbjojo9iGbqZYPojrxSST6PeTP8oUq1Pd+fhBcepFjncI6qi5APyNTv3WaGBEzHXCsbaOi2sK6MRjYs3f13llEqlFmIycQ==,iv:RgXziCaKRkPpg0lScITFZb2t9tamCamYHeR9pdf+5wU=,tag:P5FbZstMycaxSDPQtqevEA==,type:str]
 sops:
     age:
         - recipient: age1qntcdwtxrfu92lhj2nzhlc3uqt8nxks5vw7rd23w2cj7c0qyuqqqmey085
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuTGg0bXAxTVJaZS9HQ2pu
-            N3ovUEcxc2cxY1hzc0pFeWEzTy81NVliMkZJCkFVUHdaTUVLbXE5K3BGU1hJaUlE
-            QVFyMmkva2lCdnRSRWNQZjJJY1BKNm8KLS0tIGVKWmJPa2ZnNlEraysxYkNobHYr
-            SkRaZXdoNURPTDBpN1R1R1dzUUxPRUEKw41ko6poYPUVbS062mC56j5htl3S7rUB
-            nT4lduwjMe0dZiO69tqzAeX9mj+FekWN3VGK1sJ1MHvMXSy+yizKAQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVWjNoRzBHd3NKRngzSXpv
+            ckNtbjVlWXNSNGRRMW1xbmQ5RExQdjBvM0ZNCmRVNUdRQU45MjhGSkRHMkF1WWR3
+            UkpNTit2V0xFNGg4MnoxbDdMV2kxeVkKLS0tIFcxUUJlbSt4Z3RJMzhobEEwd3A2
+            dHI0NTlWbUV6bytVR2lDcU9RMjJjOFUKLlaEQxrqISNVMTQVrngN82Dev5/Mcc+n
+            w8SJNDyVsVjFy1jUZqNFuvkAU0NtW19VoFV7ZfhOmDLuTkxrSsAAVQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-02T00:50:53Z"
-    mac: ENC[AES256_GCM,data:b0RXqR2MJri/ybL5jhKfhDZEnKP+puDx1YMpF7Rvf7FRm0sXxEtWXCt2nq5J51lJiZ0NFYNlVLoMVvDQ7d2JyYN2NqYQq0dWWjc77MzA32wch7u0KxZ3qZwCc3Yr8rcMF4o3Oa2eX7/3NZeVFTf3LxULr/HX68wDStDxImCdrD4=,iv:bhAL6FqwFv97RTBJSdOTqaQeac+3gw5ICf4RfJMW9q8=,tag:nJO5c487+x7bNIXTw1aStw==,type:str]
+    lastmodified: "2026-08-30T21:22:17Z"
+    mac: ENC[AES256_GCM,data:LjUs4Tj+jCr2TRe4Ss08Scr/PadgIDwVN/+EYzLVo/kCGI88wx6qIw1ZjXHxAJ2dWKBOIO++6jl9heKVogXzXAVQa0m8bE+DrRUG3pd7LULuQSKJYOnaMFzZAGTFxkx8puBhMsw3O+fw6p1lnkR6XHZuUmaPP0G7dhcpvzCbGbQ=,iv:WAigpf5XZ8Sx+UsxF0KykkrYjG67ByfmZGc46c/jCQA=,tag:SaB8Hca5yjei3RMKmv0l6g==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Both `severity: critical` and `severity: warning` alerts were routing to
  PagerDuty (same routing key, different PD severity tag) — any Prometheus
  warning-tier alert paged, including the long-window (1d/6h, 3d/6h)
  `KubeAPIErrorBudgetBurn` SLO rules, which are poorly suited to a
  single-node cluster with embedded etcd sharing one aging SSD with Longhorn
  and backup I/O. Those rules have long "memory" too — a brief real spike can
  keep them firing for hours after the underlying cause has already resolved.
- Repoints the `severity: warning` route to the `null` receiver so it no
  longer pages. `severity: critical` is untouched — still pages via
  `pagerduty-critical`.
- Removed the now-unused `pagerduty-warning` receiver definition.
- Warning-severity alerts remain visible in Alertmanager/Grafana, they just
  won't generate a PagerDuty incident.

## Test plan
- [x] Decrypted the updated secret locally and confirmed the route/receiver
      structure: `severity: critical` -> `pagerduty-critical`,
      `severity: warning` -> `null`
- [ ] Confirm live in Alertmanager after Flux reconciles: `severity: warning`
      alerts show as routed to `null` (e.g. via `amtool config routes test`
      or the Alertmanager UI), and no PagerDuty incident is created on the
      next warning-tier alert