### PR TITLE
fix(authentik): revert serviceAccount.create, restore broken worker rollout

### DIFF
--- a/k3s/infrastructure/configs/authentik/helmrelease.yaml
+++ b/k3s/infrastructure/configs/authentik/helmrelease.yaml
@@ -195,19 +195,24 @@ spec:
         - name: custom-blueprints
           mountPath: /blueprints/custom
 
-    # Audit finding: serviceAccount.create: true (the chart default) pulls in
-    # the authentik-remote-cluster subchart, which grants the worker's
-    # ServiceAccount a namespaced Role with CRUD on secrets/services/
-    # configmaps/deployments/ingresses/middlewares/httproutes/servicemonitors
-    # (see charts/authentik-remote-cluster/templates/role.yaml at chart
-    # version 2.1.0). That RBAC exists so authentik's own "Kubernetes"
-    # outpost integration can render outposts as native k8s objects, but our
-    # actual outpost is the hand-rolled Deployment in outpost-deployment.yaml
-    # — the managed-outpost path is never used. Disabling create removes the
-    # ServiceAccount + Role/RoleBinding + ClusterRole/ClusterRoleBinding
-    # entirely (chart dependency condition: serviceAccount.create); the
-    # worker deployment template falls back to no serviceAccountName (i.e.
-    # the namespace's default SA) when this is false, so no other server/
-    # worker functionality depends on it.
+    # Audit finding (PR #373) tried disabling this to drop the unused
+    # authentik-remote-cluster RBAC (broad namespaced Role on secrets/
+    # services/configmaps/deployments/ingresses/etc. — see
+    # charts/authentik-remote-cluster/templates/role.yaml at chart version
+    # 2.1.0). That broke the live cluster: the worker/server Deployment
+    # templates hardcode `serviceAccountName: authentik`
+    # (serviceAccount.fullnameOverride) regardless of this flag — disabling
+    # `create` only stops the ServiceAccount object from being created, it
+    # does NOT change what the pods reference, so the worker rollout got
+    # stuck on `FailedMount: serviceaccounts "authentik" not found`.
+    # `authentik-remote-cluster` is aliased in as a single dependency gated
+    # by this one condition (Chart.yaml: `alias: serviceAccount, condition:
+    # serviceAccount.create`) — the chart bundles the ServiceAccount and the
+    # broad RBAC together with no finer-grained toggle to split them.
+    # Reverted to the chart default (true) to restore function. Dropping the
+    # unused RBAC cleanly would require a postRenderer patch to delete just
+    # the Role/RoleBinding/ClusterRole/ClusterRoleBinding objects while
+    # leaving the ServiceAccount itself — left as a follow-up, not attempted
+    # here given the live-breakage urgency.
     serviceAccount:
-      create: false
+      create: true


### PR DESCRIPTION
## Summary
**Regression from #373.** That PR set `serviceAccount.create: false` to drop
the unused `authentik-remote-cluster` RBAC (broad namespaced Role on
secrets/services/configmaps/deployments/ingresses/etc., meant for authentik's
native-K8s-outpost integration, which this repo doesn't use — a hand-rolled
Deployment is used instead).

That broke the live cluster: the chart's worker/server Deployment templates
hardcode `serviceAccountName: authentik` (`serviceAccount.fullnameOverride`)
regardless of the `create` flag. Disabling `create` only stops the
ServiceAccount object from being created — it does not change what the pods
reference — so the worker rollout got stuck:
`FailedMount: serviceaccounts "authentik" not found`.

Confirmed live: `authentik-server` and the pre-existing `authentik-worker`
replica kept running (no full outage, SSO logins continued working through
the old pod), but the new worker ReplicaSet from #373's rollout was Pending
and never became ready.

Root cause: `authentik-remote-cluster` is aliased into the parent chart as a
single Helm dependency gated by one condition
(`Chart.yaml: alias: serviceAccount, condition: serviceAccount.create`) — it
bundles the ServiceAccount and the broad RBAC together with no finer-grained
toggle to split them apart.

## Fix
Reverted `serviceAccount.create` to `true` (the chart default), restoring
the ServiceAccount the worker/server pods actually need. This brings the
unused RBAC back too — that's an accepted tradeoff to restore function now.
Cleanly dropping just the RBAC (keeping the SA) would need a postRenderer
patch to delete the Role/RoleBinding/ClusterRole/ClusterRoleBinding objects
specifically; left as a documented follow-up, not attempted here given the
live-breakage urgency.

## Test plan
- [x] `helm template` against the pinned chart version confirms `ServiceAccount/authentik` renders and `Deployment/authentik-worker` references it
- [ ] After merge + Flux reconcile: confirm `authentik-worker` rollout completes (`kubectl rollout status`) and the stuck ReplicaSet's pod goes Ready