### PR TITLE
fix(probes): add missing liveness/readiness probes to 4 app workloads

### DIFF
--- a/k3s/applications/pihole/helmrelease.yaml
+++ b/k3s/applications/pihole/helmrelease.yaml
@@ -157,3 +157,39 @@ spec:
     # -- Required for Pi-hole to listen on all interfaces in K3s CNI
     extraEnvVars:
       FTLCONF_dns_listeningMode: "all"
+
+  # -- The chart's monitoring.sidecar (ekofr/pihole-exporter) has no probes
+  # value; it exposes Prometheus metrics on / at monitoring.sidecar.port
+  # (9617), confirmed live via `curl http://<pod-ip>:9617/metrics` (200).
+  # Patched in post-render since the chart template hardcodes the exporter
+  # container with no way to inject probes via values.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: pihole
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: pihole
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: exporter
+                        livenessProbe:
+                          httpGet:
+                            path: /metrics
+                            port: prometheus
+                          initialDelaySeconds: 30
+                          periodSeconds: 30
+                          failureThreshold: 5
+                        readinessProbe:
+                          httpGet:
+                            path: /metrics
+                            port: prometheus
+                          initialDelaySeconds: 15
+                          periodSeconds: 15
+                          failureThreshold: 3

--- a/k3s/applications/qbittorrent/deployment.yaml
+++ b/k3s/applications/qbittorrent/deployment.yaml
@@ -209,6 +209,14 @@ spec:
             periodSeconds: 30
             failureThreshold: 5
             timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 10
           resources:
             requests:
               cpu: 100m
@@ -239,6 +247,13 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9586
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
           resources:
             requests:
               cpu: 25m

--- a/k3s/applications/sense-exporter/deployment.yaml
+++ b/k3s/applications/sense-exporter/deployment.yaml
@@ -127,6 +127,20 @@ spec:
             - name: config
               mountPath: /etc/sense_energy_prometheus_exporter/config.yaml
               subPath: config.yaml
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9993
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9993
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
           resources:
             requests:
               cpu: 10m

--- a/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
+++ b/k3s/infrastructure/configs/authentik/outpost-deployment.yaml
@@ -72,6 +72,20 @@ spec:
               name: http
             - containerPort: 9443
               name: https
+          livenessProbe:
+            httpGet:
+              path: /outpost.goauthentik.io/ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /outpost.goauthentik.io/ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- Audited all Deployments/StatefulSets/DaemonSets cluster-wide for missing liveness/readiness probes
- Added probes to the 4 workloads where a real health endpoint was confirmed live in-cluster before wiring it up:
  - `authentik-outpost` proxy container: `/outpost.goauthentik.io/ping` on 9000
  - `pihole` exporter sidecar: `/metrics` on 9617 (via HelmRelease `postRenderers.kustomize.patches`, since the chart's `monitoring.sidecar` has no probes value)
  - `qbittorrent` qbt-exporter and gluetun-exporter: added `readinessProbe` mirroring their existing `livenessProbe`
  - `sense-exporter`: `/metrics` on 9993

`goldilocks-controller` and `system-upgrade-controller` were also flagged as missing probes but are excluded here: neither binary opens any port (`--help` shows no health/metrics flag, and `/proc/net/tcp` inside the running container shows zero listening sockets), so there's no real signal to probe — adding one would just be theater.

## Test plan
- [x] `kubectl kustomize` succeeds for qbittorrent, sense-exporter, authentik/configs
- [x] `helmrelease.yaml` parses cleanly and the postRenderer patch format matches Flux's documented syntax (verified against fluxcd/helm-controller docs)
- [x] Confirmed each probe's endpoint returns 200 against the live pod before wiring it in (curl/wget from an ephemeral pod or in-container)
- [ ] Flux reconciliation of the pihole HelmRelease succeeds and the exporter sidecar picks up the patched probes