### PR TITLE
fix(sense-exporter): remove crash-looping liveness/readiness probes

### DIFF
--- a/k3s/applications/sense-exporter/deployment.yaml
+++ b/k3s/applications/sense-exporter/deployment.yaml
@@ -127,20 +127,12 @@ spec:
             - name: config
               mountPath: /etc/sense_energy_prometheus_exporter/config.yaml
               subPath: config.yaml
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 9993
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            failureThreshold: 5
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 9993
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            failureThreshold: 3
+          # No liveness/readiness probes: /metrics performs a synchronous,
+          # per-request fetch from the Sense cloud API with no cheap health
+          # path. HTTP probes here previously crash-looped the container
+          # (probe timeouts during slow Sense API calls) and hammered
+          # Sense's API every 15s for 20+ hours, likely triggering the
+          # account-level rate limiting that made it worse.
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- PR #377 added `httpGet /metrics` liveness/readiness probes to sense-exporter, but that endpoint synchronously calls out to the Sense cloud API per request (through the gluetun VPN tunnel) with no cheap health-check path
- 1s probe timeouts crash-looped the container (244 restarts / 20+ hours) and hammered Sense's API every 15s, likely triggering account-level rate limiting (empty/invalid API responses observed in logs)
- Removes probes from this container only; the other 3 workloads from #377 are unaffected

## Test plan
- [ ] Merge and let Flux reconcile
- [ ] Confirm sense-exporter pod reaches `2/2 Ready` and restart count stops climbing
- [ ] Confirm `/metrics` eventually serves data once Sense API rate limit (if any) clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dSXEdv47e2SB5TkWy2GSq